### PR TITLE
feat(sync): mirror the source into a volume instead of bind-mounting it live

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ commands:
     type: build
     context: .
     tag: slidict/slidict:development
+sync: # optional; mirror the source into a named volume instead of bind-mounting it live
+  exclude:
+    - .git
+    - tmp/
+    - node_modules/
 ```
 
 `env` values are stringified. `wip config` masks any key matching token, password, secret,
@@ -128,6 +133,53 @@ inside the main container) can reach `development.mysql`/`redis`/etc. by their d
 the same way Compose's service names resolve. `wip down` tears the main container and all
 dependencies down (the network itself is left in place). Each dependency entry accepts `image`
 (required), `command`, `env`, `ports`, `volumes`, and `workdir` — the same shape as `defaults`.
+
+### Source sync
+
+Bind-mounting the app directory (`.:/app`) is what usually makes a container boot crawl under
+wslc — see [Slow boot when the app directory is
+bind-mounted](#slow-boot-when-the-app-directory-is-bind-mounted) for why. A `sync:` block hands
+that problem to `wip`: the source is mounted read-only, the app runs off a named volume, and wip
+mirrors one into the other with `rsync`.
+
+```yaml
+sync:
+  source: .          # host path, relative to wip.yml (default: the wip.yml directory)
+  target: /app       # container path served by the volume (default: defaults.workdir, else /app)
+  volume: app-src    # named volume holding the mirror (default: "<defaults.container>-src")
+  mount: /host-src   # where the source is bind-mounted read-only (default: /host-src)
+  exclude:           # rsync --exclude patterns
+    - .git
+    - tmp/
+    - node_modules/
+  delete: true       # rsync --delete (default: true)
+  command: rsync     # binary that does the mirroring (default: rsync)
+  options: []        # extra flags appended to the rsync invocation
+  interval: 2        # seconds between syncs for `wip sync --watch` (default: 2)
+```
+
+Everything below `sync:` is optional — `sync: {}` alone already works. With it in place:
+
+- Any `defaults.volumes` entry mounting `target` (the usual `.:/app`) is replaced by
+  `<source>:/host-src:ro` plus `app-src:/app`, so the running app only ever touches the volume.
+  Other volumes (`bundle:/usr/local/bundle`, ...) are passed through untouched, and
+  `dependencies:` keep mounting whatever they declare.
+- `wip up` mirrors the source into the volume before the container boots; `wip up --no-sync`
+  skips that step.
+- `wip sync` mirrors on demand — `wslc exec`ing rsync inside the container when it's running, and
+  falling back to a throwaway container with the same mounts when it isn't.
+- `wip sync --watch [--interval N]` keeps re-syncing until Ctrl-C, so host edits reach the
+  container with a short delay. Run it in a second terminal alongside `wip up -d`.
+- `wip doctor` reports the resolved source, volume, and target, and fails if the source is missing.
+
+Two things to keep in mind. The mirror runs `rsync` *inside* the container, so the image needs it
+(`RUN apt-get update && apt-get install -y rsync`) — or point `sync.command` at a copy tool the
+image already has. And the mirror is one-way (host → volume): anything the app writes under
+`target` is removed by the next `--delete` pass unless you `exclude` it, give it its own volume,
+or set `delete: false`.
+
+`sync:` is mutually exclusive with `compose:` — in compose mode the compose file owns the volume
+layout.
 
 ### Compose mode
 
@@ -178,12 +230,13 @@ found, its version, and which compose file `wip` resolved.
 | `wip doctor` | Diagnose WSL2, interop, WSLC, config, architecture, and Git |
 | `wip config` | Print the effective configuration (secrets masked) |
 | `wip build -- --no-cache` | Build the image from the `build` definition |
-| `wip up [-d]` | Start `defaults.container` and its `dependencies` (creating any that are missing, on `defaults.network` if set). `-d` runs the main container in the background |
+| `wip up [-d] [--no-sync]` | Start `defaults.container` and its `dependencies` (creating any that are missing, on `defaults.network` if set). `-d` runs the main container in the background; with `sync:` configured, the source is mirrored into the volume first unless `--no-sync` |
 | `wip down` | Stop and remove `defaults.container` and its `dependencies` |
 | `wip exec [--no-interactive] COMMAND...` | Run a command in the existing container |
 | `wip run [--no-interactive] COMMAND...` | Run a command in a new `--rm` container (compose mode: `exec`s into `compose.service` instead) |
 | `wip shell` | Open the configured shell, falling back to `bash` then `sh` |
 | `wip logs [-f] [SERVICE...]` | Follow compose service logs (compose mode only) |
+| `wip sync [-w] [--interval N]` | Mirror the source into the sync volume once, or keep re-syncing with `--watch` (needs `sync:`) |
 | `wip NAME ARGS...` | Run `commands.NAME`, appending any extra arguments |
 
 TTY allocation is decided by combining the command's config, the CLI option, and whether both
@@ -261,12 +314,11 @@ side can look busy while almost no data is actually transferred, and the process
 for minutes with barely any resource usage to show for it.
 
 If a debug log shows a boot-time command "stuck" with low CPU/mem/IO in `resource_monitor`'s
-output, this is worth checking before assuming the app itself is broken. The workaround is to stop
-bind-mounting the source live and instead mirror it into a named volume: mount the host path
-read-only (`.:/host-src:ro`), add a named volume for `/app`, and have the container's entrypoint
-`rsync` from the read-only mount into the volume before boot, then keep syncing in the background
-(e.g. every couple of seconds) so edits still show up with a short delay. The app then only ever
-touches fast native storage once it's running.
+output, this is worth checking before assuming the app itself is broken. The fix is to stop
+bind-mounting the source live and mirror it into a named volume instead, so the app only ever
+touches fast native storage once it's running. `wip` does that for you — add a `sync:` block and
+it rewrites the mounts, mirrors before boot, and re-syncs on demand. See [Source
+sync](#source-sync).
 
 ### CPU architecture mismatch
 
@@ -330,10 +382,12 @@ for `wip`, roughly in priority order:
 3. **Bind-mount boot time (`rails c`, `bundle`, ...)** — commands like `wip rails c` still start
    noticeably slower than the equivalent under `docker compose`, mostly from WSL2 bind-mounted
    (`.:/app`-style) volumes doing many small reads for gems/`node_modules` (use `--debug` to
-   confirm it's disk I/O and not `wip`'s own overhead). This isn't really `wip`'s responsibility —
-   the fix has to come from either the mount layer or the project's own volume layout. We're also
-   hoping for improvements on the `wslc` side itself (faster bind-mount/cache behavior); `wip`
-   will pick those up for free as soon as they land.
+   confirm it's disk I/O and not `wip`'s own overhead). [Source sync](#source-sync) works around
+   this today by running the app off a named volume and mirroring the host tree into it, at the
+   cost of a one-way sync with a short delay. A tighter loop (host-side file watching instead of
+   interval polling, two-way sync) is the natural next step. We're also hoping for improvements on
+   the `wslc` side itself (faster bind-mount/cache behavior); `wip` will pick those up for free as
+   soon as they land.
 
 Each of these should stay additive to the existing `wip.yml` shape — no breaking changes to
 `defaults`, `commands`, `dependencies`, or `compose` are planned. A resident daemon and a GUI

--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ Everything below `sync:` is optional — `sync: {}` alone already works. With it
   container with a short delay. Run it in a second terminal alongside `wip up -d`.
 - `wip doctor` reports the resolved source, volume, and target, and fails if the source is missing.
 
+Like every built-in command, `wip sync` takes precedence over a `commands:` entry of the same
+name; wip says so and points at `wip dispatch sync`, which still runs yours.
+
 Two things to keep in mind. The mirror runs `rsync` *inside* the container, so the image needs it
 (`RUN apt-get update && apt-get install -y rsync`) — or point `sync.command` at a copy tool the
 image already has. And the mirror is one-way (host → volume): anything the app writes under

--- a/lib/wip.rb
+++ b/lib/wip.rb
@@ -2,6 +2,7 @@
 
 require_relative 'wip/version'
 require_relative 'wip/errors'
+require_relative 'wip/sync_settings'
 require_relative 'wip/config'
 require_relative 'wip/config_loader'
 require_relative 'wip/environment'

--- a/lib/wip/cli.rb
+++ b/lib/wip/cli.rb
@@ -80,9 +80,10 @@ module Wip
     option :interval, type: :numeric, desc: 'Seconds between syncs when watching (default: sync.interval)'
     def sync
       settings = sync_settings!
+      warn_shadowed_command('sync')
       return run_sync unless options[:watch]
 
-      interval = options[:interval] || settings.interval
+      interval = watch_interval(settings)
       warn "wip: syncing #{settings.source} -> #{settings.volume}:#{settings.target} " \
            "every #{interval}s (Ctrl-C to stop)"
       loop do
@@ -250,6 +251,24 @@ module Wip
 
     def sync_settings!
       load_config.sync || raise(ConfigError, '`wip sync` needs a sync: block in wip.yml')
+    end
+
+    # `sync.interval` is validated when the config loads; --interval isn't, and
+    # a negative one would only surface as an ArgumentError from `sleep`.
+    def watch_interval(settings)
+      interval = options[:interval] || settings.interval
+      raise ConfigError, '--interval must be a positive number' unless interval.positive?
+
+      interval
+    end
+
+    # A built-in command wins over a `commands:` entry of the same name, so
+    # point at `wip dispatch` rather than letting the custom one vanish.
+    def warn_shadowed_command(name)
+      return unless load_config.commands.key?(name)
+
+      warn "wip: commands.#{name} in wip.yml is shadowed by the built-in `wip #{name}`; " \
+           "run it with `wip dispatch #{name}`"
     end
 
     # Inside the running container the mirror is a plain `exec`; otherwise it

