### PR TITLE
feat(sync): add sync.build to let wip build its own mirror image

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ mode: container # default. This example is container mode end-to-end — see "Co
                 # compose: block instead; the two don't mix within one wip.yml.
 wslc:
   command: auto # tries wslc.exe, wslc, then System32; an absolute path also works
-container: app # optional; which dependencies: entry `up`/`exec`/`run`/`build`/`commands:` target (default: app)
+container: app # required once dependencies: has entries; which one `up`/`exec`/`run`/`build`/`commands:`
+               # target. No default — a project must say which entry is the primary one explicitly.
 network: app-tier # optional; shared by every dependencies: entry so containers can resolve each other by name
 dependencies:
   app: # container: points here — the one container wip execs into and runs commands in
@@ -129,10 +130,11 @@ directly with no copying.
 
 ### Dependency containers
 
-`dependencies:` holds every container uniformly — the primary one `container:` points at (`app`
-by default) and any sidecar services (a database, Redis, ...) alongside it. Each entry accepts
-`image` (required), `command`, `env`, `ports`, `volumes`, and `workdir`; there's no separate,
-differently-shaped block for "the one you exec into."
+`dependencies:` holds every container uniformly — the primary one `container:` points at and any
+sidecar services (a database, Redis, ...) alongside it. Each entry accepts `image` (required),
+`command`, `env`, `ports`, `volumes`, and `workdir`; there's no separate, differently-shaped block
+for "the one you exec into." `container:` has no default; once `dependencies:` has any entries,
+wip needs to be told explicitly which one is primary rather than guessing a name.
 
 What sets the primary entry apart is operational, not structural: `wip up` brings up every other
 entry by name first (creating `network:` beforehand if it doesn't exist and set), then boots or
@@ -302,7 +304,7 @@ found, its version, and which compose file `wip` resolved.
 | `wip doctor` | Diagnose WSL2, interop, WSLC, config, architecture, and Git |
 | `wip config` | Print the effective configuration (secrets masked) |
 | `wip build -- --no-cache` | Build the image from the `build` definition |
-| `wip up [-d] [--no-sync]` | Start the primary `dependencies:` entry (`container:`, default `app`) and its sidecars (creating any that are missing, on `network:` if set). `-d` runs the main container in the background; with `sync:` configured, the source is mirrored into the volume first unless `--no-sync` |
+| `wip up [-d] [--no-sync]` | Start the primary `dependencies:` entry (`container:` names which one) and its sidecars (creating any that are missing, on `network:` if set). `-d` runs the main container in the background; with `sync:` configured, the source is mirrored into the volume first unless `--no-sync` |
 | `wip down` | Stop and remove the primary container and its sidecar `dependencies:` |
 | `wip exec [--no-interactive] COMMAND...` | Run a command in the existing container |
 | `wip run [--no-interactive] COMMAND...` | Run a command in a new `--rm` container (compose mode: `exec`s into `compose.service` instead) |

--- a/README.md
+++ b/README.md
@@ -167,9 +167,16 @@ sync:
   interval: 2        # seconds between syncs for `wip sync --watch` (default: 2)
   mode: exec         # exec (mirror inside the running container) or run (a throwaway one);
                       # default: exec for `mode: container`, run for `mode: compose`
-  image: null        # image for the mirror container; required under mode: compose (there's no
-                      # dependencies: entry to borrow one from there), unused under mode: container
-                      # unless set (falls back to the primary container's own image)
+  image: null        # image for the mirror container; unused under mode: container unless set
+                      # (falls back to the primary container's own image). Under mode: compose,
+                      # one of image or build is required (there's no dependencies: entry to fall
+                      # back to)
+  build:              # optional; has wip build the mirror image itself instead of requiring one to
+                       # already exist. build.tag wins over image if both are set.
+    dockerfile: |
+      FROM alpine:latest
+      RUN apk add --no-cache rsync
+    tag: null          # optional (default: "wip-sync-<container>:latest")
 ```
 
 Everything below `sync:` is optional — `sync: {}` alone already works. With it in place:
@@ -187,6 +194,8 @@ Everything below `sync:` is optional — `sync: {}` alone already works. With it
 - `wip sync --watch [--interval N]` keeps re-syncing until Ctrl-C, so host edits reach the
   container with a short delay. Run it in a second terminal alongside `wip up -d`.
 - `wip doctor` reports the resolved source, volume, and target, and fails if the source is missing.
+- With `sync.build` configured, `wip build`s that image once per `wip up`/`wip sync` invocation
+  (including once before a `--watch` loop starts, not on every tick) before mirroring with it.
 
 Like every built-in command, `wip sync` takes precedence over a `commands:` entry of the same
 name; wip says so and points at `wip dispatch sync`, which still runs yours.
@@ -215,13 +224,32 @@ or set `delete: false`.
   the compose service directly.
 - `sync.mode` defaults to `run` and can't be set to `exec` (only a container wip itself booted is
   guaranteed to have the read-only source mount attached, which compose services never do), and
-  `sync.image` becomes required, since that disposable container needs an image from somewhere —
-  under `mode: container` it borrows the primary `dependencies:` entry's image, but compose mode
-  has no such entry to borrow from.
+  `sync.image` or `sync.build` becomes required, since that disposable container needs an image
+  from somewhere — under `mode: container` it borrows the primary `dependencies:` entry's image,
+  but compose mode has no such entry to borrow from.
 
 `wip up`'s pre-boot mirror (and the `--no-sync` flag that skips it) works the same way under
 `mode: compose` as it does otherwise: the source is mirrored into the volume before
 `compose up` starts the service that mounts it.
+
+Since `sync.mode: run` boots a fresh container on every mirror, reusing your app's full image here
+just adds startup overhead for something that only ever runs `rsync`. A dedicated, minimal image is
+worth it — `wip` doesn't publish or default to one itself (same reasoning as `compose.command`:
+picking a specific third-party image for you isn't its call to make), but `sync.build` covers it
+without needing to manage a separate image yourself:
+
+```yaml
+sync:
+  build:
+    dockerfile: |
+      FROM alpine:latest
+      RUN apk add --no-cache rsync
+```
+
+wip builds this once per `wip up`/`wip sync` invocation (not on every `--watch` tick — see above)
+and uses the result, tagged `wip-sync-<container>:latest` by default (`build.tag` overrides it).
+Prefer managing the image yourself instead? Build and tag it however you like, then set `sync.image`
+to that tag directly — `sync.build`'s tag wins if both are set, so don't configure both at once.
 
 ### Compose mode
 

--- a/lib/wip/cli.rb
+++ b/lib/wip/cli.rb
@@ -5,6 +5,7 @@ require 'yaml'
 require 'json'
 require 'stringio'
 require 'shellwords'
+require 'tmpdir'
 
 module Wip
   # Thor-based command-line interface for wip.
@@ -93,6 +94,7 @@ module Wip
     def sync
       settings = sync_settings!
       warn_shadowed_command('sync')
+      ensure_sync_image(settings)
       return run_sync unless options[:watch]
 
       interval = watch_interval(settings)
@@ -270,6 +272,18 @@ module Wip
       load_config.sync || raise(ConfigError, '`wip sync` needs a sync: block in wip.yml')
     end
 
+    # Builds sync.build's image once per invocation (not per --watch tick, which
+    # would pay Docker build-cache-lookup overhead on every mirror for no reason).
+    # A no-op unless sync.build is configured.
+    def ensure_sync_image(settings)
+      return unless settings.build
+
+      Dir.mktmpdir('wip-sync-build-') do |dir|
+        File.write(File.join(dir, 'Dockerfile'), settings.build['dockerfile'])
+        execute(builder.sync_build(dir))
+      end
+    end
+
     # `sync.interval` is validated when the config loads; --interval isn't, and
     # a negative one would only surface as an ArgumentError from `sleep`.
     def watch_interval(settings)
@@ -300,6 +314,7 @@ module Wip
       settings = load_config.sync
       return unless settings
 
+      ensure_sync_image(settings)
       warn "wip: syncing #{settings.source} -> #{settings.volume}:#{settings.target}"
       execute(builder.sync_run)
       warn "wip: run `wip sync --watch` in another terminal to keep #{settings.target} up to date"

--- a/lib/wip/command_builder.rb
+++ b/lib/wip/command_builder.rb
@@ -16,7 +16,7 @@ module Wip
       # dependencies: entries don't carry their own name (it's the hash key), so the
       # exec target defaults to @config.container; a commands: entry can still
       # redirect it by setting its own `container:`.
-      values = primary_values.merge('container' => @config.container).merge(settings)
+      values = primary_values.merge('container' => required_container).merge(settings)
       command = [@wslc, 'exec']
       command << '-it' if tty?(interactive)
       command.concat(options(values, include_container: true, include_publish: false)).concat(arguments)
@@ -32,7 +32,7 @@ module Wip
 
     def up(detach: false)
       values = primary_values
-      command = [@wslc, 'run', '--name', @config.container]
+      command = [@wslc, 'run', '--name', required_container]
       command.push('--network', @config.network) if @config.network
       command << '-d' if detach
       command << '-it' if !detach && tty?(true)
@@ -42,13 +42,13 @@ module Wip
     end
 
     def start(detach: false)
-      command = [@wslc, 'start', @config.container]
+      command = [@wslc, 'start', required_container]
       command.push('-a', '-i') unless detach
       command
     end
 
     def find
-      [@wslc, 'list', '--all', '--filter', "name=#{@config.container}", '--format', 'json']
+      [@wslc, 'list', '--all', '--filter', "name=#{required_container}", '--format', 'json']
     end
 
     # Mirrors into the volume from a throwaway container. Used for sync.mode:
@@ -81,15 +81,15 @@ module Wip
     # itself booted is guaranteed to have both the read-only source mount and
     # the volume attached.
     def sync_exec
-      [@wslc, 'exec', @config.container, *required_sync.mirror_command]
+      [@wslc, 'exec', required_container, *required_sync.mirror_command]
     end
 
     def down
-      [@wslc, 'stop', @config.container]
+      [@wslc, 'stop', required_container]
     end
 
     def remove
-      [@wslc, 'remove', '-f', @config.container]
+      [@wslc, 'remove', '-f', required_container]
     end
 
     def network_create
@@ -196,9 +196,17 @@ module Wip
       @config.dependency(name) || raise(ConfigError, "Unknown dependency: #{name}")
     end
 
+    def required_container
+      container = @config.container
+      raise ConfigError, 'container: must be set in wip.yml' if container.to_s.empty?
+
+      container
+    end
+
     def primary_values
-      @config.primary || raise(ConfigError, "No dependencies.#{@config.container} entry " \
-                                            '(set container: to name a different one)')
+      container = required_container
+      @config.dependency(container) || raise(ConfigError, "No dependencies.#{container} entry " \
+                                                          '(check container: in wip.yml)')
     end
   end
 end

--- a/lib/wip/command_builder.rb
+++ b/lib/wip/command_builder.rb
@@ -53,14 +53,27 @@ module Wip
 
     # Mirrors into the volume from a throwaway container. Used for sync.mode:
     # run (compose's default, and mode: container's fallback for when the app
-    # container isn't running yet — e.g. just before `up` boots it). sync.image
-    # overrides the mirror container's image; compose mode requires it, since
-    # there's no dependencies: entry to fall back to (compose owns those).
+    # container isn't running yet — e.g. just before `up` boots it). The image
+    # comes from sync.build's tag (once built via sync_build), else sync.image,
+    # else the primary dependencies: entry; compose mode requires one of the
+    # first two, since it has no dependencies: entry to fall back to.
     def sync_run
       sync = required_sync
       command = [@wslc, 'run', '--rm']
       sync.volume_specs.each { |spec| command.push('-v', spec) }
-      command.push(sync.image || required(primary_values, 'image')).concat(sync.mirror_command)
+      image = sync.build&.fetch('tag') || sync.image || required(primary_values, 'image')
+      command.push(image).concat(sync.mirror_command)
+    end
+
+    # Builds sync.build's image from a Dockerfile staged in `context` (a caller-
+    # managed directory, since the build only reads it once `wslc build` runs).
+    # Doesn't touch dependencies: at all, so it works the same under compose
+    # mode as it does under container mode.
+    def sync_build(context)
+      sync = required_sync
+      raise ConfigError, 'No sync.build configured in wip.yml' unless sync.build
+
+      [@wslc, 'build', '-t', sync.build['tag'], context]
     end
 
     # Mirrors from inside the already-running container. Only valid for

--- a/lib/wip/config.rb
+++ b/lib/wip/config.rb
@@ -25,8 +25,11 @@ module Wip
     def dependencies = @raw['dependencies'] || {}
     # Which dependencies: entry `up`/`down`/`exec`/`run`/`build`/`commands:` target
     # by default — the one container wip itself considers "the app." Everything
-    # else in dependencies: is a sidecar wip only starts and stops.
-    def container = presence(@raw['container']) || 'app'
+    # else in dependencies: is a sidecar wip only starts and stops. No default:
+    # guessing a name here (the old default was "app") either matches by luck or
+    # fails in a way that doesn't point at the real problem (a differently-named
+    # entry), so a project with any dependencies: must say which one explicitly.
+    def container = presence(@raw['container'])
     def network = @raw['network']
     def mode = @raw['mode'] || 'container'
     def compose = @raw['compose']
@@ -107,6 +110,13 @@ module Wip
 
     def validate_dependencies!
       raise ConfigError, 'dependencies must be a mapping' unless dependencies.is_a?(Hash)
+      # Under compose mode, populated dependencies: is already an error on its own
+      # (validate_compose!, below) — this only needs to fire for the mode: container
+      # case, where dependencies: having entries but no container: is otherwise valid.
+      if dependencies.any? && !container && !compose?
+        raise ConfigError,
+              'container: must be set when dependencies: has entries'
+      end
 
       dependencies.each { |name, entry| validate_dependency!(name, entry) }
     end

--- a/lib/wip/initializer.rb
+++ b/lib/wip/initializer.rb
@@ -11,9 +11,10 @@ module Wip
     CONTAINER_TEMPLATE = <<~YAML
       version: 1
       mode: container
+      container: app # TODO: rename freely, as long as it matches a key under dependencies: below
 
       dependencies:
-        app: # TODO: this is the container wip creates, execs into, and runs commands in
+        app: # this is the container wip creates, execs into, and runs commands in
           image: your/image:tag # TODO: image to run
           workdir: /app # TODO: adjust to match your image, or delete this line
 
@@ -40,6 +41,8 @@ module Wip
       <<~YAML
         version: 1
         mode: compose
+        container: app # TODO: rename freely; only used to name sync's volume ("<container>-src"),
+                        # since compose.yml — not dependencies: — owns this service's own definition
 
         compose:
           service: app # TODO: which service in #{compose_file} wip run/exec/NAME target

--- a/lib/wip/initializer.rb
+++ b/lib/wip/initializer.rb
@@ -49,9 +49,9 @@ module Wip
       YAML
     end
 
-    # sync: needs sync.image (mode: compose has no dependencies: entry to borrow one from) and a
-    # named volume the compose service mounts, matching sync.volume ("app-src" by default). Checked
-    # against the detected compose file so the hint doesn't repeat what's already set up.
+    # sync: needs sync.image or sync.build (mode: compose has no dependencies: entry to borrow an
+    # image from) and a named volume the compose service mounts, matching sync.volume ("app-src" by
+    # default). Checked against the detected compose file so the hint doesn't repeat what's set up.
     def sync_hint
       return sync_hint_configured if compose_volume_mounted?
 
@@ -61,14 +61,17 @@ module Wip
     def sync_hint_configured
       <<~COMMENT.chomp
         # #{compose_file} already mounts a volume matching sync.volume's default (app-src).
-        # sync: # add sync.image too (required under mode: compose) — see README
+        # sync: # add sync.build or sync.image too (one's required under mode: compose) — see README
       COMMENT
     end
 
     def sync_hint_todo
       <<~COMMENT.chomp
         # sync: # optional; mirrors the source into a named volume instead of bind-mounting it live
-        #   image: your/image:tag # required under mode: compose (no dependencies: entry to borrow one from)
+        #   build: # required under mode: compose (no dependencies: entry to borrow an image from)
+        #     dockerfile: |
+        #       FROM alpine:latest
+        #       RUN apk add --no-cache rsync
         #   # the service above must also mount a volume named "app-src" (sync.volume's default) at the
         #   # path your app expects — add to #{compose_file}:
         #   #   volumes:

--- a/lib/wip/sync_settings.rb
+++ b/lib/wip/sync_settings.rb
@@ -32,7 +32,7 @@ module Wip
     # compose owns its own services' mounts and never guarantees that shape.
     SYNC_MODES = %w[exec run].freeze
 
-    attr_reader :target, :mount, :volume, :exclude, :binary, :extra_options, :interval, :mode, :image
+    attr_reader :target, :mount, :volume, :exclude, :binary, :extra_options, :interval, :mode, :image, :build
 
     def initialize(raw, base: nil, workdir: nil, container: nil, compose: false)
       raise ConfigError, 'sync must be a mapping' unless raw.is_a?(Hash)
@@ -40,6 +40,7 @@ module Wip
       @base = base
       assign_paths(raw, workdir: workdir, container: container)
       assign_mirror(raw)
+      assign_build(raw)
       assign_mode(raw, compose: compose)
       validate!
     end
@@ -76,7 +77,7 @@ module Wip
     def to_h
       { 'source' => source, 'target' => target, 'mount' => mount, 'volume' => volume,
         'delete' => delete?, 'exclude' => exclude, 'command' => binary, 'options' => extra_options,
-        'interval' => interval, 'mode' => mode, 'image' => image }
+        'interval' => interval, 'mode' => mode, 'image' => image, 'build' => build }
     end
 
     private
@@ -85,7 +86,8 @@ module Wip
       @raw_source = presence(raw['source']) || '.'
       @target = presence(raw['target']) || presence(workdir) || DEFAULT_TARGET
       @mount = presence(raw['mount']) || DEFAULT_MOUNT
-      @volume = presence(raw['volume']) || "#{presence(container) || 'wip'}-src"
+      @container_name = presence(container) || 'wip'
+      @volume = presence(raw['volume']) || "#{@container_name}-src"
     end
 
     def assign_mirror(raw)
@@ -96,12 +98,29 @@ module Wip
       @interval = raw.key?('interval') ? raw['interval'] : DEFAULT_INTERVAL
     end
 
+    # sync.build lets wip build a small, dedicated mirror image itself (e.g. alpine
+    # + rsync) instead of requiring one to already exist — handy since sync.mode:
+    # run boots a fresh container per mirror and reusing the app's full image just
+    # adds startup overhead for something that only ever runs rsync.
+    def assign_build(raw)
+      build = raw['build']
+      @build = nil
+      return unless build
+
+      raise ConfigError, 'sync.build must be a mapping' unless build.is_a?(Hash)
+
+      dockerfile = presence(build['dockerfile'])
+      raise ConfigError, 'sync.build.dockerfile must not be empty' unless dockerfile
+
+      @build = { 'dockerfile' => dockerfile, 'tag' => presence(build['tag']) || "wip-sync-#{@container_name}:latest" }
+    end
+
     def assign_mode(raw, compose:)
       @mode = presence(raw['mode']) || (compose ? 'run' : 'exec')
       @image = presence(raw['image'])
       raise ConfigError, "sync.mode must be one of #{SYNC_MODES.join(', ')}" unless SYNC_MODES.include?(@mode)
 
-      validate_image!(compose)
+      validate_image_source!(compose)
       return unless compose && exec?
 
       raise ConfigError, 'sync.mode: exec needs mode: container (compose owns its services’ mounts, ' \
@@ -109,12 +128,13 @@ module Wip
     end
 
     # compose mode has no dependencies: entry to fall back to for the mirror
-    # container's image, so sync.image can't be left implicit there.
-    def validate_image!(compose)
-      return if !compose || @image
+    # container's image, so it can't be left implicit there — sync.image or
+    # sync.build must name one explicitly.
+    def validate_image_source!(compose)
+      return if !compose || @image || @build
 
-      raise ConfigError, 'sync.image is required under mode: compose (there’s no dependencies: entry ' \
-                         'to borrow the mirror container’s image from)'
+      raise ConfigError, 'sync.image or sync.build is required under mode: compose (there’s no ' \
+                         'dependencies: entry to borrow the mirror container’s image from)'
     end
 
     def validate!

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.11.0'
+  VERSION = '0.12.0'
 end

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.12.0'
+  VERSION = '0.13.0'
 end

--- a/spec/wip/cli_spec.rb
+++ b/spec/wip/cli_spec.rb
@@ -245,6 +245,59 @@ RSpec.describe Wip::CLI do
       described_class.start(%w[sync])
     end
 
+    it 'builds the sync.build image once before mirroring, using it over the primary dependency' do
+      File.write('wip.yml', <<~YAML)
+        version: 1
+        dependencies:
+          app:
+            image: example:dev
+        sync:
+          mode: run
+          build:
+            dockerfile: |
+              FROM alpine:latest
+              RUN apk add --no-cache rsync
+      YAML
+      runner = stub_runner('')
+      expect(runner).to receive(:run).with(a_collection_including('build', '-t', 'wip-sync-app:latest'),
+                                           interactive: false).and_return(0).ordered
+      expect(runner).to receive(:run).with(a_collection_including('--rm', 'wip-sync-app:latest', 'rsync'),
+                                           interactive: false).and_return(0).ordered
+
+      described_class.start(%w[sync])
+    end
+
+    it 'builds sync.build once per --watch run, not on every tick' do
+      File.write('wip.yml', <<~YAML)
+        version: 1
+        dependencies:
+          app:
+            image: example:dev
+        sync:
+          mode: run
+          build:
+            dockerfile: FROM alpine:latest
+      YAML
+      runner = stub_runner('')
+      builds = 0
+      allow(runner).to receive(:run).with(a_collection_including('build'), interactive: false) do
+        builds += 1
+        0
+      end
+      syncs = 0
+      allow(runner).to receive(:run).with(a_collection_including('--rm', 'rsync'), interactive: false) do
+        syncs += 1
+        raise Interrupt if syncs == 2
+
+        0
+      end
+
+      described_class.start(%w[sync --watch --interval 0.01])
+
+      expect(builds).to eq(1)
+      expect(syncs).to eq(2)
+    end
+
     it 'keeps mirroring on an interval with --watch until interrupted' do
       runner = stub_runner('')
       syncs = 0

--- a/spec/wip/cli_spec.rb
+++ b/spec/wip/cli_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Wip::CLI do
     Dir.mktmpdir do |dir|
       File.write(File.join(dir, 'wip.yml'), <<~YAML)
         version: 1
+        container: app
         dependencies:
           app:
             image: example:dev
@@ -90,6 +91,7 @@ RSpec.describe Wip::CLI do
   it 'creates the network and dependencies before bringing up the main container' do
     File.write('wip.yml', <<~YAML)
       version: 1
+      container: app
       network: app-tier
       dependencies:
         app:
@@ -140,6 +142,7 @@ RSpec.describe Wip::CLI do
   it 'auto-loads .env next to wip.yml and injects it as container env, without overriding wip.yml env' do
     File.write('wip.yml', <<~YAML)
       version: 1
+      container: app
       dependencies:
         app:
           image: example:dev
@@ -170,6 +173,7 @@ RSpec.describe Wip::CLI do
     before do
       File.write('wip.yml', <<~YAML)
         version: 1
+        container: app
         dependencies:
           app:
             image: example:dev
@@ -231,6 +235,7 @@ RSpec.describe Wip::CLI do
     it 'uses a throwaway container when sync.mode: run is configured' do
       File.write('wip.yml', <<~YAML)
         version: 1
+        container: app
         dependencies:
           app:
             image: example:dev
@@ -248,6 +253,7 @@ RSpec.describe Wip::CLI do
     it 'builds the sync.build image once before mirroring, using it over the primary dependency' do
       File.write('wip.yml', <<~YAML)
         version: 1
+        container: app
         dependencies:
           app:
             image: example:dev
@@ -270,6 +276,7 @@ RSpec.describe Wip::CLI do
     it 'builds sync.build once per --watch run, not on every tick' do
       File.write('wip.yml', <<~YAML)
         version: 1
+        container: app
         dependencies:
           app:
             image: example:dev
@@ -314,7 +321,7 @@ RSpec.describe Wip::CLI do
     end
 
     it 'requires a sync block' do
-      File.write('wip.yml', "version: 1\ndependencies:\n  app:\n    image: example:dev\n")
+      File.write('wip.yml', "version: 1\ncontainer: app\ndependencies:\n  app:\n    image: example:dev\n")
 
       expect { described_class.start(%w[sync]) }.to raise_error(Wip::ConfigError, /needs a sync: block/)
     end
@@ -329,6 +336,7 @@ RSpec.describe Wip::CLI do
     it 'points at `wip dispatch` when wip.yml defines a command the built-in shadows' do
       File.write('wip.yml', <<~YAML)
         version: 1
+        container: app
         dependencies:
           app:
             image: example:dev
@@ -352,6 +360,7 @@ RSpec.describe Wip::CLI do
     File.write('Dockerfile', "FROM scratch\n")
     File.write('wip.yml', <<~YAML)
       version: 1
+      container: app
       dependencies:
         app:
           image: example:dev
@@ -419,6 +428,7 @@ RSpec.describe Wip::CLI do
       File.write('wip.yml', <<~YAML)
         version: 1
         mode: compose
+        container: app
         compose:
           service: app
           command: wslc-compose
@@ -498,6 +508,7 @@ RSpec.describe Wip::CLI do
     it 'rejects `wip logs` outside compose mode' do
       File.write('wip.yml', <<~YAML)
         version: 1
+        container: app
         dependencies:
           app:
             image: example:dev

--- a/spec/wip/command_builder_spec.rb
+++ b/spec/wip/command_builder_spec.rb
@@ -166,6 +166,28 @@ RSpec.describe Wip::CommandBuilder do
       expect { described_class.new(wslc: 'wslc.exe', config: config, environment: environment).sync_run }
         .to raise_error(Wip::ConfigError, /No sync: block/)
     end
+
+    it 'uses the sync.build tag over sync.image and the primary dependency, without needing one to exist' do
+      built_config = Wip::Config.new('mode' => 'compose',
+                                     'compose' => { 'service' => 'app', 'command' => 'my-compose-tool' },
+                                     'sync' => { 'build' => { 'dockerfile' => 'FROM alpine' } })
+      builder = described_class.new(wslc: 'wslc.exe', config: built_config, environment: environment)
+
+      expect(builder.sync_run).to eq(['wslc.exe', 'run', '--rm', '-v', '.:/host-src:ro', '-v', 'app-src:/app',
+                                      'wip-sync-app:latest', 'rsync', '-r', '-l', '-t', '--whole-file', '--delete',
+                                      '/host-src/', '/app/'])
+    end
+
+    it 'builds the sync.build Dockerfile from a caller-supplied context' do
+      built_config = Wip::Config.new('sync' => { 'build' => { 'dockerfile' => 'FROM alpine', 'tag' => 'x:1' } })
+      builder = described_class.new(wslc: 'wslc.exe', config: built_config, environment: environment)
+
+      expect(builder.sync_build('/tmp/staged')).to eq(%w[wslc.exe build -t x:1 /tmp/staged])
+    end
+
+    it 'raises when building without a sync.build block' do
+      expect { builder.sync_build('/tmp/staged') }.to raise_error(Wip::ConfigError, /No sync\.build configured/)
+    end
   end
 
   describe 'dotenv support' do

--- a/spec/wip/command_builder_spec.rb
+++ b/spec/wip/command_builder_spec.rb
@@ -4,7 +4,8 @@ require 'spec_helper'
 RSpec.describe Wip::CommandBuilder do
   let(:environment) { instance_double(Wip::Environment, interactive?: true) }
   let(:config) do
-    Wip::Config.new('dependencies' => { 'app' => { 'image' => 'example:dev', 'workdir' => '/app' } },
+    Wip::Config.new('container' => 'app',
+                    'dependencies' => { 'app' => { 'image' => 'example:dev', 'workdir' => '/app' } },
                     'commands' => { 'rails' => { 'command' => 'bin/rails', 'interactive' => true },
                                     'build' => { 'type' => 'build', 'tag' => 'example:dev', 'context' => '.' } })
   end
@@ -70,7 +71,8 @@ RSpec.describe Wip::CommandBuilder do
   end
 
   it 'appends the primary dependency command so the container stays running' do
-    with_command = Wip::Config.new('dependencies' => { 'app' => { 'image' => 'example:dev', 'workdir' => '/app',
+    with_command = Wip::Config.new('container' => 'app',
+                                   'dependencies' => { 'app' => { 'image' => 'example:dev', 'workdir' => '/app',
                                                                   'command' => 'local' } })
     builder = described_class.new(wslc: 'wslc.exe', config: with_command, environment: environment)
 
@@ -87,7 +89,7 @@ RSpec.describe Wip::CommandBuilder do
 
   describe 'network and dependency support' do
     let(:networked_config) do
-      Wip::Config.new('network' => 'app-tier',
+      Wip::Config.new('container' => 'app', 'network' => 'app-tier',
                       'dependencies' => { 'app' => { 'image' => 'example:dev', 'workdir' => '/app' },
                                           'redis' => { 'image' => 'redis:latest' },
                                           'development.mysql' => {
@@ -133,7 +135,8 @@ RSpec.describe Wip::CommandBuilder do
 
   describe 'sync support' do
     let(:synced_config) do
-      Wip::Config.new('dependencies' => { 'app' => { 'image' => 'example:dev', 'workdir' => '/app',
+      Wip::Config.new('container' => 'app',
+                      'dependencies' => { 'app' => { 'image' => 'example:dev', 'workdir' => '/app',
                                                      'volumes' => ['.:/app', 'bundle:/usr/local/bundle'] },
                                           'redis' => { 'image' => 'redis:latest', 'volumes' => ['.:/app'] } },
                       'sync' => { 'exclude' => ['.git'] })
@@ -168,7 +171,7 @@ RSpec.describe Wip::CommandBuilder do
     end
 
     it 'uses the sync.build tag over sync.image and the primary dependency, without needing one to exist' do
-      built_config = Wip::Config.new('mode' => 'compose',
+      built_config = Wip::Config.new('mode' => 'compose', 'container' => 'app',
                                      'compose' => { 'service' => 'app', 'command' => 'my-compose-tool' },
                                      'sync' => { 'build' => { 'dockerfile' => 'FROM alpine' } })
       builder = described_class.new(wslc: 'wslc.exe', config: built_config, environment: environment)

--- a/spec/wip/config_spec.rb
+++ b/spec/wip/config_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 RSpec.describe Wip::Config do
   it 'merges custom commands onto the primary container and converts environment values to strings' do
-    config = described_class.new('version' => 1,
+    config = described_class.new('version' => 1, 'container' => 'app',
                                  'dependencies' => { 'app' => { 'image' => 'example:dev', 'workdir' => '/app' } },
                                  'commands' => { 'web' => { 'command' => 'server',
                                                             'env' => { 'PORT' => 3000 } } })
@@ -16,10 +16,17 @@ RSpec.describe Wip::Config do
     expect(config.to_h.dig('commands', 'x', 'env', 'API_TOKEN')).to eq('[REDACTED]')
   end
 
-  it 'exposes container, defaulting to app, and the primary dependency it points at' do
-    config = described_class.new('dependencies' => { 'app' => { 'image' => 'example:dev', 'command' => 'local' } })
+  it 'exposes container and the primary dependency it points at, with no implicit default' do
+    config = described_class.new('container' => 'app',
+                                 'dependencies' => { 'app' => { 'image' => 'example:dev', 'command' => 'local' } })
     expect(config.container).to eq('app')
     expect(config.primary).to include('image' => 'example:dev', 'command' => 'local')
+    expect(described_class.new({}).container).to be_nil
+  end
+
+  it 'requires container: once dependencies: has entries, rather than guessing a name' do
+    expect { described_class.new('dependencies' => { 'app' => { 'image' => 'example:dev' } }) }
+      .to raise_error(Wip::ConfigError, /container: must be set when dependencies: has entries/)
   end
 
   it 'lets container point at a differently-named dependency' do
@@ -29,11 +36,14 @@ RSpec.describe Wip::Config do
 
   it 'has no primary entry when the pointed-at dependency is missing' do
     expect(described_class.new({}).primary).to be_nil
-    expect(described_class.new('dependencies' => { 'redis' => { 'image' => 'redis:latest' } }).primary).to be_nil
+    missing = described_class.new('container' => 'app',
+                                  'dependencies' => { 'redis' => { 'image' => 'redis:latest' } })
+    expect(missing.primary).to be_nil
   end
 
   it 'exposes dependencies with defaulted settings, uniformly for the primary and sidecars' do
-    config = described_class.new('dependencies' => { 'redis' => { 'image' => 'redis:latest' } })
+    config = described_class.new('container' => 'redis',
+                                 'dependencies' => { 'redis' => { 'image' => 'redis:latest' } })
 
     expect(config.dependency('redis')).to include('image' => 'redis:latest', 'workdir' => nil,
                                                   'interactive' => false, 'remove' => true,
@@ -43,7 +53,7 @@ RSpec.describe Wip::Config do
 
   it 'requires dependencies to set an image' do
     expect do
-      described_class.new('dependencies' => { 'redis' => { 'command' => 'redis-server' } })
+      described_class.new('container' => 'redis', 'dependencies' => { 'redis' => { 'command' => 'redis-server' } })
     end.to raise_error(Wip::ConfigError, /dependencies\.redis must set image/)
   end
 
@@ -155,7 +165,7 @@ RSpec.describe Wip::Config do
   end
 
   it 'allows sync.build alongside compose in place of sync.image' do
-    config = described_class.new('mode' => 'compose',
+    config = described_class.new('mode' => 'compose', 'container' => 'app',
                                  'compose' => { 'service' => 'app', 'command' => 'my-compose-tool' },
                                  'sync' => { 'build' => { 'dockerfile' => 'FROM alpine' } })
     expect(config.sync.build['tag']).to eq('wip-sync-app:latest')
@@ -170,14 +180,15 @@ RSpec.describe Wip::Config do
   end
 
   it 'includes the resolved sync settings in the effective configuration' do
-    config = described_class.new('dependencies' => { 'app' => { 'image' => 'example:dev' } },
+    config = described_class.new('container' => 'app',
+                                 'dependencies' => { 'app' => { 'image' => 'example:dev' } },
                                  'sync' => { 'exclude' => ['.git'] })
 
     expect(config.to_h['sync']).to include('volume' => 'app-src', 'target' => '/app', 'exclude' => ['.git'])
   end
 
   it 'includes container and network in the effective configuration, with no defaults or up block' do
-    config = described_class.new('network' => 'app-tier',
+    config = described_class.new('container' => 'app', 'network' => 'app-tier',
                                  'dependencies' => { 'app' => { 'image' => 'example:dev' } })
 
     expect(config.to_h).to include('container' => 'app', 'network' => 'app-tier')

--- a/spec/wip/config_spec.rb
+++ b/spec/wip/config_spec.rb
@@ -146,12 +146,19 @@ RSpec.describe Wip::Config do
     expect(config.sync.mode).to eq('run')
   end
 
-  it 'requires sync.image alongside compose' do
+  it 'requires sync.image or sync.build alongside compose' do
     expect do
       described_class.new('mode' => 'compose',
                           'compose' => { 'service' => 'app', 'command' => 'my-compose-tool' },
                           'sync' => {})
-    end.to raise_error(Wip::ConfigError, /sync\.image is required under mode: compose/)
+    end.to raise_error(Wip::ConfigError, /sync\.image or sync\.build is required under mode: compose/)
+  end
+
+  it 'allows sync.build alongside compose in place of sync.image' do
+    config = described_class.new('mode' => 'compose',
+                                 'compose' => { 'service' => 'app', 'command' => 'my-compose-tool' },
+                                 'sync' => { 'build' => { 'dockerfile' => 'FROM alpine' } })
+    expect(config.sync.build['tag']).to eq('wip-sync-app:latest')
   end
 
   it 'rejects sync.mode: exec alongside compose' do

--- a/spec/wip/doctor_spec.rb
+++ b/spec/wip/doctor_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Wip::Doctor do
   it 'reports an invalid sync block as a failed check' do
     results = results_for(<<~YAML)
       version: 1
+      container: app
       dependencies:
         app:
           image: example:dev
@@ -30,6 +31,7 @@ RSpec.describe Wip::Doctor do
   it 'reports the resolved sync plan when the source exists' do
     results = results_for(<<~YAML)
       version: 1
+      container: app
       dependencies:
         app:
           image: example:dev
@@ -50,5 +52,18 @@ RSpec.describe Wip::Doctor do
     YAML
 
     expect(results).to include(an_object_having_attributes(level: :fail, message: 'No dependencies.web entry'))
+  end
+
+  it 'reports a missing container: as a failed check when dependencies: has entries' do
+    results = results_for(<<~YAML)
+      version: 1
+      dependencies:
+        app:
+          image: example:dev
+    YAML
+
+    expect(results).to include(an_object_having_attributes(
+                                 level: :fail, message: 'container: must be set when dependencies: has entries'
+                               ))
   end
 end

--- a/spec/wip/sync_settings_spec.rb
+++ b/spec/wip/sync_settings_spec.rb
@@ -57,10 +57,28 @@ RSpec.describe Wip::SyncSettings do
     expect(described_class.new({ 'image' => 'example:dev' }, compose: true).mode).to eq('run')
   end
 
-  it 'requires sync.image under compose, since there is no dependencies: entry to borrow it from' do
+  it 'requires sync.image or sync.build under compose, since there is no dependencies: entry to borrow one from' do
     expect { described_class.new({}, compose: true) }
-      .to raise_error(Wip::ConfigError, /sync\.image is required under mode: compose/)
+      .to raise_error(Wip::ConfigError, /sync\.image or sync\.build is required under mode: compose/)
     expect(described_class.new({ 'image' => 'example:dev' }, compose: true).image).to eq('example:dev')
+    built = described_class.new({ 'build' => { 'dockerfile' => 'FROM alpine' } }, compose: true)
+    expect(built.build).to eq('dockerfile' => 'FROM alpine', 'tag' => 'wip-sync-wip:latest')
+  end
+
+  it 'derives the build tag from the container name, or lets sync.build.tag override it' do
+    settings = described_class.new({ 'build' => { 'dockerfile' => 'FROM alpine' } }, container: 'app')
+    expect(settings.build['tag']).to eq('wip-sync-app:latest')
+
+    overridden = described_class.new({ 'build' => { 'dockerfile' => 'FROM alpine', 'tag' => 'custom:latest' } })
+    expect(overridden.build['tag']).to eq('custom:latest')
+  end
+
+  it 'rejects a non-mapping sync.build and an empty sync.build.dockerfile' do
+    expect do
+      described_class.new({ 'build' => 'nope' })
+    end.to raise_error(Wip::ConfigError, /sync\.build must be a mapping/)
+    expect { described_class.new({ 'build' => {} }) }
+      .to raise_error(Wip::ConfigError, /sync\.build\.dockerfile must not be empty/)
   end
 
   it 'leaves sync.image unset outside compose, where it is optional' do


### PR DESCRIPTION
## Summary
- `sync.mode: run` boots a fresh container on every mirror (always, under `mode: compose`, since there's nothing already running to exec into), so reusing the app's full image there just adds startup overhead for a container that only ever runs `rsync`. Until now the only option was building and tagging a dedicated image outside of wip and pointing `sync.image` at it by hand.
- New `sync.build` covers that without a separate image to maintain: give it a Dockerfile (typically a two-line `alpine` + `rsync` one) and wip builds it once per `wip up`/`wip sync` invocation — including once before a `--watch` loop starts, **not** on every tick — tagging it `wip-sync-<container>:latest` by default (`sync.build.tag` overrides it).
- `sync.image` still works for projects that would rather manage the image themselves; `sync.build`'s tag wins if both are set.
- `wip init`'s generated compose starter now shows a ready-to-uncomment `sync.build` block directly instead of just pointing at the README.

## Breaking change: `container:` has no default anymore
- `container:` (which `dependencies:` entry `up`/`exec`/`run`/`build`/`commands:` target) used to default to `"app"`. Guessing a name either matched by luck or failed with an error that didn't point at the real problem.
- `container:` is now required once `dependencies:` has any entries (validated eagerly at config load, mirroring how `mode: compose` already requires a `compose:` block). A project with no `dependencies:` at all (sync-only or custom-commands-only configs) still doesn't need it.
- `wip init`'s templates now set `container: app` explicitly, matching the `dependencies.app` entry they create.
- README and doctor updated accordingly (`wip doctor` reports a clear failure if `dependencies:` has entries but `container:` is missing).

Bump version to v0.13.0.

## Test plan
- [x] `bundle exec rspec` (159 examples, 0 failures)
- [x] `bundle exec rubocop` (no offenses)
- [x] Manually ran `wip init` (both container and compose modes) and confirmed the generated `wip.yml` loads and resolves `container`/`primary` correctly
- [x] Manually verified `sync_run`/`sync_build` argv construction for a `sync.build`-configured compose config

🤖 Generated with [Claude Code](https://claude.com/claude-code)