### PR TITLE
feat: add --debug flag with step timing and resource monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,13 +148,29 @@ exit, but the timestamp of the `+ ...` line tells you when wip finished its own 
 off to `wslc`/`docker` — useful for telling wip-side overhead apart from time spent booting inside
 the container.
 
-While a step is still running, wip also prints a host resource snapshot (load average, memory
-used, and the top CPU-consuming processes) every 5 seconds, so a hang is visible even before the
-command has produced any output of its own:
+While a step is still running, wip also prints a host resource snapshot (load average, memory,
+disk I/O, and the top CPU-consuming processes) every 5 seconds, so a hang is visible even before
+the command has produced any output of its own:
 
 ```console
-wip: [debug] still running (load 3.42 2.10 1.05 | mem 6.1G/15.6G | top: wslc.exe(8842) cpu 61.0%/mem 3.2%, ...): running: wslc.exe exec -it -w /app app bin/rails c
+wip: [debug] still running (load 3.42 2.10 1.05 | mem 6.1G/15.6G | io read 12000KB/s write 400KB/s | top: wslc.exe(8842) cpu 61.0%/mem 3.2%, ...): running: wslc.exe exec -it -w /app app bin/rails c
 ```
+
+The disk I/O figure is worth watching first if the host's CPU and memory look idle — a slow
+`bundle`/`rails` boot is often WSL2's bind-mounted (`.:/app`-style) volumes doing a lot of small
+reads, not the container starving for CPU.
+
+For commands that hand the real terminal to the child (`-it`, e.g. `rails c`), these periodic
+snapshots go to a log file instead of your terminal — wip prints the path once at the start —
+since writing into a terminal the child controls in raw mode would garble both outputs. Commands
+that don't need a TTY still get the snapshots printed live.
+
+Override that choice with `--debug-log`:
+
+- `--debug-log=-` forces snapshots inline even for `-it` commands (only useful if you know your
+  terminal/pager can tolerate the interleaving).
+- `--debug-log=PATH` always writes snapshots to `PATH`, including for non-TTY commands, e.g. to
+  keep every run's snapshots in one place: `wip rails c --debug --debug-log=/tmp/wip-debug.log`.
 
 ## doctor
 

--- a/lib/wip/cli.rb
+++ b/lib/wip/cli.rb
@@ -10,6 +10,7 @@ module Wip
   class CLI < Thor
     class_option :config, type: :string, desc: 'Path to wip.yml'
     class_option :debug, type: :boolean, default: false, desc: 'Print progress and timing for each step'
+    class_option :debug_log, type: :string, desc: 'Where --debug snapshots go: a file path, or "-" for inline'
     default_task :dispatch
 
     def self.exit_on_failure? = true
@@ -121,7 +122,7 @@ module Wip
 
     def execute(command, interactive: false, exit_on_failure: true)
       runner = CommandRunner.new(debug: debug?)
-      code = reporter.step("running: #{CommandDisplay.for_debug(command)}") do
+      code = reporter.step("running: #{CommandDisplay.for_debug(command)}", live: !interactive) do
         runner.run(command, interactive: interactive)
       end
       exit(code) if exit_on_failure && !code.zero?
@@ -143,7 +144,7 @@ module Wip
     end
 
     def debug? = options[:debug] || !ENV['WIP_DEBUG'].to_s.empty?
-    def reporter = @reporter ||= DebugReporter.new(enabled: debug?)
+    def reporter = @reporter ||= DebugReporter.new(enabled: debug?, log: options[:debug_log])
 
     def ensure_network
       network = load_config.network

--- a/lib/wip/debug_reporter.rb
+++ b/lib/wip/debug_reporter.rb
@@ -1,27 +1,59 @@
 # frozen_string_literal: true
 
+require 'tmpdir'
+
 module Wip
   # Prints each step wip takes and how long it took, when debug mode is enabled.
   class DebugReporter
-    def initialize(enabled:, out: $stderr)
+    # `log:` overrides where resource snapshots go, regardless of `live`:
+    #   nil  - automatic (see `step`'s `live:`)
+    #   '-'  - always print inline, even for interactive steps
+    #   path - always write to this file, even for non-interactive steps
+    def initialize(enabled:, out: $stderr, log: nil)
       @enabled = enabled
       @out = out
+      @log = log
     end
 
-    def step(label)
+    # `live: false` is for steps that hand the real TTY to the child process
+    # (e.g. `wslc exec -it`). The child owns raw-mode cursor control there, so
+    # writing periodic snapshots straight into that same terminal races with
+    # it and garbles the output; those snapshots go to a log file instead,
+    # unless overridden by `log:` in the constructor.
+    def step(label, live: true)
       return yield unless @enabled
 
       started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       @out.puts "wip: [debug] #{label}"