--- a/lib/wip/cli.rb
+++ b/lib/wip/cli.rb
@@ -63,6 +63,7 @@ module Wip
 
     desc 'up', 'Start the configured container and its dependencies, creating them if necessary'
     option :detach, type: :boolean, default: false, aliases: '-d'
+    option :sync, type: :boolean, default: true, desc: 'Mirror the source into the sync volume first (--no-sync skips)'
     def up
       if load_config.compose?
         return execute(compose_bridge.up(detach: options[:detach]), interactive: tty?(!options[:detach]))
@@ -70,7 +71,26 @@ module Wip
 
       ensure_network
       load_config.dependencies.each_key { |name| ensure_dependency(name) }
+      sync_before_boot if options[:sync]
       ensure_container
+    end
+
+    desc 'sync', 'Mirror the source tree into the sync volume'
+    option :watch, type: :boolean, default: false, aliases: '-w', desc: 'Keep re-syncing until interrupted'
+    option :interval, type: :numeric, desc: 'Seconds between syncs when watching (default: sync.interval)'
+    def sync
+      settings = sync_settings!
+      return run_sync unless options[:watch]
+
+      interval = options[:interval] || settings.interval
+      warn "wip: syncing #{settings.source} -> #{settings.volume}:#{settings.target} " \
+           "every #{interval}s (Ctrl-C to stop)"
+      loop do
+        run_sync(exit_on_failure: false)
+        sleep interval
+      end
+    rescue Interrupt
+      warn "\nwip: sync stopped"
     end
 
     desc 'down', 'Stop and remove the configured container and its dependencies'
