### PR TITLE
feat(config): make orchestration and sync mode explicit instead of inferred

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Put a `wip.yml` in your project root. Running from a subdirectory walks up to fi
 
 ```yaml
 version: 1
+mode: container # or compose; picks the orchestration path `up`/`down`/`sync`/etc. take (default: container)
 wslc:
   command: auto # tries wslc.exe, wslc, then System32; an absolute path also works
 defaults:
@@ -156,6 +157,8 @@ sync:
   command: rsync     # binary that does the mirroring (default: rsync)
   options: []        # extra flags appended to the rsync invocation
   interval: 2        # seconds between syncs for `wip sync --watch` (default: 2)
+  mode: exec         # exec (mirror inside the running container) or run (a throwaway one);
+                      # default: exec for `mode: container`, run for `mode: compose`
 ```
 
 Everything below `sync:` is optional — `sync: {}` alone already works. With it in place:
@@ -166,8 +169,10 @@ Everything below `sync:` is optional — `sync: {}` alone already works. With it
   `dependencies:` keep mounting whatever they declare.
 - `wip up` mirrors the source into the volume before the container boots; `wip up --no-sync`
   skips that step.
-- `wip sync` mirrors on demand — `wslc exec`ing rsync inside the container when it's running, and
-  falling back to a throwaway container with the same mounts when it isn't.
+- `wip sync` mirrors on demand: `sync.mode: exec` (the default under `mode: container`) execs
+  rsync inside the already-running container; `sync.mode: run` always uses a throwaway container
+  with the same mounts instead. Which one runs is fixed by config, not guessed at from whether a
+  container happens to be up.
 - `wip sync --watch [--interval N]` keeps re-syncing until Ctrl-C, so host edits reach the
   container with a short delay. Run it in a second terminal alongside `wip up -d`.
 - `wip doctor` reports the resolved source, volume, and target, and fails if the source is missing.
@@ -181,8 +186,11 @@ image already has. And the mirror is one-way (host → volume): anything the app
 `target` is removed by the next `--delete` pass unless you `exclude` it, give it its own volume,
 or set `delete: false`.
 
