### PR TITLE
fix/bump version quote regex

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -41,7 +41,7 @@ jobs:
           ruby <<'RUBY' >> "$GITHUB_OUTPUT"
           version_file = "lib/wip/version.rb"
           content = File.read(version_file)
-          current = content[/VERSION\s*=\s*"(\d+\.\d+\.\d+)"/, 1]
+          current = content[/VERSION\s*=\s*['"](\d+\.\d+\.\d+)['"]/, 1]
           abort "Could not find current version in #{version_file}" unless current
 
           major, minor, patch = current.split(".").map(&:to_i)
@@ -68,7 +68,7 @@ jobs:
         env:
           NEXT_VERSION: ${{ steps.version.outputs.next }}
         run: |
-          ruby -e 'path = "lib/wip/version.rb"; version = ENV.fetch("NEXT_VERSION"); content = File.read(path); updated = content.sub(/VERSION\s*=\s*"\d+\.\d+\.\d+"/, "VERSION = \"#{version}\""); abort "Version was not updated" if updated == content; File.write(path, updated)'
+          ruby -e 'path = "lib/wip/version.rb"; version = ENV.fetch("NEXT_VERSION"); content = File.read(path); updated = content.sub(/VERSION\s*=\s*(["\x27])\d+\.\d+\.\d+\1/, "VERSION = \x27#{version}\x27"); abort "Version was not updated" if updated == content; File.write(path, updated)'
 
       - name: Verify gemspec
         run: gem build wslc-wip.gemspec


### PR DESCRIPTION
- **feat: implement initial WSLC development CLI**
- **ci: add GitHub Actions workflows and switch RubyGems publish to trusted publishing**
- **chore: rename gem to wslc-wip and fix leftover slidict references**
- **ci: remove redundant ci.yml workflow**
- **fix: resolve Thor reserved-word command names and Config keyword-arg breakage**
- **chore: ignore Gemfile.lock**
- **fix: address CodeRabbit review feedback on PR #1**
- **docs: document Conventional Commits convention in AGENTS.md**
- **fix(ci): pin rubygems/configure-rubygems-credentials to v2**
- **fix(ci): accept single or double quotes in version.rb regex**
