### PR TITLE
fix: dispatch unknown top-level commands to wip.yml custom commands

### DIFF
--- a/lib/wip/cli.rb
+++ b/lib/wip/cli.rb
@@ -9,6 +9,20 @@ module Wip
     class_option :config, type: :string, desc: 'Path to wip.yml'
     default_task :dispatch
 
+    def self.exit_on_failure? = true
+
+    # Thor only falls back to the default task when no command name is given at
+    # all; an unrecognized first argument (e.g. a custom wip.yml command name)
+    # would otherwise raise "Could not find command". Route those to `dispatch`.
+    def self.dispatch(meth, given_args, given_opts, config)
+      name = given_args.first
+      if meth.nil? && name && !name.to_s.start_with?('-') && find_command_possibilities(name).empty?
+        return super('dispatch', given_args, given_opts, config)
+      end
+
+      super
+    end
+
     desc 'version', 'Show wip and WSLC versions'
     def version
       puts "wip #{VERSION}"

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end

--- a/spec/wip/cli_spec.rb
+++ b/spec/wip/cli_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+
+RSpec.describe Wip::CLI do
+  around do |example|
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, 'wip.yml'), <<~YAML)
+        version: 1
+        defaults:
+          container: app
+          image: example:dev
+        commands:
+          rails:
+            command: bin/rails
+            interactive: true
+      YAML
+      Dir.chdir(dir) { example.run }
+    end
+  end
+
+  it 'routes an unrecognized top-level command to the custom wip.yml dispatcher' do
+    runner = instance_double(Wip::CommandRunner)
+    allow(Wip::CommandRunner).to receive(:new).and_return(runner)
+    allow(Wip::CommandResolver).to receive(:new).and_return(instance_double(Wip::CommandResolver,
+                                                                            resolve: 'wslc.exe'))
+
+    expect(runner).to receive(:run).with(%w[wslc.exe exec -w /app app bin/rails c]).and_return(0)
+
+    described_class.start(%w[rails c])
+  end
+end


### PR DESCRIPTION
## Summary
- Thor only falls back to `default_task` when *no* command name is given at all, not when the first argument fails to match a known command — so `wip rails c` raised `Could not find command "rails"` instead of routing to the `rails` entry in `wip.yml`.
- Override `CLI.dispatch` to reroute an unrecognized first argument to the `dispatch` command (the same mechanism Thor itself uses for subcommand fallback).
- Define `exit_on_failure?` to silence Thor's related deprecation warning and ensure command failures exit non-zero.

## Test plan
- [x] `bundle exec rspec` (16 examples, 0 failures)
- [x] `bundle exec rubocop` (no offenses)
- [x] Built the gem locally (`gem build` + `gem install --user-install`) and ran `wip rails c` against a real `wip.yml` — no longer raises `Could not find command`, reaches `wslc exec` correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)