### PR TITLE
fix: drop -p/-v flags from wslc exec commands

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,5 +10,8 @@ Metrics/AbcSize:
   Max: 25
 Metrics/ClassLength:
   Max: 140
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*
 Layout/LineLength:
   Max: 120

--- a/lib/wip/command_builder.rb
+++ b/lib/wip/command_builder.rb
@@ -15,7 +15,7 @@ module Wip
       values = @config.defaults.merge(settings)
       command = [@wslc, 'exec']
       command << '-it' if tty?(interactive)
-      command.concat(options(values, include_container: true)).concat(arguments)
+      command.concat(options(values, include_container: true, include_publish: false)).concat(arguments)
     end
 
     def run(arguments, settings: {}, interactive: true)
@@ -46,12 +46,14 @@ module Wip
 
     private
 
-    def options(values, include_container: false)
+    def options(values, include_container: false, include_publish: true)
       result = []
       result.push('-w', values['workdir']) unless values['workdir'].to_s.empty?
       values.fetch('env', {}).each { |key, value| result.push('-e', "#{key}=#{value}") }
-      Array(values['ports']).each { |port| result.push('-p', port.to_s) }
-      Array(values['volumes']).each { |volume| result.push('-v', volume.to_s) }
+      if include_publish
+        Array(values['ports']).each { |port| result.push('-p', port.to_s) }
+        Array(values['volumes']).each { |volume| result.push('-v', volume.to_s) }
+      end
       result << required(values, 'container') if include_container
       result
     end

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end

--- a/spec/wip/command_builder_spec.rb
+++ b/spec/wip/command_builder_spec.rb
@@ -31,4 +31,10 @@ RSpec.describe Wip::CommandBuilder do
   it 'appends custom command arguments' do
     expect(builder.custom('rails', ['console'])).to eq(%w[wslc.exe exec -it -w /app app bin/rails console])
   end
+
+  it 'omits ports and volumes from exec commands since wslc exec does not accept them' do
+    settings = { 'ports' => ['5000:3000'], 'volumes' => ['.:/app'], 'interactive' => true }
+    expect(builder.exec(%w[bin/rails c], settings: settings))
+      .to eq(%w[wslc.exe exec -it -w /app app bin/rails c])
+  end
 end


### PR DESCRIPTION
## Summary
- `wslc exec` only supports `-d`, `-e`, `--env-file`, `-i`, `-t`, `-u`, `-w` — it rejects `-p`/`-v`, unlike `wslc run`/`create`.
- `CommandBuilder#exec` was still forwarding `ports`/`volumes` from `defaults` as `-p`/`-v`, so any exec-based `wip.yml` command (e.g. `commands.rails`) failed with `引数の別名が現在のコマンドに対して認識されませんでした: '-p'` whenever the config's `defaults` included `ports`/`volumes` — this is what broke `wip rails c`.
- Restrict `-p`/`-v` generation to `run`, add a regression spec, and exclude `spec/**/*` from `Metrics/BlockLength` for the new spec block.

## Test plan
- [x] `bundle exec rspec` (15 examples, 0 failures)
- [x] `bundle exec rubocop` (no offenses)
- [x] Manually verified against a real `wip.yml` with `ports`/`volumes` in `defaults`: `wslc.exe exec` now parses successfully instead of rejecting `-p`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * `exec` コマンドで、ポート公開やボリューム設定が誤って付与されないよう修正しました。
  * `wslc exec` が受け付けるオプションのみで、正しいコマンドを生成します。
  * 通常のオプション生成では、従来どおりポートやボリューム設定を利用できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->