### PR TITLE
feat: support up.command so wip up starts a long-running container

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ defaults:
     - "3000:3000"
   volumes:
     - ".:/app"
+up:
+  command: server # `wip up` がコンテナ作成時にイメージへ渡す常駐コマンド（未指定ならイメージの既定 CMD）
 commands:
   rails:
     type: exec
@@ -82,7 +84,7 @@ commands:
 | `wip doctor` | WSL2、相互運用、WSLC、設定、アーキテクチャ、Git を診断 |
 | `wip config` | デフォルト適用済み設定（秘密値をマスク） |
 | `wip build -- --no-cache` | build 定義でイメージをビルド |
-| `wip up [-d]` | `defaults.container` を起動（無ければ作成）。`-d` でバックグラウンド実行 |
+| `wip up [-d]` | `defaults.container` を起動（無ければ `up.command` 付きで作成）。`-d` でバックグラウンド実行 |
 | `wip down` | `defaults.container` を停止・削除 |
 | `wip exec [--no-interactive] COMMAND...` | 既存コンテナ内で実行 |
 | `wip run [--no-interactive] COMMAND...` | `--rm` の新規コンテナで実行 |

--- a/lib/wip/command_builder.rb
+++ b/lib/wip/command_builder.rb
@@ -32,6 +32,8 @@ module Wip
       command << '-d' if detach
       command << '-it' if !detach && tty?(true)
       command.concat(options(values)).push(required(values, 'image'))
+      command.concat(Shellwords.split(@config.up_command.to_s)) if @config.up_command
+      command
     end
 
     def start(detach: false)

--- a/lib/wip/config.rb
+++ b/lib/wip/config.rb
@@ -17,6 +17,7 @@ module Wip
     def wslc_command = @raw.dig('wslc', 'command') || 'auto'
     def commands = @raw['commands'] || {}
     def defaults = DEFAULTS.merge(@raw['defaults'] || {})
+    def up_command = @raw.dig('up', 'command')
 
     def command(name)
       entry = commands[name.to_s]
@@ -27,6 +28,7 @@ module Wip
 
     def to_h(redact: true)
       value = { 'version' => 1, 'wslc' => { 'command' => wslc_command }, 'defaults' => defaults,
+                'up' => { 'command' => up_command },
                 'commands' => commands.transform_values { |entry| defaults.merge('type' => 'exec').merge(entry) } }
       redact ? redact_secrets(value) : value
     end
@@ -36,6 +38,7 @@ module Wip
     def validate!
       raise ConfigError, "Unsupported configuration version: #{@raw['version']}" unless (@raw['version'] || 1) == 1
       raise ConfigError, 'commands must be a mapping' unless commands.is_a?(Hash)
+      raise ConfigError, 'up must be a mapping' if @raw.key?('up') && !@raw['up'].is_a?(Hash)
 
       commands.each { |name, entry| validate_command!(name, entry) }
     end

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end

--- a/spec/wip/command_builder_spec.rb
+++ b/spec/wip/command_builder_spec.rb
@@ -58,4 +58,12 @@ RSpec.describe Wip::CommandBuilder do
     expect(builder.down).to eq(%w[wslc.exe stop app])
     expect(builder.remove).to eq(%w[wslc.exe remove -f app])
   end
+
+  it 'appends the configured up command so the container stays running' do
+    with_up_command = Wip::Config.new('defaults' => { 'container' => 'app', 'image' => 'example:dev' },
+                                      'up' => { 'command' => 'local' })
+    builder = described_class.new(wslc: 'wslc.exe', config: with_up_command, environment: environment)
+
+    expect(builder.up(detach: true)).to eq(%w[wslc.exe run --name app -d -w /app example:dev local])
+  end
 end

--- a/spec/wip/config_spec.rb
+++ b/spec/wip/config_spec.rb
@@ -13,4 +13,13 @@ RSpec.describe Wip::Config do
     config = described_class.new('commands' => { 'x' => { 'command' => 'x', 'env' => { 'API_TOKEN' => 'secret' } } })
     expect(config.to_h.dig('commands', 'x', 'env', 'API_TOKEN')).to eq('[REDACTED]')
   end
+
+  it 'exposes the up command, defaulting to nil' do
+    expect(described_class.new({}).up_command).to be_nil
+    expect(described_class.new('up' => { 'command' => 'local' }).up_command).to eq('local')
+  end
+
+  it 'rejects a non-mapping up section' do
+    expect { described_class.new('up' => 'local') }.to raise_error(Wip::ConfigError, /up must be a mapping/)
+  end
 end


### PR DESCRIPTION
## Summary
- Follow-up to #9. In real-world use against slidict.io, `wip up -d` created the `app` container successfully but it exited immediately — `wslc run --name app ... image` runs the image's default CMD with no arguments, and slidict.io's `entrypoint.sh` branches on `$1`, falling into a no-op `exec "$@"` when nothing is passed. `compose.yml`'s `app` service works around this with an explicit `command: "local"`.
- Add an optional `up.command` to `wip.yml` so `wip up` can pass the same command, e.g.:
  ```yaml
  up:
    command: local
  ```
- `Config#up_command` validates `up` is a mapping if present, and is included (nil-safe) in `wip config` output.

## Verification
- `bundle exec rspec` (25 examples, 0 failures)
- `bundle exec rubocop` (no offenses)
- Manually verified the generated command against slidict.io's real settings matches `compose.yml`'s `command: "local"`:
  `wslc run --name app -d -w /app slidict/slidict.io:local local`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * `wip up` 実行時に、設定した常駐コマンドをコンテナへ渡せるようになりました。
  * コマンド未指定時は、イメージに設定された既定のコマンドが使用されます。

* **ドキュメント**
  * `up.command` の設定方法と動作を設定例・コマンド一覧に追加しました。

* **バグ修正**
  * `up` 設定が正しい形式でない場合、適切なエラーを表示するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->