-`sync:` is mutually exclusive with `compose:` — in compose mode the compose file owns the volume
-layout.
+`sync:` works alongside `mode: compose` too. Compose still owns the volume layout — a compose
+service must mount the same named volume `sync.volume` names — but wip's mirror runs as its own
+throwaway container (`sync.mode` defaults to `run` and can't be set to `exec` under `mode:
+compose`, since only a container wip itself booted is guaranteed to have the read-only source
+mount attached).
 
 ### Compose mode
 
@@ -191,6 +199,7 @@ If your project already has a real `compose.yml`, don't duplicate it in `depende
 
 ```yaml
 version: 1
+mode: compose              # required to enable compose mode; a compose: block with no mode: compose is an error
 compose:
   service: app             # required: which compose service wip run/exec/NAME target
   command: wslc-compose    # required: the compose-for-wslc binary/path you have installed

--- a/lib/wip/cli.rb
+++ b/lib/wip/cli.rb
@@ -271,14 +271,13 @@ module Wip
            "run it with `wip dispatch #{name}`"
     end
 
-    # Inside the running container the mirror is a plain `exec`; otherwise it
-    # takes a throwaway container that mounts the same source and volume.
+    # sync.mode picks the path explicitly (default: exec for mode: container,
+    # run for mode: compose) rather than probing whether a container happens
+    # to be running under a matching name.
     def run_sync(exit_on_failure: true)
-      command = container_running? ? builder.sync_exec : builder.sync_run
+      command = sync_settings!.exec? ? builder.sync_exec : builder.sync_run
       execute(command, exit_on_failure: exit_on_failure)
     end
-
-    def container_running? = resource_exists?(builder.find_running)
 
     def sync_before_boot
       settings = load_config.sync

--- a/lib/wip/command_builder.rb
+++ b/lib/wip/command_builder.rb
@@ -49,13 +49,9 @@ module Wip
       [@wslc, 'list', '--all', '--filter', "name=#{container}", '--format', 'json']
     end
 
-    def find_running
-      container = required(@config.defaults, 'container')
-      [@wslc, 'list', '--filter', "name=#{container}", '--format', 'json']
-    end
-
-    # Mirrors into the volume from a throwaway container, for when the app
-    # container isn't running yet (or at all) — e.g. just before `up` boots it.
+    # Mirrors into the volume from a throwaway container. Used for sync.mode:
+    # run (compose's default, and mode: container's fallback for when the app
+    # container isn't running yet — e.g. just before `up` boots it).
     def sync_run
       sync = required_sync
       command = [@wslc, 'run', '--rm']
@@ -63,8 +59,10 @@ module Wip
       command.push(required(@config.defaults, 'image')).concat(sync.mirror_command)
     end
 
-    # Mirrors from inside the running container, which already has both the
-    # read-only source mount and the volume attached.
+    # Mirrors from inside the already-running container. Only valid for
+    # sync.mode: exec (mode: container's default), since only a container wip
+    # itself booted is guaranteed to have both the read-only source mount and
+    # the volume attached.
     def sync_exec
       [@wslc, 'exec', required(@config.defaults, 'container'), *required_sync.mirror_command]
     end

--- a/lib/wip/config.rb
+++ b/lib/wip/config.rb
@@ -6,6 +6,10 @@ module Wip
     DEFAULTS = { 'container' => 'app', 'workdir' => '/app', 'interactive' => false,
                  'remove' => true, 'env' => {}, 'ports' => [], 'volumes' => [] }.freeze
     SECRET_PATTERN = /token|password|secret|credential|auth/i
+    # Which orchestration path `up`/`down`/`sync`/etc. take. Explicit rather than
+    # inferred from a `compose:` block's presence, so a config reader doesn't have
+    # to know that rule to predict which mode wip runs in.
+    MODES = %w[container compose].freeze
     attr_reader :path
 
     def initialize(raw, path = nil)
@@ -20,8 +24,9 @@ module Wip
     def up_command = @raw.dig('up', 'command')
     def dependencies = @raw['dependencies'] || {}
     def network = defaults['network']
+    def mode = @raw['mode'] || 'container'
     def compose = @raw['compose']
-    def compose? = !!compose
+    def compose? = mode == 'compose'
     def compose_service = compose && compose['service']
     def compose_file = compose && compose['file']
     def compose_project = compose && compose['project']
@@ -50,8 +55,8 @@ module Wip
 
     def to_h(redact: true)
       value = { 'version' => 1, 'wslc' => { 'command' => wslc_command }, 'defaults' => defaults,
-                'up' => { 'command' => up_command }, 'dependencies' => dependencies, 'compose' => compose,
-                'sync' => sync&.to_h,
+                'up' => { 'command' => up_command }, 'mode' => mode, 'dependencies' => dependencies,
+                'compose' => compose, 'sync' => sync&.to_h,
                 'commands' => commands.transform_values { |entry| defaults.merge('type' => 'exec').merge(entry) } }
       redact ? redact_secrets(value) : value
     end
@@ -62,6 +67,7 @@ module Wip
       raise ConfigError, "Unsupported configuration version: #{@raw['version']}" unless (@raw['version'] || 1) == 1
       raise ConfigError, 'up must be a mapping' if @raw.key?('up') && !@raw['up'].is_a?(Hash)
 
+      validate_mode!
       validate_commands!
       validate_dependencies!
       validate_compose!
@@ -70,12 +76,20 @@ module Wip
 
     def build_sync
       SyncSettings.new(@raw['sync'], base: path && File.dirname(path.to_s),
-                                     workdir: defaults['workdir'], container: defaults['container'])
+                                     workdir: defaults['workdir'], container: defaults['container'],
+                                     compose: compose?)
     end
 
+    def validate_mode!
+      raise ConfigError, "mode must be one of #{MODES.join(', ')}" unless MODES.include?(mode)
+      raise ConfigError, 'mode: compose requires a compose: block' if compose? && !@raw.key?('compose')
+      raise ConfigError, 'a compose: block requires mode: compose' if @raw.key?('compose') && !compose?
+    end
+
+    # Forces SyncSettings to build (and so run its own validation, including
+    # sync.mode vs. mode) at load time instead of on first access.
     def validate_sync!
-      return unless sync
-      raise ConfigError, 'sync is mutually exclusive with compose' if compose?
+      sync if @raw.key?('sync')
     end
 
     def validate_commands!

--- a/lib/wip/sync_settings.rb
+++ b/lib/wip/sync_settings.rb
@@ -26,19 +26,26 @@ module Wip
     BASE_OPTIONS = %w[-r -l -t --whole-file].freeze
     # Trailing mount options wslc/docker accept after the container path.
     VOLUME_MODES = %w[ro rw z Z cached delegated consistent].freeze