@@ -226,6 +246,28 @@ module Wip
         warn "wip: dependency '#{name}' not found, creating it"
         execute(builder.dependency_up(name))
       end
+    end
+
+    def sync_settings!
+      load_config.sync || raise(ConfigError, '`wip sync` needs a sync: block in wip.yml')
+    end
+
+    # Inside the running container the mirror is a plain `exec`; otherwise it
+    # takes a throwaway container that mounts the same source and volume.
+    def run_sync(exit_on_failure: true)
+      command = container_running? ? builder.sync_exec : builder.sync_run
+      execute(command, exit_on_failure: exit_on_failure)
+    end
+
+    def container_running? = resource_exists?(builder.find_running)
+
+    def sync_before_boot
+      settings = load_config.sync
+      return unless settings
+
+      warn "wip: syncing #{settings.source} -> #{settings.volume}:#{settings.target}"
+      execute(builder.sync_run)
+      warn "wip: run `wip sync --watch` in another terminal to keep #{settings.target} up to date"
     end
 
     def ensure_container

--- a/lib/wip/command_builder.rb
+++ b/lib/wip/command_builder.rb
@@ -49,6 +49,26 @@ module Wip
       [@wslc, 'list', '--all', '--filter', "name=#{container}", '--format', 'json']
     end
 
+    def find_running
+      container = required(@config.defaults, 'container')
+      [@wslc, 'list', '--filter', "name=#{container}", '--format', 'json']
+    end
+
+    # Mirrors into the volume from a throwaway container, for when the app
+    # container isn't running yet (or at all) — e.g. just before `up` boots it.
+    def sync_run
+      sync = required_sync
+      command = [@wslc, 'run', '--rm']
+      sync.volume_specs.each { |spec| command.push('-v', spec) }
+      command.push(required(@config.defaults, 'image')).concat(sync.mirror_command)
+    end
+
+    # Mirrors from inside the running container, which already has both the
+    # read-only source mount and the volume attached.
+    def sync_exec
+      [@wslc, 'exec', required(@config.defaults, 'container'), *required_sync.mirror_command]
+    end
+
     def down
       [@wslc, 'stop', required(@config.defaults, 'container')]
     end
@@ -70,7 +90,7 @@ module Wip
       command = [@wslc, 'run', '--name', name.to_s]
       command.push('--network', @config.network) if @config.network
       command << '-d' if detach
-      command.concat(options(values)).push(required(values, 'image'))
+      command.concat(options(values, sync: false)).push(required(values, 'image'))
       command.concat(Shellwords.split(values['command'].to_s)) unless values['command'].to_s.empty?
       command
     end
@@ -113,16 +133,27 @@ module Wip
 
     private
 
-    def options(values, include_container: false, include_publish: true)
+    def options(values, include_container: false, include_publish: true, sync: true)
       result = []
       result.push('-w', values['workdir']) unless values['workdir'].to_s.empty?
       merged_env(values).each { |key, value| result.push('-e', "#{key}=#{value}") }
       if include_publish
         Array(values['ports']).each { |port| result.push('-p', port.to_s) }
-        Array(values['volumes']).each { |volume| result.push('-v', volume.to_s) }
+        volume_specs(values, sync: sync).each { |volume| result.push('-v', volume) }
       end
       result << required(values, 'container') if include_container
       result
+    end
+
+    # With sync configured, a live bind mount of the target (`.:/app`) is
+    # swapped for the read-only source mount plus the named volume, so the
+    # running app only ever touches the volume.
+    def volume_specs(values, sync: true)
+      specs = Array(values['volumes']).map(&:to_s)
+      settings = sync ? @config.sync : nil
+      return specs unless settings
+
+      specs.reject { |spec| settings.replaces?(spec) } + settings.volume_specs
     end
 
     # .env supplies defaults; env set in wip.yml (defaults or per-command) wins on conflict.
@@ -140,6 +171,10 @@ module Wip
       raise ConfigError, 'Configured network must not be empty' if network.to_s.empty?
 
       network
+    end
+
+    def required_sync
+      @config.sync || raise(ConfigError, 'No sync: block configured in wip.yml')
     end
 
     def dependency_values(name)

