### PR TITLE
fix(debug): keep the reported debug log on disk

### DIFF
--- a/lib/wip/debug_reporter.rb
+++ b/lib/wip/debug_reporter.rb
@@ -46,7 +46,11 @@ module Wip
       return open_log(@log, "streaming resource snapshots to #{@log}") if @log
       return nil if live
 
-      file = Tempfile.new(['wip-debug-', '.log'])
+      # `Tempfile.create`, unlike `Tempfile.new`, leaves the file on disk after
+      # we close it, so the path printed just below is still there to read.
+      # It still creates with O_EXCL and 0600, which is what stops a
+      # predictable name in a shared /tmp from being pre-created as a symlink.
+      file = Tempfile.create(['wip-debug-', '.log'])
       file.sync = true
       @out.puts "wip: [debug] command owns the terminal; streaming resource snapshots to #{file.path}"
       file

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.7.1'
+  VERSION = '0.7.2'
 end

--- a/spec/wip/debug_reporter_spec.rb
+++ b/spec/wip/debug_reporter_spec.rb
@@ -36,6 +36,21 @@ RSpec.describe Wip::DebugReporter do
     end
   end
 
+  it 'leaves the reported log file on disk after the step finishes' do
+    Dir.mktmpdir do |dir|
+      allow(Dir).to receive(:tmpdir).and_return(dir)
+      out = StringIO.new
+      reporter = described_class.new(enabled: true, out: out)
+
+      reporter.step('interactive work', live: false) { :done }
+      GC.start
+
+      path = out.string[/streaming resource snapshots to (\S+)/, 1]
+      expect(path).not_to be_nil
+      expect(File).to exist(path)
+    end
+  end
+
   it '--debug-log=- forces snapshots inline even for a non-live step' do
     out = StringIO.new
     reporter = described_class.new(enabled: true, out: out, log: '-')


### PR DESCRIPTION
## 背景

v0.7.1 のセキュリティレビュー（`bd25910..1d060b4`）の副産物です。レビュー本体では **HIGH / MEDIUM の脆弱性は 0 件** でしたが、一時ファイル対策 (515d371) が機能面のリグレッションを持ち込んでいたため、それだけを修正します。

## 問題

`DebugReporter#log_file` は `Tempfile.new` でログを作りますが、`Tempfile.new` は **GC 時（遅くともプロセス終了時）にファイルを unlink するファイナライザ** を登録します。

- `step` は `ensure` でハンドルを閉じ、`file` はそのままスコープを抜ける
- 直前に `streaming resource snapshots to <path>` とパスを案内している
- ユーザーがそのパスを開く頃にはファイルが消えている

再現（Ruby 3.3.6）:

```
Tempfile.new    -> exists after GC: false
Tempfile.create -> exists after GC: true, mode: 600
```

## 修正

`Tempfile.create` に差し替えます。ブロックなしの `Tempfile.create` はファイナライザを登録せず、close 後もファイルを残します。

セキュリティ特性は維持されます — `Tempfile.create` も `O_EXCL` かつ mode 0600 で生成するため、515d371 が塞いだ「共有 `/tmp` 上の予測可能な名前を先回りして symlink に差し替える」経路は塞がったままです。旧実装の `/tmp/wip-debug-#{Process.pid}-#{Time.now.to_i}.log` + `File.open(path, 'a')` には戻していません。

## テスト

- パーミッション 0600 を確認する既存の spec はそのまま通過
- `step` 完了・`GC.start` 後もログが残ることを確認する spec を追加
- `rspec`: 120 examples, 0 failures / `rubocop`: 39 files, no offenses

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bf7PcUnugpkkhZ9AnoZzUG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * デバッグログを処理完了後もディスク上に保持できるようになりました。

* **バグ修正**
  * ガベージコレクション実行後も、生成済みのデバッグログを利用できるよう改善しました。

* **リリース**
  * バージョンを0.7.2に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->