-      monitor = ResourceMonitor.new(out: @out)
+      file = log_file(live)
+      monitor = ResourceMonitor.new(out: file || @out)
       monitor.start(label)
       begin
         yield
       ensure
         monitor.stop
+        file&.close
         elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
         @out.puts format('wip: [debug] done in %<elapsed>.2fs: %<label>s', elapsed: elapsed, label: label)
       end
+    end
+
+    private
+
+    def log_file(live)
+      return nil if @log == '-'
+      return open_log(@log, "streaming resource snapshots to #{@log}") if @log
+      return nil if live
+
+      path = File.join(Dir.tmpdir, "wip-debug-#{Process.pid}-#{Time.now.to_i}.log")
+      open_log(path, "command owns the terminal; streaming resource snapshots to #{path}")
+    end
+
+    def open_log(path, notice)
+      @out.puts "wip: [debug] #{notice}"
+      file = File.open(path, 'a') # rubocop:disable Style/FileOpen -- closed by `step`'s ensure block
+      file.sync = true
+      file
     end
   end
 end

--- a/lib/wip/resource_monitor.rb
+++ b/lib/wip/resource_monitor.rb
@@ -1,19 +1,22 @@
 # frozen_string_literal: true
 
 module Wip
-  # Periodically prints host CPU/memory/process info while a debug step is still
-  # running, so a hung or slow step is visible even before it produces output.
+  # Periodically prints host CPU/memory/disk-IO/process info while a debug step
+  # is still running, so a hung or slow step is visible even before it produces
+  # output of its own.
   class ResourceMonitor
     def initialize(interval: 5, out: $stderr)
       @interval = interval
       @out = out
+      @last_disk = disk_sectors
+      @last_sampled_at = monotonic
     end
 
     def start(label)
       @thread = Thread.new do
         loop do
           sleep @interval
-          @out.puts "wip: [debug] still running (#{load_average} | #{memory} | top: #{top_processes}): #{label}"
+          @out.puts "wip: [debug] still running (#{snapshot}): #{label}"
         end
       end
     end
@@ -24,6 +27,12 @@ module Wip
     end
 
     private
+
+    def monotonic = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    def snapshot
+      [load_average, memory, disk_io, top_processes].join(' | ')
+    end
 
     def load_average
       "load #{File.read('/proc/loadavg').split[0..2].join(' ')}"
@@ -40,15 +49,46 @@ module Wip
       'mem n/a'
     end
 
+    # WSL2's bind-mounted (9p) volumes are often the real bottleneck behind a
+    # slow `bundle`/`rails` boot, and that shows up here rather than in CPU.
+    def disk_io
+      now = monotonic
+      elapsed = [now - @last_sampled_at, 0.001].max
+      current = disk_sectors
+      read_kbps = (current[:read] - @last_disk[:read]) * 0.5 / elapsed
+      write_kbps = (current[:write] - @last_disk[:write]) * 0.5 / elapsed
+      @last_disk = current
+      @last_sampled_at = now
+      format('io read %<read>.0fKB/s write %<write>.0fKB/s', read: read_kbps, write: write_kbps)
+    rescue Errno::ENOENT, IOError
+      'io n/a'
+    end
+
+    def disk_sectors
+      totals = { read: 0, write: 0 }
+      File.readlines('/proc/diskstats').each do |line|
+        fields = line.split
+        next if fields[2].to_s.match?(/\A(loop|ram)/)
+
+        totals[:read] += fields[5].to_i
+        totals[:write] += fields[9].to_i
+      end
+      totals
+    rescue Errno::ENOENT, IOError
+      { read: 0, write: 0 }
+    end
+
     def top_processes
-      `ps -eo pid,pcpu,pmem,comm --sort=-pcpu 2>/dev/null`.lines.drop(1).first(3).filter_map do |line|
+      lines = `ps -eo pid,pcpu,pmem,comm --sort=-pcpu 2>/dev/null`.lines.drop(1).first(3)
+      entries = lines.filter_map do |line|
         pid, cpu, mem, comm = line.split(nil, 4)
         next unless comm
 
         "#{comm.strip}(#{pid}) cpu #{cpu}%/mem #{mem}%"
-      end.join(', ')
+      end
+      "top: #{entries.join(', ')}"
     rescue StandardError
-      'n/a'
+      'top: n/a'
     end
   end
 end

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.4.2'
+  VERSION = '0.4.3'
 end