--- a/lib/wip/config.rb
+++ b/lib/wip/config.rb
@@ -26,6 +26,13 @@ module Wip
     def compose_file = compose && compose['file']
     def compose_project = compose && compose['project']
     def compose_command = compose && compose['command']
+    def sync? = !!sync
+
+    def sync
+      return @sync if defined?(@sync)
+
+      @sync = @raw.key?('sync') ? build_sync : nil
+    end
 
     def command(name)
       entry = commands[name.to_s]
@@ -44,6 +51,7 @@ module Wip
     def to_h(redact: true)
       value = { 'version' => 1, 'wslc' => { 'command' => wslc_command }, 'defaults' => defaults,
                 'up' => { 'command' => up_command }, 'dependencies' => dependencies, 'compose' => compose,
+                'sync' => sync&.to_h,
                 'commands' => commands.transform_values { |entry| defaults.merge('type' => 'exec').merge(entry) } }
       redact ? redact_secrets(value) : value
     end
@@ -57,6 +65,17 @@ module Wip
       validate_commands!
       validate_dependencies!
       validate_compose!
+      validate_sync!
+    end
+
+    def build_sync
+      SyncSettings.new(@raw['sync'], base: path && File.dirname(path.to_s),
+                                     workdir: defaults['workdir'], container: defaults['container'])
+    end
+
+    def validate_sync!
+      return unless sync
+      raise ConfigError, 'sync is mutually exclusive with compose' if compose?
     end
 
     def validate_commands!

--- a/lib/wip/doctor.rb
+++ b/lib/wip/doctor.rb
@@ -21,9 +21,7 @@ module Wip
       results << result(@environment.wsl2? ? :ok : :fail, *wsl2_messages)
       results << interop_result unless @environment.windows?
       results << Result.new(:ok, "Architecture: #{@environment.architecture}")
-      config = load_config(results)
-      check_wslc(config, results) if config
-      check_compose(config, results) if config&.compose?
+      check_config(load_config(results), results)
       results << result(command_available?('git') ? :ok : :warn, 'Git is available',
                         'Git is not available to the WSLC build environment')
       results
@@ -51,6 +49,14 @@ module Wip
     rescue ConfigError => e
       results << Result.new(:fail, e.message)
       nil
+    end
+
+    def check_config(config, results)
+      return unless config
+
+      check_wslc(config, results)
+      check_compose(config, results) if config.compose?
+      check_sync(config, results) if config.sync?
     end
 
     def check_wslc(config, results)
@@ -96,6 +102,13 @@ module Wip
                         "Compose file not found: #{path}")
     rescue ConfigError => e
       results << Result.new(:fail, e.message)
+    end
+
+    def check_sync(config, results)
+      sync = config.sync
+      results << result(File.directory?(sync.source) ? :ok : :fail,
+                        "Sync source #{sync.source} mirrors into volume #{sync.volume} at #{sync.target}",
+                        "Sync source not found: #{sync.source}")
     end
 
     def result(condition, ok_message, fail_message)

--- a/lib/wip/error_interpreter.rb
+++ b/lib/wip/error_interpreter.rb
@@ -11,10 +11,23 @@ module Wip
       case output
       when /pull access denied|insufficient_scope|authorization failed/i then registry_message
       when %r{no matching manifest for linux/(?:amd64|arm64)}i then architecture_message
+      when /rsync: (?:command )?not found|executable file not found[^\n]*rsync/i then rsync_message
       end
     end
 
     private
+
+    def rsync_message
+      <<~TEXT
+        `wip sync` needs rsync inside the image.
+
+        Install it in your Dockerfile:
+
+          RUN apt-get update && apt-get install -y rsync
+
+        Or point sync.command at a tool the image already has.
+      TEXT
+    end
 
     def registry_message
       <<~TEXT

--- a/lib/wip/error_interpreter.rb
+++ b/lib/wip/error_interpreter.rb
@@ -3,6 +3,14 @@
 module Wip
   # Translates raw WSLC error output into friendlier hints.
   class ErrorInterpreter
+    # Shells report a missing rsync as "rsync: not found", while the container
+    # runtime names the executable either before or after its own phrasing.
+    RSYNC_MISSING = Regexp.union(
+      /rsync: (?:command )?not found/i,
+      /rsync[^\n]*executable file not found/i,
+      /executable file not found[^\n]*rsync/i
+    )
+
     def initialize(architecture: Environment.new.architecture)
       @architecture = architecture
     end
@@ -11,7 +19,7 @@ module Wip
       case output
       when /pull access denied|insufficient_scope|authorization failed/i then registry_message
       when %r{no matching manifest for linux/(?:amd64|arm64)}i then architecture_message
-      when /rsync: (?:command )?not found|executable file not found[^\n]*rsync/i then rsync_message
+      when RSYNC_MISSING then rsync_message
       end
     end
 

