### PR TITLE
feat: support dependency containers and a shared network for wip up

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ defaults:
   workdir: /app
   interactive: false
   remove: true
+  network: app-tier # optional; shared with `dependencies` so containers can resolve each other by name
   env:
     RAILS_ENV: development
     PORT: "3000"
@@ -60,6 +61,15 @@ defaults:
 up:
   command: server # command `wip up` passes to the image when it creates the container
                    # (omit to use the image's default CMD)
+dependencies:
+  redis:
+    image: redis:latest
+  development.mysql:
+    image: mysql:8.0
+    command: --default-authentication-plugin=mysql_native_password
+    env:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: development
 commands:
   rails:
     type: exec
@@ -91,6 +101,16 @@ commands:
 credential, or auth. Keep real secrets out of the config file and in your runtime environment
 instead.
 
+### Dependency containers
+
+If your app needs sidecar services (a database, Redis, ...), declare them under `dependencies`
+and set `defaults.network`. `wip up` creates the network first (if it doesn't exist), then brings
+up each dependency by name before the main container — so `bin/rails c` (or anything else run
+inside the main container) can reach `development.mysql`/`redis`/etc. by their dependency name,
+the same way Compose's service names resolve. `wip down` tears the main container and all
+dependencies down (the network itself is left in place). Each dependency entry accepts `image`
+(required), `command`, `env`, `ports`, `volumes`, and `workdir` — the same shape as `defaults`.
+
 ## Commands
 
 | Command | Description |
@@ -99,8 +119,8 @@ instead.
 | `wip doctor` | Diagnose WSL2, interop, WSLC, config, architecture, and Git |
 | `wip config` | Print the effective configuration (secrets masked) |
 | `wip build -- --no-cache` | Build the image from the `build` definition |
-| `wip up [-d]` | Start `defaults.container` (creating it with `up.command` if missing). `-d` runs it in the background |
-| `wip down` | Stop and remove `defaults.container` |
+| `wip up [-d]` | Start `defaults.container` and its `dependencies` (creating any that are missing, on `defaults.network` if set). `-d` runs the main container in the background |
+| `wip down` | Stop and remove `defaults.container` and its `dependencies` |
 | `wip exec [--no-interactive] COMMAND...` | Run a command in the existing container |
 | `wip run [--no-interactive] COMMAND...` | Run a command in a new `--rm` container |
 | `wip shell` | Open the configured shell, falling back to `bash` then `sh` |
@@ -165,10 +185,10 @@ checklist.
 
 ## Not in the initial release
 
-Compose compatibility, a resident/daemon process, a GUI, PowerShell-specific tuning, direct
-registry API/manifest parsing, self-update, and plugins are all unimplemented. Likely future
-additions: a richer config schema, lifecycle hooks, multi-container support, platform selection,
-and more detailed diagnostics.
+Full Compose compatibility (multiple networks, `depends_on` ordering/health checks, profiles), a
+resident/daemon process, a GUI, PowerShell-specific tuning, direct registry API/manifest parsing,
+self-update, and plugins are all unimplemented. Likely future additions: a richer config schema,
+lifecycle hooks, platform selection, and more detailed diagnostics.
 
 ## License
 

--- a/lib/wip/cli.rb
+++ b/lib/wip/cli.rb
@@ -53,24 +53,22 @@ module Wip
       execute(builder.build(settings: load_config.command('build') || {}, extra: extra))
     end
 
-    desc 'up', 'Start the configured container, creating it if necessary'
+    desc 'up', 'Start the configured container and its dependencies, creating them if necessary'
     option :detach, type: :boolean, default: false, aliases: '-d'
     def up
-      container = load_config.defaults['container']
-      interactive = builder.tty?(!options[:detach])
-      if container_exists?
-        warn "wip: starting existing container '#{container}'"
-        execute(builder.start(detach: options[:detach]), interactive: interactive)
-      else
-        warn "wip: container '#{container}' not found, creating it"
-        execute(builder.up(detach: options[:detach]), interactive: interactive)
-      end
+      ensure_network
+      load_config.dependencies.each_key { |name| ensure_dependency(name) }
+      ensure_container
     end
 
-    desc 'down', 'Stop and remove the configured container'
+    desc 'down', 'Stop and remove the configured container and its dependencies'
     def down
       execute(builder.down, exit_on_failure: false)
       execute(builder.remove, exit_on_failure: false)
+      load_config.dependencies.each_key do |name|
+        execute(builder.dependency_down(name), exit_on_failure: false)
+        execute(builder.dependency_remove(name), exit_on_failure: false)
+      end
     end
 
     desc 'exec COMMAND...', 'Execute a command in the running container'
@@ -126,12 +124,53 @@ module Wip
       code
     end
 
-    def container_exists?
+    def resource_exists?(find_command)
       out = StringIO.new
-      code = CommandRunner.new(stdout: out, stderr: StringIO.new).run(builder.find)
+      code = CommandRunner.new(stdout: out, stderr: StringIO.new).run(find_command)
       code.zero? && !JSON.parse(out.string).empty?
     rescue JSON::ParserError
       false
+    end
+
+    def ensure_network
+      network = load_config.network
+      return unless network
+      return if network_exists?(network)
+
+      warn "wip: creating network '#{network}'"
+      execute(builder.network_create, exit_on_failure: false)
+    end
+
+    def network_exists?(network)
+      out = StringIO.new
+      code = CommandRunner.new(stdout: out, stderr: StringIO.new).run(builder.network_list)
+      return false unless code.zero?
+
+      JSON.parse(out.string).any? { |entry| entry['Name'] == network }
+    rescue JSON::ParserError
+      false
+    end
+
+    def ensure_dependency(name)
+      if resource_exists?(builder.dependency_find(name))
+        warn "wip: starting existing dependency '#{name}'"
+        execute(builder.dependency_start(name))
+      else
+        warn "wip: dependency '#{name}' not found, creating it"
+        execute(builder.dependency_up(name))
+      end
+    end
+
+    def ensure_container
+      container = load_config.defaults['container']
+      interactive = builder.tty?(!options[:detach])
+      if resource_exists?(builder.find)
+        warn "wip: starting existing container '#{container}'"
+        execute(builder.start(detach: options[:detach]), interactive: interactive)
+      else
+        warn "wip: container '#{container}' not found, creating it"
+        execute(builder.up(detach: options[:detach]), interactive: interactive)
+      end
     end
   end
 end

--- a/lib/wip/command_builder.rb
+++ b/lib/wip/command_builder.rb
@@ -29,6 +29,7 @@ module Wip
     def up(detach: false)
       values = @config.defaults
       command = [@wslc, 'run', '--name', required(values, 'container')]
+      command.push('--network', @config.network) if @config.network
       command << '-d' if detach
       command << '-it' if !detach && tty?(true)
       command.concat(options(values)).push(required(values, 'image'))
@@ -53,6 +54,40 @@ module Wip
 
     def remove
       [@wslc, 'remove', '-f', required(@config.defaults, 'container')]
+    end
+
+    def network_create
+      [@wslc, 'network', 'create', required_network]
+    end
+
+    def network_list
+      [@wslc, 'network', 'list', '--format', 'json']
+    end
+
+    def dependency_up(name, detach: true)
+      values = dependency_values(name)
+      command = [@wslc, 'run', '--name', name.to_s]
+      command.push('--network', @config.network) if @config.network
+      command << '-d' if detach
+      command.concat(options(values)).push(required(values, 'image'))
+      command.concat(Shellwords.split(values['command'].to_s)) unless values['command'].to_s.empty?
+      command
+    end
+
+    def dependency_start(name)
+      [@wslc, 'start', name.to_s]
+    end
+
+    def dependency_find(name)
+      [@wslc, 'list', '--all', '--filter', "name=#{name}", '--format', 'json']
+    end
+
+    def dependency_down(name)
+      [@wslc, 'stop', name.to_s]
+    end
+
+    def dependency_remove(name)
+      [@wslc, 'remove', '-f', name.to_s]
     end
 
     def build(settings:, extra: [])
@@ -94,6 +129,17 @@ module Wip
       raise ConfigError, "Configured #{key} must not be empty" if value.to_s.empty?
 
       value
+    end
+
+    def required_network
+      network = @config.network
+      raise ConfigError, 'Configured network must not be empty' if network.to_s.empty?
+
+      network
+    end
+
+    def dependency_values(name)
+      @config.dependency(name) || raise(ConfigError, "Unknown dependency: #{name}")
     end
   end
 end

--- a/lib/wip/config.rb
+++ b/lib/wip/config.rb
@@ -18,6 +18,8 @@ module Wip
     def commands = @raw['commands'] || {}
     def defaults = DEFAULTS.merge(@raw['defaults'] || {})
     def up_command = @raw.dig('up', 'command')
+    def dependencies = @raw['dependencies'] || {}
+    def network = defaults['network']
 
     def command(name)
       entry = commands[name.to_s]
@@ -26,9 +28,16 @@ module Wip
       defaults.merge('type' => 'exec').merge(entry)
     end
 
+    def dependency(name)
+      entry = dependencies[name.to_s]
+      return unless entry
+
+      { 'workdir' => nil, 'env' => {}, 'ports' => [], 'volumes' => [] }.merge(entry)
+    end
+
     def to_h(redact: true)
       value = { 'version' => 1, 'wslc' => { 'command' => wslc_command }, 'defaults' => defaults,
-                'up' => { 'command' => up_command },
+                'up' => { 'command' => up_command }, 'dependencies' => dependencies,
                 'commands' => commands.transform_values { |entry| defaults.merge('type' => 'exec').merge(entry) } }
       redact ? redact_secrets(value) : value
     end
@@ -37,10 +46,22 @@ module Wip
 
     def validate!
       raise ConfigError, "Unsupported configuration version: #{@raw['version']}" unless (@raw['version'] || 1) == 1
-      raise ConfigError, 'commands must be a mapping' unless commands.is_a?(Hash)
       raise ConfigError, 'up must be a mapping' if @raw.key?('up') && !@raw['up'].is_a?(Hash)
 
+      validate_commands!
+      validate_dependencies!
+    end
+
+    def validate_commands!
+      raise ConfigError, 'commands must be a mapping' unless commands.is_a?(Hash)
+
       commands.each { |name, entry| validate_command!(name, entry) }
+    end
+
+    def validate_dependencies!
+      raise ConfigError, 'dependencies must be a mapping' unless dependencies.is_a?(Hash)
+
+      dependencies.each { |name, entry| validate_dependency!(name, entry) }
     end
 
     def validate_command!(name, entry)
@@ -48,6 +69,13 @@ module Wip
 
       type = entry['type'] || (name == 'build' ? 'build' : 'exec')
       raise ConfigError, "Invalid command type for #{name}: #{type}" unless %w[exec run build].include?(type)
+
+      entry['env']&.transform_values!(&:to_s)
+    end
+
+    def validate_dependency!(name, entry)
+      raise ConfigError, "dependencies.#{name} must be a mapping" unless entry.is_a?(Hash)
+      raise ConfigError, "dependencies.#{name} must set image" if entry['image'].to_s.empty?
 
       entry['env']&.transform_values!(&:to_s)
     end

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.3.1'
+  VERSION = '0.4.0'
 end

--- a/spec/wip/cli_spec.rb
+++ b/spec/wip/cli_spec.rb
@@ -59,4 +59,54 @@ RSpec.describe Wip::CLI do
 
     described_class.start(%w[up])
   end
+
+  it 'creates the network and dependencies before bringing up the main container' do
+    File.write('wip.yml', <<~YAML)
+      version: 1
+      defaults:
+        container: app
+        image: example:dev
+        network: app-tier
+      dependencies:
+        redis:
+          image: redis:latest
+    YAML
+
+    fake_runner = Class.new do
+      class << self
+        attr_accessor :calls, :responses
+      end
+      self.calls = []
+      self.responses = {
+        %w[wslc.exe network list --format json] => '[]',
+        %w[wslc.exe list --all --filter name=redis --format json] => '[]',
+        %w[wslc.exe list --all --filter name=app --format json] => '[]'
+      }
+
+      def initialize(stdout: nil, **_kwargs)
+        @stdout = stdout
+      end
+
+      def run(command, interactive: false, **_kwargs)
+        self.class.calls << [command, interactive]
+        @stdout&.write(self.class.responses.fetch(command, ''))
+        0
+      end
+    end
+    stub_const('Wip::CommandRunner', fake_runner)
+    allow(Wip::CommandResolver).to receive(:new).and_return(instance_double(Wip::CommandResolver,
+                                                                            resolve: 'wslc.exe'))
+
+    described_class.start(%w[up -d])
+
+    expected_commands = [
+      %w[wslc.exe network list --format json],
+      %w[wslc.exe network create app-tier],
+      %w[wslc.exe list --all --filter name=redis --format json],
+      %w[wslc.exe run --name redis --network app-tier -d redis:latest],
+      %w[wslc.exe list --all --filter name=app --format json],
+      %w[wslc.exe run --name app --network app-tier -d -w /app example:dev]
+    ]
+    expect(fake_runner.calls.map(&:first)).to eq(expected_commands)
+  end
 end

--- a/spec/wip/command_builder_spec.rb
+++ b/spec/wip/command_builder_spec.rb
@@ -70,4 +70,49 @@ RSpec.describe Wip::CommandBuilder do
 
     expect(builder.up(detach: true)).to eq(%w[wslc.exe run --name app -d -w /app example:dev local])
   end
+
+  describe 'network and dependency support' do
+    let(:networked_config) do
+      Wip::Config.new('defaults' => { 'container' => 'app', 'image' => 'example:dev', 'network' => 'app-tier' },
+                      'dependencies' => { 'redis' => { 'image' => 'redis:latest' },
+                                          'development.mysql' => {
+                                            'image' => 'mysql:8.0',
+                                            'command' => '--default-authentication-plugin=mysql_native_password',
+                                            'env' => { 'MYSQL_ROOT_PASSWORD' => 'password' },
+                                            'ports' => ['3306:3306']
+                                          } })
+    end
+    subject(:builder) { described_class.new(wslc: 'wslc.exe', config: networked_config, environment: environment) }
+
+    it 'attaches the main container to the configured network on creation' do
+      expect(builder.up(detach: true)).to eq(%w[wslc.exe run --name app --network app-tier -d -w /app example:dev])
+    end
+
+    it 'builds network create and list commands' do
+      expect(builder.network_create).to eq(%w[wslc.exe network create app-tier])
+      expect(builder.network_list).to eq(%w[wslc.exe network list --format json])
+    end
+
+    it 'builds a dependency container on the shared network with its own env/ports/command' do
+      expected = ['wslc.exe', 'run', '--name', 'development.mysql', '--network', 'app-tier', '-d', '-e',
+                  'MYSQL_ROOT_PASSWORD=password', '-p', '3306:3306', 'mysql:8.0',
+                  '--default-authentication-plugin=mysql_native_password']
+      expect(builder.dependency_up('development.mysql')).to eq(expected)
+    end
+
+    it 'builds a simple dependency container without a custom command' do
+      expect(builder.dependency_up('redis')).to eq(%w[wslc.exe run --name redis --network app-tier -d redis:latest])
+    end
+
+    it 'builds start/find/down/remove commands for a dependency' do
+      expect(builder.dependency_start('redis')).to eq(%w[wslc.exe start redis])
+      expect(builder.dependency_find('redis')).to eq(%w[wslc.exe list --all --filter name=redis --format json])
+      expect(builder.dependency_down('redis')).to eq(%w[wslc.exe stop redis])
+      expect(builder.dependency_remove('redis')).to eq(%w[wslc.exe remove -f redis])
+    end
+
+    it 'raises for an undefined dependency' do
+      expect { builder.dependency_up('unknown') }.to raise_error(Wip::ConfigError, /Unknown dependency: unknown/)
+    end
+  end
 end

--- a/spec/wip/config_spec.rb
+++ b/spec/wip/config_spec.rb
@@ -22,4 +22,23 @@ RSpec.describe Wip::Config do
   it 'rejects a non-mapping up section' do
     expect { described_class.new('up' => 'local') }.to raise_error(Wip::ConfigError, /up must be a mapping/)
   end
+
+  it 'exposes dependencies with defaulted settings' do
+    config = described_class.new('dependencies' => { 'redis' => { 'image' => 'redis:latest' } })
+
+    expect(config.dependency('redis')).to include('image' => 'redis:latest', 'env' => {}, 'ports' => [],
+                                                  'volumes' => [])
+    expect(config.dependency('unknown')).to be_nil
+  end
+
+  it 'requires dependencies to set an image' do
+    expect do
+      described_class.new('dependencies' => { 'redis' => { 'command' => 'redis-server' } })
+    end.to raise_error(Wip::ConfigError, /dependencies\.redis must set image/)
+  end
+
+  it 'exposes defaults.network, defaulting to nil' do
+    expect(described_class.new({}).network).to be_nil
+    expect(described_class.new('defaults' => { 'network' => 'app-tier' }).network).to eq('app-tier')
+  end
 end


### PR DESCRIPTION
## Summary

Investigated the report that `wip rails c` was still broken on slidict.io even with the interactive-TTY fix (#11) in place. Root cause turned out to be architectural, not a bug in the Ruby code:

- `wip.yml` only ever describes **one** container (`defaults`). `wip up` had no way to start anything else.
- slidict.io's `config/database.yml` connects to `host: development.mysql`, and `compose.yml` also depends on `redis` — both defined as separate Compose services on a shared bridge network with DNS aliases.
- Since `wip up` only started `app` (no network, no mysql/redis), `bin/rails c` hung indefinitely trying to resolve `development.mysql`, which is exactly what I reproduced: multiple stuck `bin/rails c` processes piling up inside the container, and a direct TCP connect confirming there was nothing listening.

This is a real gap, not something fixable by tweaking `CommandRunner`/`CommandBuilder` — wip needed a way to model dependency containers.

## Change

- New `defaults.network` (optional) and top-level `dependencies` map in `wip.yml`:
  ```yaml
  defaults:
    network: app-tier
  dependencies:
    redis:
      image: redis:latest
    development.mysql:
      image: mysql:8.0
      command: --default-authentication-plugin=mysql_native_password
      env:
        MYSQL_ROOT_PASSWORD: password
        MYSQL_DATABASE: development
  ```
- `wip up`: creates the network first if it doesn't exist, then brings up each dependency (same quiet find → start-or-create flow already used for the main container), then starts the main container attached to that network — so it can resolve dependencies by name, mirroring Compose service DNS.
- `wip down`: tears down the main container and all dependencies (network is left in place; shared infra, not owned by a single teardown).
- `CommandBuilder`: `network_create`/`network_list`, `dependency_up`/`dependency_start`/`dependency_find`/`dependency_down`/`dependency_remove`.
- `Config`: `dependencies`, `dependency(name)`, `network`, with validation (must be a mapping, each entry needs `image`).

## Verification
- `bundle exec rspec` (38 examples, 0 failures) — added specs for `Config#dependency`/`#network`, all the new `CommandBuilder` methods, and a `CLI` spec asserting the full `wip up` command sequence (network list → network create → dependency find → dependency run → container find → container run).
- `bundle exec rubocop` (no offenses)
- Full real-world verification against `wslc.exe` with slidict.io: added `network: slidict-app-tier` + `development.mysql`/`redis` to its `wip.yml`, ran `wip up -d`, confirmed all three containers came up on the shared network, `getent hosts development.mysql redis` resolved from inside `app`, and a live TCP connect from `app` to `development.mysql:3306` succeeded. (Reverted that `wip.yml` change afterward — it's the user's file to opt into.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ネットワーク設定に対応し、必要なネットワークを自動作成してコンテナを接続できるようになりました。
  - Redisなどの依存コンテナを、メインコンテナより先に起動・停止・削除できるようになりました。
  - 依存サービスのイメージ、環境変数、ポート、カスタムコマンドを設定できるようになりました。
  - 未定義の依存関係やイメージ不足を設定エラーとして通知します。

- **ドキュメント**
  - 依存コンテナ、ネットワーク設定、および`up`・`down`コマンドの利用方法を追加・更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->