--- a/spec/wip/cli_spec.rb
+++ b/spec/wip/cli_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 require 'tmpdir'
+require 'fileutils'
 
 RSpec.describe Wip::CLI do
   around do |example|
@@ -41,6 +42,19 @@ RSpec.describe Wip::CLI do
       a_string_matching(%r{\[debug\] running: wslc\.exe exec.*bin/rails c})
         .and(a_string_matching(/\[debug\] done in \d+\.\d{2}s/))
     ).to_stderr
+  end
+
+  it 'forwards --debug-log to the DebugReporter' do
+    runner = instance_double(Wip::CommandRunner, run: 0)
+    allow(Wip::CommandRunner).to receive(:new).and_return(runner)
+    allow(Wip::CommandResolver).to receive(:new).and_return(instance_double(Wip::CommandResolver,
+                                                                            resolve: 'wslc.exe'))
+    log_path = File.join(Dir.mktmpdir, 'custom.log')
+    expect(Wip::DebugReporter).to receive(:new).with(enabled: true, log: log_path).and_call_original
+
+    described_class.start(['rails', 'c', '--debug', "--debug-log=#{log_path}"])
+  ensure
+    FileUtils.rm_rf(File.dirname(log_path)) if log_path
   end
 
   it 'creates the container when `up` finds none existing via a quiet `wslc list` probe' do

--- a/spec/wip/debug_reporter_spec.rb
+++ b/spec/wip/debug_reporter_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+require 'stringio'
+
+RSpec.describe Wip::DebugReporter do
+  it 'runs the block and returns its value when disabled, printing nothing' do
+    reporter = described_class.new(enabled: false)
+    expect(reporter.step('label') { 42 }).to eq(42)
+  end
+
+  it 'prints start/done lines directly to `out` for a live step' do
+    out = StringIO.new
+    reporter = described_class.new(enabled: true, out: out)
+    monitor = instance_double(Wip::ResourceMonitor, start: nil, stop: nil)
+    allow(Wip::ResourceMonitor).to receive(:new).with(out: out).and_return(monitor)
+
+    reporter.step('doing work', live: true) { :done }
+
+    expect(out.string).to include('[debug] doing work').and include('[debug] done in')
+  end
+
+  it 'redirects a non-live step to a log file by default and reports its path' do
+    Dir.mktmpdir do |dir|
+      allow(Dir).to receive(:tmpdir).and_return(dir)
+      out = StringIO.new
+      reporter = described_class.new(enabled: true, out: out)
+
+      reporter.step('interactive work', live: false) { :done }
+
+      expect(out.string).to match(%r{streaming resource snapshots to #{Regexp.escape(dir)}/wip-debug-.*\.log})
+      expect(Dir.glob(File.join(dir, 'wip-debug-*.log'))).not_to be_empty
+    end
+  end
+
+  it '--debug-log=- forces snapshots inline even for a non-live step' do
+    out = StringIO.new
+    reporter = described_class.new(enabled: true, out: out, log: '-')
+
+    reporter.step('interactive work', live: false) { :done }
+
+    expect(out.string).not_to include('streaming resource snapshots')
+  end
+
+  it '--debug-log=PATH forces snapshots to that file even for a live step' do
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, 'custom.log')
+      out = StringIO.new
+      reporter = described_class.new(enabled: true, out: out, log: path)
+
+      reporter.step('non-interactive work', live: true) { :done }
+
+      expect(out.string).to include("streaming resource snapshots to #{path}")
+      expect(File).to exist(path)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `wip exec`/`wip up`/custom `wip.yml` commands (e.g. `wip rails c`) run with no feedback while they're slow. `--debug` (or `WIP_DEBUG=1`) now prints each step wip takes and how long it took, plus a periodic host resource snapshot (load average, memory, disk I/O, top CPU processes) so a hang is visible even before the command produces output.
- Resource snapshots for interactive (`-it`) commands go to a temp log file by default instead of the shared terminal, since writing into a TTY the child controls in raw mode (e.g. `rails c`) races with its cursor control and garbles both outputs. `--debug-log=-`/`--debug-log=PATH` overrides that routing.
- `-e KEY=value` env values are masked in debug command output so secrets from `wip.yml` never hit logs.
- Bumps version to v0.4.3.

## Test plan
- [x] `bundle exec rspec` (45 examples, 0 failures)
- [x] `bundle exec rubocop` (clean)
- [x] Manually verified `--debug` on an interactive command redirects snapshots to a log file instead of corrupting the terminal, and `--debug-log=-`/`--debug-log=PATH` override that behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)