+    # exec mirrors inside the already-running, wip-managed container (fast,
+    # but only correct when wip itself created that container with the sync
+    # mounts attached). run always mirrors from a disposable container, since
+    # compose owns its own services' mounts and never guarantees that shape.
+    SYNC_MODES = %w[exec run].freeze
 
-    attr_reader :target, :mount, :volume, :exclude, :binary, :extra_options, :interval
+    attr_reader :target, :mount, :volume, :exclude, :binary, :extra_options, :interval, :mode
 
-    def initialize(raw, base: nil, workdir: nil, container: nil)
+    def initialize(raw, base: nil, workdir: nil, container: nil, compose: false)
       raise ConfigError, 'sync must be a mapping' unless raw.is_a?(Hash)
 
       @base = base
       assign_paths(raw, workdir: workdir, container: container)
       assign_mirror(raw)
+      assign_mode(raw, compose: compose)
       validate!
     end
 
     def delete? = !!@delete
+    def exec? = mode == 'exec'
 
     # Expanded against the wip.yml directory so the mirror covers the same tree
     # no matter which subdirectory wip was invoked from.
@@ -69,7 +76,7 @@ module Wip
     def to_h
       { 'source' => source, 'target' => target, 'mount' => mount, 'volume' => volume,
         'delete' => delete?, 'exclude' => exclude, 'command' => binary, 'options' => extra_options,
-        'interval' => interval }
+        'interval' => interval, 'mode' => mode }
     end
 
     private
@@ -87,6 +94,15 @@ module Wip
       @binary = presence(raw['command']) || DEFAULT_BINARY
       @extra_options = Array(raw['options']).map(&:to_s)
       @interval = raw.key?('interval') ? raw['interval'] : DEFAULT_INTERVAL
+    end
+
+    def assign_mode(raw, compose:)
+      @mode = presence(raw['mode']) || (compose ? 'run' : 'exec')
+      raise ConfigError, "sync.mode must be one of #{SYNC_MODES.join(', ')}" unless SYNC_MODES.include?(@mode)
+      return unless compose && exec?
+
+      raise ConfigError, 'sync.mode: exec needs mode: container (compose owns its services’ mounts, ' \
+                         'so it can’t guarantee the running container has the sync mounts attached)'
     end
 
     def validate!

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.7.4'
+  VERSION = '0.8.0'
 end

--- a/spec/wip/cli_spec.rb
+++ b/spec/wip/cli_spec.rb
@@ -215,9 +215,8 @@ RSpec.describe Wip::CLI do
       described_class.start(%w[up -d --no-sync])
     end
 
-    it 'runs a one-shot mirror inside the container when it is already running' do
-      runner = stub_runner('[{"Name":"app"}]')
-      allow(runner).to receive(:run).with(%w[wslc.exe list --filter name=app --format json]).and_return(0)
+    it 'runs a one-shot mirror inside the running container (sync.mode: exec, the default)' do
+      runner = stub_runner('')
       expect(runner).to receive(:run).with(
         %w[wslc.exe exec app rsync -r -l -t --whole-file --delete --exclude=.git /host-src/ /app/],
         interactive: false
@@ -226,17 +225,25 @@ RSpec.describe Wip::CLI do
       described_class.start(%w[sync])
     end
 
-    it 'falls back to a throwaway container when the app container is not running' do
-      runner = stub_runner('[]')
-      allow(runner).to receive(:run).with(%w[wslc.exe list --filter name=app --format json]).and_return(0)
+    it 'uses a throwaway container when sync.mode: run is configured' do
+      File.write('wip.yml', <<~YAML)
+        version: 1
+        defaults:
+          container: app
+          image: example:dev
+        sync:
+          exclude:
+            - .git
+          mode: run
+      YAML
+      runner = stub_runner('')
       expect(runner).to receive(:run).with(a_collection_including('--rm', 'rsync'), interactive: false).and_return(0)
 
       described_class.start(%w[sync])
     end
 
     it 'keeps mirroring on an interval with --watch until interrupted' do
-      runner = stub_runner('[{"Name":"app"}]')
-      allow(runner).to receive(:run).with(%w[wslc.exe list --filter name=app --format json]).and_return(0)
+      runner = stub_runner('')
       syncs = 0
       allow(runner).to receive(:run).with(a_collection_including('rsync'), interactive: false) do
         syncs += 1
@@ -324,6 +331,7 @@ RSpec.describe Wip::CLI do
       Dir.mktmpdir do |dir|
         File.write(File.join(dir, 'wip.yml'), <<~YAML)
           version: 1
+          mode: compose
           compose:
             service: app
             command: wslc-compose

--- a/spec/wip/command_builder_spec.rb
+++ b/spec/wip/command_builder_spec.rb
@@ -147,10 +147,6 @@ RSpec.describe Wip::CommandBuilder do
                                          /host-src/ /app/])
     end
 
