### PR TITLE
Detect WSLC mounted-volume limit errors and provide recovery hint; bump version to 0.13.1

### DIFF
--- a/lib/wip/error_interpreter.rb
+++ b/lib/wip/error_interpreter.rb
@@ -10,6 +10,11 @@ module Wip
       /rsync[^\n]*executable file not found/i,
       /executable file not found[^\n]*rsync/i
     )
+    VOLUME_LIMIT_REACHED = Regexp.union(
+      /0x8007000e/i,
+      /too many mounted volumes/i,
+      /マウントされているボリュームが多すぎます/
+    )
 
     def initialize(architecture: Environment.new.architecture)
       @architecture = architecture
@@ -17,6 +22,7 @@ module Wip
 
     def interpret(output)
       case output
+      when VOLUME_LIMIT_REACHED then volume_limit_message
       when /pull access denied|insufficient_scope|authorization failed/i then registry_message
       when %r{no matching manifest for linux/(?:amd64|arm64)}i then architecture_message
       when RSYNC_MISSING then rsync_message
@@ -24,6 +30,20 @@ module Wip
     end
 
     private
+
+    def volume_limit_message
+      <<~TEXT
+        The WSLC session has reached its mounted-volume limit.
+
+        Stop any containers you no longer need, then restart the session:
+
+          wslc container list
+          wslc container stop <container-name>
+          wslc system session terminate
+
+        Then retry the command.
+      TEXT
+    end
 
     def rsync_message
       <<~TEXT

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.13.0'
+  VERSION = '0.13.1'
 end

--- a/spec/wip/error_interpreter_spec.rb
+++ b/spec/wip/error_interpreter_spec.rb
@@ -16,4 +16,19 @@ RSpec.describe Wip::ErrorInterpreter do
     expect(interpreter.interpret('exec: "rsync": executable file not found in $PATH')).to include('wip sync')
     expect(interpreter.interpret('executable file not found in $PATH: rsync')).to include('wip sync')
   }
+  it('suggests freeing volumes and restarting a volume-limited WSLC session') {
+    message = interpreter.interpret(
+      'マウントされているボリュームが多すぎます (上限: 15)。エラー コード: 0x8007000e'
+    )
+
+    expect(message).to include(
+      'wslc container list',
+      'wslc container stop <container-name>',
+      'wslc system session terminate'
+    )
+  }
+  it('recognizes the mounted-volume limit without a localized error description') {
+    expect(interpreter.interpret('Error code: 0X8007000E')).to include('mounted-volume limit')
+    expect(interpreter.interpret('Too many mounted volumes (limit: 15)')).to include('mounted-volume limit')
+  }
 end


### PR DESCRIPTION
### Motivation

- Surface a clearer, actionable hint when WSLC sessions hit the mounted-volume limit (Windows error code `0x8007000e` or localized "too many mounted volumes" messages).

### Description

- Add `VOLUME_LIMIT_REACHED` Regexp to `Wip::ErrorInterpreter` matching `0x8007000e`, English and Japanese "too many mounted volumes" text.
- Return a new `volume_limit_message` that instructs users to stop unneeded containers and terminate the WSLC session, showing commands like `wslc container list`, `wslc container stop <container-name>`, and `wslc system session terminate`.
- Wire the new matcher into `interpret` so volume-limit output returns the new message.
- Bump `Wip::VERSION` from `0.13.0` to `0.13.1` and add specs in `spec/wip/error_interpreter_spec.rb` covering the new detection and messages.

### Testing

- Ran the test suite with `bundle exec rspec` and the updated `spec/wip/error_interpreter_spec.rb` tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70496b3ce883228f518d67ee74b790)