### PR TITLE
feat(init): show sync/compose volume guidance in the compose starter

### DIFF
--- a/lib/wip/initializer.rb
+++ b/lib/wip/initializer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'yaml'
+
 module Wip
   # Builds a starter wip.yml. Detects an existing compose file next to the
   # target (the same filenames ComposeBridge auto-detects) to decide between
@@ -42,7 +44,46 @@ module Wip
         compose:
           service: app # TODO: which service in #{compose_file} wip run/exec/NAME target
           command: wslc-compose # TODO: the compose-for-wslc binary/path you have installed
+
+        #{sync_hint}
       YAML
+    end
+
+    # sync: needs sync.image (mode: compose has no dependencies: entry to borrow one from) and a
+    # named volume the compose service mounts, matching sync.volume ("app-src" by default). Checked
+    # against the detected compose file so the hint doesn't repeat what's already set up.
+    def sync_hint
+      return sync_hint_configured if compose_volume_mounted?
+
+      sync_hint_todo
+    end
+
+    def sync_hint_configured
+      <<~COMMENT.chomp
+        # #{compose_file} already mounts a volume matching sync.volume's default (app-src).
+        # sync: # add sync.image too (required under mode: compose) — see README
+      COMMENT
+    end
+
+    def sync_hint_todo
+      <<~COMMENT.chomp
+        # sync: # optional; mirrors the source into a named volume instead of bind-mounting it live
+        #   image: your/image:tag # required under mode: compose (no dependencies: entry to borrow one from)
+        #   # the service above must also mount a volume named "app-src" (sync.volume's default) at the
+        #   # path your app expects — add to #{compose_file}:
+        #   #   volumes:
+        #   #     - app-src:/app
+        #   # and, alongside services:
+        #   # volumes:
+        #   #   app-src:
+      COMMENT
+    end
+
+    def compose_volume_mounted?
+      services = YAML.safe_load_file(File.join(@dir, compose_file), aliases: true)&.fetch('services', nil) || {}
+      services.values.any? { |service| Array(service['volumes']).any? { |v| v.to_s.start_with?('app-src:') } }
+    rescue StandardError
+      false
     end
   end
 end

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.10.0'
+  VERSION = '0.11.0'
 end

--- a/spec/wip/initializer_spec.rb
+++ b/spec/wip/initializer_spec.rb
@@ -24,10 +24,30 @@ RSpec.describe Wip::Initializer do
         initializer = described_class.new(dir: dir)
 
         expect(initializer.compose?).to be(true)
-        parsed = YAML.safe_load(initializer.call)
+        output = initializer.call
+        parsed = YAML.safe_load(output)
         expect(parsed).to include('version' => 1, 'mode' => 'compose')
         expect(parsed['compose']).to include('service', 'command')
+        expect(output).to include('required under mode: compose').and include('app-src')
       end
+    end
+  end
+
+  it 'points at README when the compose file already mounts a volume matching sync.volume' do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, 'compose.yml'), <<~YAML)
+        services:
+          app:
+            image: example:dev
+            volumes:
+              - app-src:/app
+        volumes:
+          app-src:
+      YAML
+      output = described_class.new(dir: dir).call
+
+      expect(output).to include('already mounts a volume matching').and include('see README')
+      expect(output).not_to include('path your app expects')
     end
   end
 end


### PR DESCRIPTION
## Summary
- `mode: compose` needs `sync.image` (no `dependencies:` entry to borrow one from) and a compose service that mounts a volume matching `sync.volume` (`app-src` by default) — easy to miss since `sync:` isn't in the compose starter at all today.
- `wip init` now checks the detected compose file for an existing `app-src` volume mount and adds a commented `sync:` hint to the generated `wip.yml`: a short pointer to the README if it's already set up, or the full snippet (the `sync.image` requirement plus the `compose.yml` volume block to add) if not.
- This is diagnosis + guidance only (as decided) — `wip init` never edits the user's existing `compose.yml`.
- Bump version to v0.11.0 (additive, no breaking changes).

## Test plan
- [x] `bundle exec rspec` (149 examples, 0 failures)
- [x] `bundle exec rubocop` (no offenses)
- [x] Manually ran `wip init` against a compose.yml with no matching volume (shows the full TODO snippet) and one that already mounts `app-src` (shows the short pointer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Compose 構成を検出し、ボリューム設定に応じた `sync` の設定案内を表示するようになりました。
  * 対応する `app-src` ボリュームがある場合は、README に沿った設定方法を案内します。
  * 必要な設定が見つからない場合は、追加すべき設定を示す案内を表示します。

* **改善**
  * Compose ファイルを読み込めない場合でも、必要な設定を確認しやすくなりました。
  * バージョンを 0.11.0 に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->