### PR TITLE
feat: add wip up/down commands to manage the persistent container

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,7 @@ Examples:
 - `feat(cli): add doctor command`
 - `fix(config): accept positional path argument`
 - `ci: add push trigger for main`
+
+## Version bumps
+
+Follow [Semantic Versioning](https://semver.org/). Bump minor for new commands/features (`feat`), patch for bug fixes (`fix`), major for breaking changes.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ commands:
 | `wip doctor` | WSL2、相互運用、WSLC、設定、アーキテクチャ、Git を診断 |
 | `wip config` | デフォルト適用済み設定（秘密値をマスク） |
 | `wip build -- --no-cache` | build 定義でイメージをビルド |
+| `wip up [-d]` | `defaults.container` を起動（無ければ作成）。`-d` でバックグラウンド実行 |
+| `wip down` | `defaults.container` を停止・削除 |
 | `wip exec [--no-interactive] COMMAND...` | 既存コンテナ内で実行 |
 | `wip run [--no-interactive] COMMAND...` | `--rm` の新規コンテナで実行 |
 | `wip shell` | 定義済み shell、または `bash`、`sh` の順に起動 |

--- a/lib/wip/cli.rb
+++ b/lib/wip/cli.rb
@@ -51,6 +51,19 @@ module Wip
       execute(builder.build(settings: load_config.command('build') || {}, extra: extra))
     end
 
+    desc 'up', 'Start the configured container, creating it if necessary'
+    option :detach, type: :boolean, default: false, aliases: '-d'
+    def up
+      code = execute(builder.start(detach: options[:detach]), exit_on_failure: false)
+      execute(builder.up(detach: options[:detach])) if code != 0
+    end
+
+    desc 'down', 'Stop and remove the configured container'
+    def down
+      execute(builder.down, exit_on_failure: false)
+      execute(builder.remove, exit_on_failure: false)
+    end
+
     desc 'exec COMMAND...', 'Execute a command in the running container'
     option :interactive, type: :boolean, default: true
     def exec(*command)
@@ -69,7 +82,8 @@ module Wip
       configured = load_config.command('shell')
       return execute(builder.custom('shell', [])) if configured
 
-      code = execute(builder.exec(['bash'], settings: { 'interactive' => true }, interactive: true))
+      code = execute(builder.exec(['bash'], settings: { 'interactive' => true }, interactive: true),
+                     exit_on_failure: false)
       execute(builder.exec(['sh'], settings: { 'interactive' => true }, interactive: true)) if code != 0
     end
     map 'shell' => :shell_command
@@ -88,9 +102,9 @@ module Wip
     def resolver = CommandResolver.new
     def builder = CommandBuilder.new(wslc: resolver.resolve(load_config.wslc_command), config: load_config)
 
-    def execute(command)
+    def execute(command, exit_on_failure: true)
       code = CommandRunner.new.run(command)
-      exit(code) unless code.zero?
+      exit(code) if exit_on_failure && !code.zero?
       code
     end
   end

--- a/lib/wip/command_builder.rb
+++ b/lib/wip/command_builder.rb
@@ -26,6 +26,28 @@ module Wip
       command.concat(options(values)).push(required(values, 'image')).concat(arguments)
     end
 
+    def up(detach: false)
+      values = @config.defaults
+      command = [@wslc, 'run', '--name', required(values, 'container')]
+      command << '-d' if detach
+      command << '-it' if !detach && tty?(true)
+      command.concat(options(values)).push(required(values, 'image'))
+    end
+
+    def start(detach: false)
+      command = [@wslc, 'start', required(@config.defaults, 'container')]
+      command.push('-a', '-i') unless detach
+      command
+    end
+
+    def down
+      [@wslc, 'stop', required(@config.defaults, 'container')]
+    end
+
+    def remove
+      [@wslc, 'remove', '-f', required(@config.defaults, 'container')]
+    end
+
     def build(settings:, extra: [])
       values = @config.defaults.merge(settings)
       context = values['context'] || '.'

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.1.4'
+  VERSION = '0.2.0'
 end

--- a/spec/wip/cli_spec.rb
+++ b/spec/wip/cli_spec.rb
@@ -30,4 +30,16 @@ RSpec.describe Wip::CLI do
 
     described_class.start(%w[rails c])
   end
+
+  it 'falls back to creating the container when `up` finds none to start' do
+    runner = instance_double(Wip::CommandRunner)
+    allow(Wip::CommandRunner).to receive(:new).and_return(runner)
+    allow(Wip::CommandResolver).to receive(:new).and_return(instance_double(Wip::CommandResolver,
+                                                                            resolve: 'wslc.exe'))
+
+    expect(runner).to receive(:run).with(%w[wslc.exe start app -a -i]).and_return(1)
+    expect(runner).to receive(:run).with(%w[wslc.exe run --name app -w /app example:dev]).and_return(0)
+
+    described_class.start(%w[up])
+  end
 end

--- a/spec/wip/command_builder_spec.rb
+++ b/spec/wip/command_builder_spec.rb
@@ -37,4 +37,25 @@ RSpec.describe Wip::CommandBuilder do
     expect(builder.exec(%w[bin/rails c], settings: settings))
       .to eq(%w[wslc.exe exec -it -w /app app bin/rails c])
   end
+
+  it 'builds a detached up command that names the persistent container' do
+    expect(builder.up(detach: true)).to eq(%w[wslc.exe run --name app -d -w /app example:dev])
+  end
+
+  it 'builds a foreground up command with -it when the terminal is interactive' do
+    expect(builder.up).to eq(%w[wslc.exe run --name app -it -w /app example:dev])
+  end
+
+  it 'builds a start command that attaches by default' do
+    expect(builder.start).to eq(%w[wslc.exe start app -a -i])
+  end
+
+  it 'builds a detached start command without attaching' do
+    expect(builder.start(detach: true)).to eq(%w[wslc.exe start app])
+  end
+
+  it 'builds down and remove commands for the configured container' do
+    expect(builder.down).to eq(%w[wslc.exe stop app])
+    expect(builder.remove).to eq(%w[wslc.exe remove -f app])
+  end
 end


### PR DESCRIPTION
## Summary
- `wip` had no `dip up`/`dip down`-style command, so after `wip build` there was no way to bring the configured container up in the background; `wip rails c` / `wip shell` / custom `exec` commands always failed with "container not found".
- Add `CommandBuilder#up`/`#start`/`#down`/`#remove` and CLI commands `wip up [-d]` / `wip down`:
  - `wip up` tries `wslc start <container>` first; if that fails (container doesn't exist yet), falls back to `wslc run --name <container> ...` using `defaults` (image/env/ports/volumes/workdir). `-d`/`--detach` runs it in the background, matching `docker compose up -d`.
  - `wip down` stops and removes the named container.
- Fixed a latent bug in `CLI#execute`: it always called `exit(code)` on any non-zero exit, so `shell_command`'s existing bash→sh fallback could never actually run the `sh` branch. Added `exit_on_failure:` so start→run (and bash→sh) fallbacks can inspect the exit code first.

## Verification
- `bundle exec rspec` (22 examples, 0 failures)
- `bundle exec rubocop` (no offenses)
- Built the gem locally, installed it, and ran it end-to-end against a real `wip.yml` + `wslc.exe`:
  - `wip up -d` with no container → created + started `app` via `wslc run --name app -d ...`
  - `wip up -d` again (container exists, stopped) → reused it via `wslc start app`, no duplicate container
  - `wip rails c` → correctly reached the container (error changed from "container not found" to the app's own "container not running", i.e. the image's default CMD exits — unrelated to wip)
  - `wip down` → stopped and removed the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)