--- a/lib/wip/sync_settings.rb
+++ b/lib/wip/sync_settings.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'pathname'
+
+module Wip
+  # Validated access to the `sync:` block, which mirrors the host source tree
+  # into a named volume instead of bind-mounting it live.
+  #
+  # A bind-mounted app directory is shared into the container's VM over
+  # virtiofs, so every stat/open a boot-time directory scan makes is a round
+  # trip. Mirroring the tree into a named volume (native storage inside the VM)
+  # and re-running the mirror on demand keeps the edit-on-the-host workflow
+  # while leaving the running app on fast disk.
+  class SyncSettings
+    DEFAULT_MOUNT = '/host-src'
+    DEFAULT_TARGET = '/app'
+    DEFAULT_BINARY = 'rsync'
+    DEFAULT_INTERVAL = 2
+    # -a preserves modes and timestamps so file watchers and bundler see a
+    # faithful copy rather than a tree that looks freshly written every sync.
+    BASE_OPTIONS = %w[-a].freeze
+    # Trailing mount options wslc/docker accept after the container path.
+    VOLUME_MODES = %w[ro rw z Z cached delegated consistent].freeze
+
+    attr_reader :target, :mount, :volume, :exclude, :binary, :extra_options, :interval
+
+    def initialize(raw, base: nil, workdir: nil, container: nil)
+      raise ConfigError, 'sync must be a mapping' unless raw.is_a?(Hash)
+
+      @base = base
+      assign_paths(raw, workdir: workdir, container: container)
+      assign_mirror(raw)
+      validate!
+    end
+
+    def delete? = !!@delete
+
+    # Expanded against the wip.yml directory so the mirror covers the same tree
+    # no matter which subdirectory wip was invoked from.
+    def source
+      @source ||= @base ? Pathname(@base).join(@raw_source).expand_path.to_s : @raw_source
+    end
+
+    # What `-v` specs the main container needs: the source read-only, and the
+    # named volume where the app actually runs.
+    def volume_specs = ["#{source}:#{mount}:ro", "#{volume}:#{target}"]
+
+    # True for a configured volume that sync replaces, so `.:/app` in
+    # `defaults.volumes` quietly becomes the read-only mount plus the volume.
+    def replaces?(spec)
+      [target.chomp('/'), mount.chomp('/')].include?(container_path(spec))
+    end
+
+    # Trailing slashes matter to rsync: they copy the *contents* of the mount
+    # into the target rather than nesting it one directory deeper.
+    def mirror_command
+      command = [binary, *BASE_OPTIONS]
+      command << '--delete' if delete?
+      command.concat(exclude.map { |pattern| "--exclude=#{pattern}" })
+      command.concat(extra_options)
+      command.push("#{mount.chomp('/')}/", "#{target.chomp('/')}/")
+    end
+
+    def to_h
+      { 'source' => source, 'target' => target, 'mount' => mount, 'volume' => volume,
+        'delete' => delete?, 'exclude' => exclude, 'command' => binary, 'options' => extra_options,
+        'interval' => interval }
+    end
+
+    private
+
+    def assign_paths(raw, workdir:, container:)
+      @raw_source = presence(raw['source']) || '.'
+      @target = presence(raw['target']) || presence(workdir) || DEFAULT_TARGET
+      @mount = presence(raw['mount']) || DEFAULT_MOUNT
+      @volume = presence(raw['volume']) || "#{presence(container) || 'wip'}-src"
+    end
+
+    def assign_mirror(raw)
+      @delete = raw.fetch('delete', true)
+      @exclude = Array(raw['exclude']).map(&:to_s)
+      @binary = presence(raw['command']) || DEFAULT_BINARY
+      @extra_options = Array(raw['options']).map(&:to_s)
+      @interval = raw.key?('interval') ? raw['interval'] : DEFAULT_INTERVAL
+    end
+
+    def validate!
+      raise ConfigError, 'sync.target must be an absolute path' unless @target.start_with?('/')
+      raise ConfigError, 'sync.mount must be an absolute path' unless @mount.start_with?('/')
+      raise ConfigError, 'sync.mount must differ from sync.target' if @mount.chomp('/') == @target.chomp('/')
+      return if @interval.is_a?(Numeric) && @interval.positive?
+
+      raise ConfigError, 'sync.interval must be a positive number'
+    end
+
+    def container_path(spec)
+      parts = spec.to_s.split(':')
+      parts.pop if parts.size > 2 && VOLUME_MODES.include?(parts.last)
+      parts.last.to_s.chomp('/')
+    end
+
+    def presence(value) = value.to_s.empty? ? nil : value.to_s
+  end
+end

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.6.0'
+  VERSION = '0.7.0'
 end

--- a/spec/wip/cli_spec.rb
+++ b/spec/wip/cli_spec.rb
@@ -253,6 +253,31 @@ RSpec.describe Wip::CLI do
 
       expect { described_class.start(%w[sync]) }.to raise_error(Wip::ConfigError, /needs a sync: block/)
     end
+
+    it 'rejects a non-positive --interval instead of letting sleep raise' do
+      stub_runner('[]')
+
+      expect { described_class.start(%w[sync --watch --interval -1]) }
+        .to raise_error(Wip::ConfigError, /--interval must be a positive number/)
+    end
+
+    it 'points at `wip dispatch` when wip.yml defines a command the built-in shadows' do
+      File.write('wip.yml', <<~YAML)
+        version: 1
+        defaults:
+          container: app
+          image: example:dev
+        sync: {}
+        commands:
+          sync:
+            command: bin/custom-sync
+      YAML
+      runner = stub_runner('[]')
+      allow(runner).to receive(:run).and_return(0)
+
+      expect { described_class.start(%w[sync]) }
+        .to output(/commands\.sync .* is shadowed by the built-in `wip sync`.*wip dispatch sync/m).to_stderr
+    end
   end
 
   it 'excludes files matched by .dockerignore from the build context' do

