### PR TITLE
fix: support running wip natively on Windows Ruby

### DIFF
--- a/lib/wip/doctor.rb
+++ b/lib/wip/doctor.rb
@@ -15,9 +15,8 @@ module Wip
 
     def call
       results = []
-      results << result(@environment.wsl2? ? :ok : :fail, 'Running on WSL2', 'Not running on WSL2')
-      results << result(@environment.windows_interop? ? :ok : :fail, 'Windows executable interoperability is enabled',
-                        'Windows executable interoperability is disabled')
+      results << result(@environment.wsl2? ? :ok : :fail, *wsl2_messages)
+      results << interop_result unless @environment.windows?
       results << Result.new(:ok, "Architecture: #{@environment.architecture}")
       config = load_config(results)
       command = resolve(config, results) if config
@@ -28,6 +27,17 @@ module Wip
     end
 
     private
+
+    def wsl2_messages
+      return ['WSL2 is available', 'WSL2 is not available'] if @environment.windows?
+
+      ['Running on WSL2', 'Not running on WSL2']
+    end
+
+    def interop_result
+      result(@environment.windows_interop? ? :ok : :fail, 'Windows executable interoperability is enabled',
+             'Windows executable interoperability is disabled')
+    end
 
     def load_config(results)
       config = @loader.load

--- a/lib/wip/environment.rb
+++ b/lib/wip/environment.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'open3'
+
 module Wip
   # Detects WSL2, Windows interop, and architecture facts about the host.
   class Environment
@@ -8,7 +10,11 @@ module Wip
       @stdout = stdout
     end
 
+    def windows? = Gem.win_platform?
+
     def wsl2?
+      return wsl2_backend_available? if windows?
+
       File.read('/proc/version').match?(/microsoft.*WSL2/i)
     rescue Errno::ENOENT
       false
@@ -18,9 +24,20 @@ module Wip
     def interactive? = @stdin.tty? && @stdout.tty?
 
     def architecture
-      machine = `uname -m`.strip
-      { 'x86_64' => 'linux/amd64', 'aarch64' => 'linux/arm64', 'arm64' => 'linux/arm64' }.fetch(machine,
-                                                                                                "linux/#{machine}")
+      machine = RbConfig::CONFIG['host_cpu']
+      { 'x86_64' => 'linux/amd64', 'x64' => 'linux/amd64', 'aarch64' => 'linux/arm64', 'arm64' => 'linux/arm64' }
+        .fetch(machine, "linux/#{machine}")
+    end
+
+    private
+
+    # On native Windows there is no /proc/version to read, so ask Windows
+    # itself whether the WSL2 backend that WSLC depends on is installed.
+    def wsl2_backend_available?
+      _output, status = Open3.capture2e('wsl.exe', '--status')
+      status.success?
+    rescue Errno::ENOENT
+      false
     end
   end
 end

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 end


### PR DESCRIPTION
## Summary
- `Environment#architecture` shelled out to `uname -m`, which doesn't exist on native Windows Ruby and crashed every `wip` command (`Errno::ENOENT`). Switched to `RbConfig::CONFIG['host_cpu']`.
- `wip doctor`'s WSL2 check now falls back to `wsl.exe --status` when running natively on Windows (instead of reading `/proc/version`), and skips the WSL-interop check there since it only applies when running inside WSL2 itself.
- Bumped version to v0.4.1.

## Test plan
- [x] `bundle exec rspec` (38 examples, 0 failures)
- [x] `bundle exec rubocop` (no offenses)
- [x] Manually verified `Doctor#call` output on a simulated native-Windows environment (interop check skipped, WSL2 message reworded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Windows環境でWSL2の利用可否を確認できるようになりました。
  * Windows以外の環境でも、実行環境やWindows実行ファイルとの相互運用性を確認できるようになりました。
  * 環境に応じたアーキテクチャ判定の精度を改善しました。
* **改善**
  * 診断時に必要な情報が、環境ごとに分かりやすく表示されるようになりました。
* **リリース**
  * バージョンを0.4.1に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->