-    it 'builds a running-only find query' do
-      expect(builder.find_running).to eq(%w[wslc.exe list --filter name=app --format json])
-    end
-
     it 'raises when sync commands are built without a sync block' do
       expect { described_class.new(wslc: 'wslc.exe', config: config, environment: environment).sync_run }
         .to raise_error(Wip::ConfigError, /No sync: block/)

--- a/spec/wip/compose_bridge_spec.rb
+++ b/spec/wip/compose_bridge_spec.rb
@@ -47,15 +47,15 @@ RSpec.describe Wip::ComposeBridge do
     end
 
     it 'uses the explicit compose.file override when set' do
-      config = Wip::Config.new({ 'compose' => { 'service' => 'app', 'file' => 'custom.yml',
-                                                'command' => 'my-compose-tool' } }, 'wip.yml')
+      config = Wip::Config.new({ 'mode' => 'compose', 'compose' => { 'service' => 'app', 'file' => 'custom.yml',
+                                                                     'command' => 'my-compose-tool' } }, 'wip.yml')
       expect(described_class.file_path(config)).to eq(Pathname('custom.yml').expand_path)
     end
 
     it 'resolves a relative compose.file against wip.yml, not the current directory' do
       FileUtils.mkdir_p('project/config')
-      config = Wip::Config.new({ 'compose' => { 'service' => 'app', 'file' => 'config/custom.yml',
-                                                'command' => 'my-compose-tool' } },
+      config = Wip::Config.new({ 'mode' => 'compose', 'compose' => { 'service' => 'app', 'file' => 'config/custom.yml',
+                                                                     'command' => 'my-compose-tool' } },
                                File.expand_path('project/wip.yml'))
       expected = Pathname(File.expand_path('project/config/custom.yml'))
 
@@ -64,21 +64,23 @@ RSpec.describe Wip::ComposeBridge do
 
     it 'keeps an absolute compose.file as-is' do
       absolute = File.expand_path('elsewhere/custom.yml')
-      config = Wip::Config.new({ 'compose' => { 'service' => 'app', 'file' => absolute,
-                                                'command' => 'my-compose-tool' } },
+      config = Wip::Config.new({ 'mode' => 'compose', 'compose' => { 'service' => 'app', 'file' => absolute,
+                                                                     'command' => 'my-compose-tool' } },
                                File.expand_path('project/wip.yml'))
       expect(described_class.file_path(config)).to eq(Pathname(absolute))
     end
 
     it 'auto-detects a compose file next to wip.yml' do
       File.write('compose.yaml', "services:\n  app:\n    image: example:dev\n")
-      config = Wip::Config.new({ 'compose' => { 'service' => 'app', 'command' => 'my-compose-tool' } },
+      config = Wip::Config.new({ 'mode' => 'compose',
+                                 'compose' => { 'service' => 'app', 'command' => 'my-compose-tool' } },
                                File.expand_path('wip.yml'))
       expect(described_class.file_path(config)).to eq(Pathname(File.expand_path('compose.yaml')))
     end
 
     it 'raises when no compose file can be found' do
-      config = Wip::Config.new({ 'compose' => { 'service' => 'app', 'command' => 'my-compose-tool' } },
+      config = Wip::Config.new({ 'mode' => 'compose',
+                                 'compose' => { 'service' => 'app', 'command' => 'my-compose-tool' } },
                                File.expand_path('wip.yml'))
       expect { described_class.file_path(config) }.to raise_error(Wip::ConfigError, /no compose file found/)
     end
@@ -86,7 +88,8 @@ RSpec.describe Wip::ComposeBridge do
 
   describe '.for' do
     it 'resolves the compose command and builds a bridge for the config' do
-      config = Wip::Config.new({ 'compose' => { 'service' => 'app', 'file' => 'compose.yml', 'project' => 'myapp',
+      config = Wip::Config.new({ 'mode' => 'compose',
+                                 'compose' => { 'service' => 'app', 'file' => 'compose.yml', 'project' => 'myapp',
                                                 'command' => 'wslc-compose' } }, 'wip.yml')
       resolver = instance_double(Wip::CommandResolver, resolve: 'wslc-compose')
 
@@ -97,8 +100,8 @@ RSpec.describe Wip::ComposeBridge do
     end
 
     it 'resolves whatever compose.command names, not a hardcoded implementation' do
-      config = Wip::Config.new({ 'compose' => { 'service' => 'app', 'file' => 'compose.yml',
-                                                'command' => 'my-compose-tool' } }, 'wip.yml')
+      config = Wip::Config.new({ 'mode' => 'compose', 'compose' => { 'service' => 'app', 'file' => 'compose.yml',
+                                                                     'command' => 'my-compose-tool' } }, 'wip.yml')
       resolver = instance_double(Wip::CommandResolver)
       expect(resolver).to receive(:resolve).with('my-compose-tool').and_return('my-compose-tool')
 
@@ -106,8 +109,8 @@ RSpec.describe Wip::ComposeBridge do
     end
 
     it 'reports the configured command, not a default candidate list, when nothing is found' do
-      config = Wip::Config.new({ 'compose' => { 'service' => 'app', 'file' => 'compose.yml',
-                                                'command' => 'my-compose-tool' } }, 'wip.yml')
+      config = Wip::Config.new({ 'mode' => 'compose', 'compose' => { 'service' => 'app', 'file' => 'compose.yml',
+                                                                     'command' => 'my-compose-tool' } }, 'wip.yml')
       resolver = Wip::CommandResolver.new(executable: ->(_name) { false }, candidates: [],
                                           label: 'compose command')
 

--- a/spec/wip/config_spec.rb
+++ b/spec/wip/config_spec.rb
@@ -42,12 +42,33 @@ RSpec.describe Wip::Config do
     expect(described_class.new('defaults' => { 'network' => 'app-tier' }).network).to eq('app-tier')
   end
 
+  it 'exposes mode, defaulting to container' do
+    expect(described_class.new({}).mode).to eq('container')
+    expect(described_class.new('mode' => 'compose',
+                               'compose' => { 'service' => 'app', 'command' => 'c' }).mode).to eq('compose')
+  end
+
+  it 'rejects an unknown mode' do
+    expect { described_class.new('mode' => 'nope') }.to raise_error(Wip::ConfigError, /mode must be one of/)
+  end
+
+  it 'requires a compose: block when mode: compose is set' do
+    expect { described_class.new('mode' => 'compose') }
+      .to raise_error(Wip::ConfigError, /mode: compose requires a compose: block/)
+  end
+
+  it 'requires mode: compose when a compose: block is set' do
+    expect { described_class.new('compose' => { 'service' => 'app', 'command' => 'c' }) }
+      .to raise_error(Wip::ConfigError, /a compose: block requires mode: compose/)
+  end
+
   it 'exposes compose settings, defaulting to disabled' do
     config = described_class.new({})
     expect(config.compose?).to be(false)
     expect(config.compose_service).to be_nil
 
-    composed = described_class.new('compose' => { 'service' => 'app', 'file' => 'compose.yml',
+    composed = described_class.new('mode' => 'compose',
+                                   'compose' => { 'service' => 'app', 'file' => 'compose.yml',
                                                   'project' => 'myapp', 'command' => 'my-compose-tool' })
     expect(composed.compose?).to be(true)
     expect(composed.compose_service).to eq('app')
@@ -62,26 +83,29 @@ RSpec.describe Wip::Config do
 
   it 'requires compose.service' do
     expect do
-      described_class.new('compose' => { 'file' => 'compose.yml', 'command' => 'my-compose-tool' })
+      described_class.new('mode' => 'compose',
+                          'compose' => { 'file' => 'compose.yml', 'command' => 'my-compose-tool' })
     end.to raise_error(Wip::ConfigError, /compose\.service must not be empty/)
   end
 
   it 'requires compose.command' do
     expect do
-      described_class.new('compose' => { 'service' => 'app' })
+      described_class.new('mode' => 'compose', 'compose' => { 'service' => 'app' })
     end.to raise_error(Wip::ConfigError, /compose\.command must not be empty/)
   end
 
   it 'rejects compose combined with dependencies' do
     expect do
-      described_class.new('compose' => { 'service' => 'app', 'command' => 'my-compose-tool' },
+      described_class.new('mode' => 'compose',
+                          'compose' => { 'service' => 'app', 'command' => 'my-compose-tool' },
                           'dependencies' => { 'redis' => { 'image' => 'redis:latest' } })
     end.to raise_error(Wip::ConfigError, /compose is mutually exclusive with dependencies/)
   end
 
   it 'rejects compose combined with defaults.network' do
     expect do
-      described_class.new('compose' => { 'service' => 'app', 'command' => 'my-compose-tool' },
+      described_class.new('mode' => 'compose',
+                          'compose' => { 'service' => 'app', 'command' => 'my-compose-tool' },
                           'defaults' => { 'network' => 'app-tier' })
     end.to raise_error(Wip::ConfigError, /compose is mutually exclusive with defaults\.network/)
   end
@@ -102,10 +126,19 @@ RSpec.describe Wip::Config do
     expect(config.sync.volume).to eq('web-src')
   end
 
-  it 'rejects sync combined with compose' do
+  it 'allows sync alongside compose, defaulting sync.mode to run' do
+    config = described_class.new('mode' => 'compose',
+                                 'compose' => { 'service' => 'app', 'command' => 'my-compose-tool' },
+                                 'sync' => {})
+    expect(config.sync.mode).to eq('run')
+  end
+
+  it 'rejects sync.mode: exec alongside compose' do
     expect do
-      described_class.new('compose' => { 'service' => 'app', 'command' => 'my-compose-tool' }, 'sync' => {})
-    end.to raise_error(Wip::ConfigError, /sync is mutually exclusive with compose/)
+      described_class.new('mode' => 'compose',
+                          'compose' => { 'service' => 'app', 'command' => 'my-compose-tool' },
+                          'sync' => { 'mode' => 'exec' })
+    end.to raise_error(Wip::ConfigError, /sync\.mode: exec needs mode: container/)
   end
 
   it 'includes the resolved sync settings in the effective configuration' do

--- a/spec/wip/sync_settings_spec.rb
+++ b/spec/wip/sync_settings_spec.rb
@@ -51,4 +51,19 @@ RSpec.describe Wip::SyncSettings do
     expect { described_class.new({ 'interval' => 0 }) }.to raise_error(Wip::ConfigError, /positive number/)
     expect { described_class.new('nope') }.to raise_error(Wip::ConfigError, /must be a mapping/)
   end
+
+  it 'defaults mode to exec outside compose, and to run under compose' do
+    expect(described_class.new({}).mode).to eq('exec')
+    expect(described_class.new({}, compose: true).mode).to eq('run')
+  end
+
+  it 'lets sync.mode override the default explicitly' do
+    expect(described_class.new({ 'mode' => 'run' }).mode).to eq('run')
+  end
+
+  it 'rejects an unknown sync.mode and exec under compose' do
+    expect { described_class.new({ 'mode' => 'nope' }) }.to raise_error(Wip::ConfigError, /sync.mode must be one of/)
+    expect { described_class.new({ 'mode' => 'exec' }, compose: true) }
+      .to raise_error(Wip::ConfigError, /sync.mode: exec needs mode: container/)
+  end
 end


### PR DESCRIPTION
## Summary
- Add a top-level `mode: container|compose` (default: `container`) that explicitly picks the orchestration path `up`/`down`/`sync`/etc. take, replacing the old implicit derivation from whether a `compose:` block was present. `mode: compose` requires a `compose:` block and vice versa (both now config errors instead of silent inference).
- Add `sync.mode: exec|run`: `exec` mirrors inside the already-running container (default under `mode: container`), `run` always uses a throwaway mirror container (default, and only option, under `mode: compose`). This replaces the old runtime probe (`container_running?`/`find_running`) that picked `sync_exec` vs `sync_run` by checking whether a same-named container happened to be running — a check that was one container-name collision away from silently mirroring into the wrong place, since `app` is both wip's default container name and a common compose service name.
- Lifts the old `sync:`/`compose:` mutual exclusion: a compose service can mount the same named volume `sync.volume` points at, and wip mirrors into it via its own throwaway container (`wslc run --rm`) without touching compose.yml or needing the compose service's exact container name.
- Bump version to v0.8.0 (breaking config schema change: a `compose:` block now requires `mode: compose`).

## Test plan
- [x] `bundle exec rspec` (129 examples, 0 failures)
- [x] `bundle exec rubocop` (no offenses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 実行方式として `container` / `compose` を選択できるようになりました。
  * 同期方式に `exec` / `run` を追加しました。実行中コンテナ内での同期、または一時コンテナを使った同期を選択できます。
  * Compose モードでも同期設定を利用できるようになりました。

* **改善**
  * Compose では `run` が既定となり、`exec` 指定時は設定エラーを表示します。
  * 設定値の検証を強化しました。

* **ドキュメント**
  * 新しいモードの設定例と動作説明をREADMEに追加しました。

* **リリース**
  * バージョンを0.8.0に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->