--- a/spec/wip/cli_spec.rb
+++ b/spec/wip/cli_spec.rb
@@ -162,6 +162,99 @@ RSpec.describe Wip::CLI do
     described_class.start(%w[up])
   end
 
+  describe 'sync mode' do
+    let(:source) { File.expand_path('.') }
+
+    before do
+      File.write('wip.yml', <<~YAML)
+        version: 1
+        defaults:
+          container: app
+          image: example:dev
+          volumes:
+            - ".:/app"
+        sync:
+          exclude:
+            - .git
+      YAML
+      allow(Wip::CommandResolver).to receive(:new).and_return(instance_double(Wip::CommandResolver,
+                                                                              resolve: 'wslc.exe'))
+    end
+
+    def stub_runner(probe_output)
+      runner = instance_double(Wip::CommandRunner)
+      allow(Wip::CommandRunner).to receive(:new) do |**kwargs|
+        kwargs[:stdout]&.write(probe_output)
+        runner
+      end
+      runner
+    end
+
+    it 'mirrors into the volume before booting, and boots off the volume instead of the bind mount' do
+      runner = stub_runner('[]')
+      allow(runner).to receive(:run).with(%w[wslc.exe list --all --filter name=app --format json]).and_return(0)
+      expect(runner).to receive(:run).with(
+        ['wslc.exe', 'run', '--rm', '-v', "#{source}:/host-src:ro", '-v', 'app-src:/app', 'example:dev',
+         'rsync', '-a', '--delete', '--exclude=.git', '/host-src/', '/app/'], interactive: false
+      ).and_return(0).ordered
+      expect(runner).to receive(:run).with(
+        ['wslc.exe', 'run', '--name', 'app', '-d', '-w', '/app', '-v', "#{source}:/host-src:ro", '-v',
+         'app-src:/app', 'example:dev'], interactive: false
+      ).and_return(0).ordered
+
+      described_class.start(%w[up -d])
+    end
+
+    it 'skips the pre-boot mirror when --no-sync is passed' do
+      runner = stub_runner('[]')
+      allow(runner).to receive(:run).with(%w[wslc.exe list --all --filter name=app --format json]).and_return(0)
+      expect(runner).not_to receive(:run).with(a_collection_including('rsync'), any_args)
+      expect(runner).to receive(:run).with(a_collection_including('--name', 'app'), interactive: false).and_return(0)
+
+      described_class.start(%w[up -d --no-sync])
+    end
+
+    it 'runs a one-shot mirror inside the container when it is already running' do
+      runner = stub_runner('[{"Name":"app"}]')
+      allow(runner).to receive(:run).with(%w[wslc.exe list --filter name=app --format json]).and_return(0)
+      expect(runner).to receive(:run).with(
+        %w[wslc.exe exec app rsync -a --delete --exclude=.git /host-src/ /app/], interactive: false
+      ).and_return(0)
+
+      described_class.start(%w[sync])
+    end
+
+    it 'falls back to a throwaway container when the app container is not running' do
+      runner = stub_runner('[]')
+      allow(runner).to receive(:run).with(%w[wslc.exe list --filter name=app --format json]).and_return(0)
+      expect(runner).to receive(:run).with(a_collection_including('--rm', 'rsync'), interactive: false).and_return(0)
+
+      described_class.start(%w[sync])
+    end
+
+    it 'keeps mirroring on an interval with --watch until interrupted' do
+      runner = stub_runner('[{"Name":"app"}]')
+      allow(runner).to receive(:run).with(%w[wslc.exe list --filter name=app --format json]).and_return(0)
+      syncs = 0
+      allow(runner).to receive(:run).with(a_collection_including('rsync'), interactive: false) do
+        syncs += 1
+        raise Interrupt if syncs == 2
+
+        0
+      end
+
+      expect { described_class.start(%w[sync --watch --interval 0.01]) }
+        .to output(/syncing .* every 0\.01s/).to_stderr
+      expect(syncs).to eq(2)
+    end
+
+    it 'requires a sync block' do
+      File.write('wip.yml', "version: 1\ndefaults:\n  container: app\n  image: example:dev\n")
+
+      expect { described_class.start(%w[sync]) }.to raise_error(Wip::ConfigError, /needs a sync: block/)
+    end
+  end
+
   it 'excludes files matched by .dockerignore from the build context' do
     FileUtils.mkdir_p('node_modules')
     File.write(File.join('node_modules', 'pkg.js'), '')

--- a/spec/wip/command_builder_spec.rb
+++ b/spec/wip/command_builder_spec.rb
@@ -116,6 +116,46 @@ RSpec.describe Wip::CommandBuilder do
     end
   end
 
