### PR TITLE
fix(security): harden temporary file handling

### DIFF
--- a/lib/wip/build_context.rb
+++ b/lib/wip/build_context.rb
@@ -29,7 +29,10 @@ module Wip
       each_included_file do |relative_path|
         target = destination.join(relative_path)
         FileUtils.mkdir_p(target.dirname)
-        FileUtils.cp(@root.join(relative_path), target)
+        # Keep links as links. Dereferencing a link here could copy arbitrary
+        # host files outside the build context (for example, ~/.ssh/id_rsa)
+        # into the staged directory and expose them to the image build.
+        FileUtils.copy_entry(@root.join(relative_path), target, false, false, false)
       end
     end
 
@@ -38,7 +41,7 @@ module Wip
         next if %w[. ..].include?(entry)
 
         path = @root.join(entry)
-        next unless path.file?
+        next unless path.file? || path.symlink?
         next if @ignore.ignored?(entry)
 
         yield entry

--- a/lib/wip/debug_reporter.rb
+++ b/lib/wip/debug_reporter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'tmpdir'
+require 'tempfile'
 
 module Wip
   # Prints each step wip takes and how long it took, when debug mode is enabled.
@@ -45,8 +46,10 @@ module Wip
       return open_log(@log, "streaming resource snapshots to #{@log}") if @log
       return nil if live
 
-      path = File.join(Dir.tmpdir, "wip-debug-#{Process.pid}-#{Time.now.to_i}.log")
-      open_log(path, "command owns the terminal; streaming resource snapshots to #{path}")
+      file = Tempfile.new(['wip-debug-', '.log'])
+      file.sync = true
+      @out.puts "wip: [debug] command owns the terminal; streaming resource snapshots to #{file.path}"
+      file
     end
 
     def open_log(path, notice)

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.7.0'
+  VERSION = '0.7.1'
 end

--- a/spec/wip/build_context_spec.rb
+++ b/spec/wip/build_context_spec.rb
@@ -30,4 +30,32 @@ RSpec.describe Wip::BuildContext do
       expect(staged_files.grep(/^node_modules/)).to be_empty
     end
   end
+
+  it 'preserves symlinks instead of copying files from outside the context' do
+    Dir.mktmpdir do |parent|
+      context = File.join(parent, 'context')
+      FileUtils.mkdir_p(context)
+      File.write(File.join(context, '.dockerignore'), "ignored\n")
+      secret = File.join(parent, 'secret')
+      File.write(secret, 'host secret')
+      File.symlink(secret, File.join(context, 'linked-secret'))
+
+      described_class.new(context).stage do |staged|
+        staged_link = File.join(staged, 'linked-secret')
+        expect(File).to be_symlink(staged_link)
+        expect(File.readlink(staged_link)).to eq(secret)
+      end
+    end
+  end
+
+  it 'preserves broken symlinks' do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, '.dockerignore'), "ignored\n")
+      File.symlink('missing', File.join(dir, 'broken'))
+
+      described_class.new(dir).stage do |staged|
+        expect(File).to be_symlink(File.join(staged, 'broken'))
+      end
+    end
+  end
 end

--- a/spec/wip/debug_reporter_spec.rb
+++ b/spec/wip/debug_reporter_spec.rb
@@ -30,7 +30,9 @@ RSpec.describe Wip::DebugReporter do
       reporter.step('interactive work', live: false) { :done }
 
       expect(out.string).to match(%r{streaming resource snapshots to #{Regexp.escape(dir)}/wip-debug-.*\.log})
-      expect(Dir.glob(File.join(dir, 'wip-debug-*.log'))).not_to be_empty
+      log = Dir.glob(File.join(dir, 'wip-debug-*.log')).first
+      expect(log).not_to be_nil
+      expect(File.stat(log).mode & 0o777).to eq(0o600)
     end
   end
 


### PR DESCRIPTION
### Motivation

- Prevent accidental inclusion of host files (for example `~/.ssh/id_rsa`) into staged build contexts via symlink dereferencing. 
- Ensure automatically-created debug log files are created in a secure, unpredictable way with owner-only permissions to avoid information leakage.

### Description

- Preserve symlinks when staging a build context by replacing `FileUtils.cp` with `FileUtils.copy_entry(..., dereference=false)` and include `symlink?` in the file iteration so links are copied as links rather than being dereferenced. 
- Use `Tempfile` for automatic debug log files in `DebugReporter#log_file`, enabling unpredictable paths and system-default secure permissions, and print the created path to the reporter output. 
- Add regression tests that assert symlink preservation for both valid and broken symlinks in `spec/wip/build_context_spec.rb` and that the automatic debug log file is created with `0600`-style permissions in `spec/wip/debug_reporter_spec.rb`. 
- Bump patch `VERSION` from `0.7.0` to `0.7.1` to reflect the security fix.

### Testing

- Ran `ruby -c` syntax checks on changed files and specs, which all returned `Syntax OK`.
- Executed targeted runtime checks that verify symlink preservation and debug-log permissions using `ruby -Ilib -e` one-liners, both of which passed. 
- Verified repository cleanliness and diffs with `git diff --check` and `git status --short --branch` after the change and committed as `fix(security): harden temporary file handling`.
- Attempted `bundle install && bundle exec rspec && bundle exec rubocop` but the full dependency install and test run were blocked because RubyGems returned HTTP 403 in this environment, so full RSpec/RuboCop runs could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ec70ec9a8832284f1ba7f89dfde33)