+  describe 'sync support' do
+    let(:synced_config) do
+      Wip::Config.new('defaults' => { 'container' => 'app', 'image' => 'example:dev', 'workdir' => '/app',
+                                      'volumes' => ['.:/app', 'bundle:/usr/local/bundle'] },
+                      'dependencies' => { 'redis' => { 'image' => 'redis:latest', 'volumes' => ['.:/app'] } },
+                      'sync' => { 'exclude' => ['.git'] })
+    end
+    subject(:builder) { described_class.new(wslc: 'wslc.exe', config: synced_config, environment: environment) }
+
+    it 'replaces the live bind mount with the read-only source and the named volume' do
+      expect(builder.up(detach: true)).to eq(['wslc.exe', 'run', '--name', 'app', '-d', '-w', '/app', '-v',
+                                              'bundle:/usr/local/bundle', '-v', '.:/host-src:ro', '-v',
+                                              'app-src:/app', 'example:dev'])
+    end
+
+    it 'leaves dependency containers mounting the host directly' do
+      expect(builder.dependency_up('redis'))
+        .to eq(%w[wslc.exe run --name redis -d -v .:/app redis:latest])
+    end
+
+    it 'mirrors from a throwaway container when the app container is not running' do
+      expect(builder.sync_run).to eq(['wslc.exe', 'run', '--rm', '-v', '.:/host-src:ro', '-v', 'app-src:/app',
+                                      'example:dev', 'rsync', '-a', '--delete', '--exclude=.git',
+                                      '/host-src/', '/app/'])
+    end
+
+    it 'mirrors inside the running container' do
+      expect(builder.sync_exec).to eq(%w[wslc.exe exec app rsync -a --delete --exclude=.git /host-src/ /app/])
+    end
+
+    it 'builds a running-only find query' do
+      expect(builder.find_running).to eq(%w[wslc.exe list --filter name=app --format json])
+    end
+
+    it 'raises when sync commands are built without a sync block' do
+      expect { described_class.new(wslc: 'wslc.exe', config: config, environment: environment).sync_run }
+        .to raise_error(Wip::ConfigError, /No sync: block/)
+    end
+  end
+
   describe 'dotenv support' do
     subject(:builder) do
       described_class.new(wslc: 'wslc.exe', config: config, environment: environment,

--- a/spec/wip/config_spec.rb
+++ b/spec/wip/config_spec.rb
@@ -85,4 +85,32 @@ RSpec.describe Wip::Config do
                           'defaults' => { 'network' => 'app-tier' })
     end.to raise_error(Wip::ConfigError, /compose is mutually exclusive with defaults\.network/)
   end
+
+  it 'has no sync settings unless a sync block is present' do
+    config = described_class.new({})
+    expect(config.sync?).to be(false)
+    expect(config.sync).to be_nil
+  end
+
+  it 'derives sync settings from defaults and the config location' do
+    config = described_class.new({ 'defaults' => { 'container' => 'web', 'workdir' => '/srv/app' }, 'sync' => {} },
+                                 '/home/me/project/wip.yml')
+
+    expect(config.sync?).to be(true)
+    expect(config.sync.source).to eq('/home/me/project')
+    expect(config.sync.target).to eq('/srv/app')
+    expect(config.sync.volume).to eq('web-src')
+  end
+
+  it 'rejects sync combined with compose' do
+    expect do
+      described_class.new('compose' => { 'service' => 'app', 'command' => 'my-compose-tool' }, 'sync' => {})
+    end.to raise_error(Wip::ConfigError, /sync is mutually exclusive with compose/)
+  end
+
+  it 'includes the resolved sync settings in the effective configuration' do
+    config = described_class.new('defaults' => { 'container' => 'app' }, 'sync' => { 'exclude' => ['.git'] })
+
+    expect(config.to_h['sync']).to include('volume' => 'app-src', 'target' => '/app', 'exclude' => ['.git'])
+  end
 end

--- a/spec/wip/doctor_spec.rb
+++ b/spec/wip/doctor_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+
+RSpec.describe Wip::Doctor do
+  def results_for(yaml)
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, 'wip.yml'), yaml)
+      described_class.new(loader: Wip::ConfigLoader.new(start_dir: dir)).call
+    end
+  end
+
+  # Config validates the sync block while loading, so a bad one has to surface
+  # as a failed check rather than an exception escaping `wip doctor`.
+  it 'reports an invalid sync block as a failed check' do
+    results = results_for(<<~YAML)
+      version: 1
+      defaults:
+        container: app
+        image: example:dev
+      sync:
+        interval: 0
+    YAML
+
+    expect(results).to include(an_object_having_attributes(level: :fail,
+                                                           message: 'sync.interval must be a positive number'))
+  end
+
+  it 'reports the resolved sync plan when the source exists' do
+    results = results_for(<<~YAML)
+      version: 1
+      defaults:
+        container: app
+        image: example:dev
+      sync: {}
+    YAML
+
+    expect(results).to include(an_object_having_attributes(level: :ok,
+                                                           message: a_string_matching(%r{volume app-src at /app})))
+  end
+end

--- a/spec/wip/error_interpreter_spec.rb
+++ b/spec/wip/error_interpreter_spec.rb
@@ -9,4 +9,7 @@ RSpec.describe Wip::ErrorInterpreter do
   it('classifies architecture errors') {
     expect(interpreter.interpret('no matching manifest for linux/amd64')).to include('linux/amd64', 'multi-platform')
   }
+  it('classifies a missing rsync in the image') {
+    expect(interpreter.interpret('sh: 1: rsync: not found')).to include('wip sync', 'apt-get install -y rsync')
+  }
 end

--- a/spec/wip/error_interpreter_spec.rb
+++ b/spec/wip/error_interpreter_spec.rb
@@ -12,4 +12,8 @@ RSpec.describe Wip::ErrorInterpreter do
   it('classifies a missing rsync in the image') {
     expect(interpreter.interpret('sh: 1: rsync: not found')).to include('wip sync', 'apt-get install -y rsync')
   }
+  it('classifies a missing rsync however the runtime words it') {
+    expect(interpreter.interpret('exec: "rsync": executable file not found in $PATH')).to include('wip sync')
+    expect(interpreter.interpret('executable file not found in $PATH: rsync')).to include('wip sync')
+  }
 end

--- a/spec/wip/sync_settings_spec.rb
+++ b/spec/wip/sync_settings_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Wip::SyncSettings do
+  subject(:sync) { described_class.new({}, container: 'app') }
+
+  it 'defaults the mount, volume, and mirror command' do
+    expect(sync.source).to eq('.')
+    expect(sync.target).to eq('/app')
+    expect(sync.mount).to eq('/host-src')
+    expect(sync.volume).to eq('app-src')
+    expect(sync.interval).to eq(2)
+    expect(sync.mirror_command).to eq(%w[rsync -a --delete /host-src/ /app/])
+  end
+
+  it 'falls back to the configured workdir for the target' do
+    expect(described_class.new({}, workdir: '/srv/app').target).to eq('/srv/app')
+  end
+
+  it 'builds the read-only source mount and the named volume' do
+    expect(sync.volume_specs).to eq(['.:/host-src:ro', 'app-src:/app'])
+  end
+
+  it 'expands the source against the wip.yml directory' do
+    settings = described_class.new({ 'source' => 'src' }, base: '/home/me/project')
+
+    expect(settings.source).to eq('/home/me/project/src')
+    expect(settings.volume_specs.first).to eq('/home/me/project/src:/host-src:ro')
+  end
+
+  it 'passes excludes, extra options, and a custom binary through to the mirror command' do
+    settings = described_class.new({ 'command' => 'rsync-3', 'exclude' => ['.git', 'tmp/'],
+                                     'options' => ['--info=stats0'], 'delete' => false })
+
+    expect(settings.mirror_command)
+      .to eq(%w[rsync-3 -a --exclude=.git --exclude=tmp/ --info=stats0 /host-src/ /app/])
+  end
+
+  it 'recognizes the volumes it replaces, including mode suffixes and Windows-style hosts' do
+    expect(sync).to be_replaces('.:/app')
+    expect(sync).to be_replaces('.:/app/')
+    expect(sync).to be_replaces('/host/src:/app:ro')
+    expect(sync).to be_replaces('C:\\src:/host-src:ro')
+    expect(sync).not_to be_replaces('bundle:/usr/local/bundle')
+  end
+
+  it 'rejects a relative target, a colliding mount, and a non-positive interval' do
+    expect { described_class.new({ 'target' => 'app' }) }.to raise_error(Wip::ConfigError, /absolute path/)
+    expect { described_class.new({ 'mount' => '/app/' }) }.to raise_error(Wip::ConfigError, /differ from sync.target/)
+    expect { described_class.new({ 'interval' => 0 }) }.to raise_error(Wip::ConfigError, /positive number/)
+    expect { described_class.new('nope') }.to raise_error(Wip::ConfigError, /must be a mapping/)
+  end
+end


### PR DESCRIPTION
Bind-mounting the app directory into a wslc container shares it in over
virtiofs, so every stat/open a boot-time directory scan makes is a round
trip and boots crawl. The README described the workaround (read-only
source mount + named volume + an entrypoint that rsyncs between them);
this moves it into wip.

A `sync:` block declares the source, target, volume, read-only mount,
rsync excludes/options, and the watch interval. With it configured:

- volume rewriting: a `defaults.volumes` entry mounting the target
  (`.:/app`) becomes `<source>:/host-src:ro` plus `<volume>:/app`, so the
  running app only touches the volume. Other volumes and `dependencies:`
  are left alone.
- `wip up` mirrors before the container boots (`--no-sync` skips it).
- `wip sync` mirrors on demand, `exec`ing rsync in the running container
  and falling back to a throwaway container when it isn't running.
- `wip sync --watch [--interval N]` keeps re-syncing until interrupted.
- `wip doctor` reports the resolved plan and fails on a missing source;
  a missing rsync in the image gets an install hint.

`sync:` is mutually exclusive with `compose:`, which owns its own volume
layout.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EowKrbDkf7DenQJ8TnDjQw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - `sync:` 設定により、ソースをコンテナ内のボリュームへ同期できるようになりました。
  - `wip sync` で単発同期や監視付きの継続同期を実行できます。
  - `up` 実行前の自動同期と、`--no-sync` による無効化に対応しました。
  - 除外、削除、同期間隔、追加コマンドオプションを設定できます。
- **改善**
  - `wip doctor` が同期設定やソースパスを診断します。
  - `rsync` 未導入時に対処方法を案内します。
- **ドキュメント**
  - 設定例、コマンド、制約事項、既知の遅延、ロードマップを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->