### PR TITLE
fix(init): keep wip.yml defaults live, comment only real choices

### DIFF
--- a/lib/wip/initializer.rb
+++ b/lib/wip/initializer.rb
@@ -6,53 +6,17 @@ module Wip
   # mode: compose-native and mode: container, since that's the one decision
   # `wip init` can't leave to a placeholder.
   class Initializer
-    # Shared across both templates: every sync.* key SyncSettings understands,
-    # commented out with its default/behavior so nothing has to be looked up
-    # in the README to customize the mirror.
-    SYNC_TEMPLATE = <<~YAML.chomp
-      sync: {} # optional; mirrors the source into a named volume instead of bind-mounting it live
-        # source: . # optional; host path to mirror (default: wip.yml directory)
-        # target: /app # optional; in-container path the mirror volume mounts at (default: workdir, else /app)
-        # mount: /host-src # optional; read-only host mount inside the container (default: /host-src)
-        # volume: app-src # optional; named volume that holds the mirrored tree (default: "<container>-src")
-        # delete: true # optional; rsync --delete so removals on the host are mirrored too (default: true)
-        # exclude: [] # optional; rsync --exclude patterns, e.g. ["node_modules", "*.log"]
-        # command: rsync # optional; mirror binary to shell out to (default: rsync)
-        # options: [] # optional; extra flags appended to the mirror command
-        # interval: 2 # optional; seconds between mirrors (default: 2)
-        # mode: exec # optional; exec (default, mirrors into the running container) | run (fresh container each mirror)
-        # image: # optional; image the mirror container runs (required under mode: compose unless build: is set)
-        # build: # optional; let wip build a small dedicated mirror image instead of requiring one to exist
-        #   dockerfile: # TODO required if build: is set
-        #   tag: # optional (default: wip-sync-<container>:latest)
-    YAML
-
-    CONTAINER_TEMPLATE = <<~YAML.freeze
+    CONTAINER_TEMPLATE = <<~YAML
       version: 1
-      mode: container # container | compose | compose-native (see README)
+      mode: container
       container: app # TODO: rename freely, as long as it matches a key under dependencies: below
-
-      # wslc: {} # optional; override which wslc binary/path wip shells out to (default: auto)
-      #   command: auto
-
-      # network: my-network # optional; container network name (mode: container only)
 
       dependencies:
         app: # this is the container wip creates, execs into, and runs commands in
           image: your/image:tag # TODO: image to run
           workdir: /app # TODO: adjust to match your image, or delete this line
-          # interactive: false # optional; keep stdin open / allocate a tty (default: false)
-          # remove: true # optional; remove the container after each run (default: true)
-          # env: {} # optional; environment variables passed to the container, e.g. {FOO: bar}
-          # ports: [] # optional; published ports, e.g. ["3000:3000"]
-          # volumes: [] # optional; extra -v specs beyond the source/sync mounts
 
-      # commands:
-      #   test: # example custom command, invoked as `wip test`
-      #     type: exec # optional; exec (default, runs in the running container) | run (fresh container) | build
-      #     command: bundle exec rspec # TODO
-
-      #{SYNC_TEMPLATE}
+      sync: {} # optional; mirrors the source into a named volume instead of bind-mounting it live
     YAML
 
     def initialize(dir: Dir.pwd)
@@ -78,21 +42,10 @@ module Wip
                               # compose-for-wslc binary needed. Prefer a real compose tool instead? Use
                               # mode: compose (see README "Compose mode") and set compose.command.
 
-        # wslc: {} # optional; override which wslc binary/path wip shells out to (default: auto)
-        #   command: auto
-
         compose:
           service: app # TODO: which service in #{compose_file} wip run/exec/NAME target
-          # file: #{compose_file} # optional; override which compose file to parse (default: auto-detected)
-          # project: # optional; project/network name (default: wip.yml directory name)
-          # command: # required under mode: compose (external compose-for-wslc binary); unused under compose-native
 
-        # commands:
-        #   test: # example custom command, invoked as `wip test`
-        #     type: exec # optional; exec (default, runs in the running container) | run (fresh container) | build
-        #     command: bundle exec rspec # TODO
-
-        #{SYNC_TEMPLATE}
+        sync: {} # optional; mirrors the source into a named volume instead of bind-mounting it live
       YAML
     end
   end

--- a/lib/wip/initializer.rb
+++ b/lib/wip/initializer.rb
@@ -1,22 +1,69 @@
 # frozen_string_literal: true
 
+require 'pathname'
+
 module Wip
   # Builds a starter wip.yml. Detects an existing compose file next to the
   # target (the same filenames ComposeBridge auto-detects) to decide between
   # mode: compose-native and mode: container, since that's the one decision
   # `wip init` can't leave to a placeholder.
   class Initializer
-    CONTAINER_TEMPLATE = <<~YAML
+    # Appended to sync: in both templates. Every key here is either a plain constant
+    # default (safe to state literally) or, where commented, a value SyncSettings
+    # derives from another key (target from workdir, volume from the container/service
+    # name) — those stay unset so they keep tracking that key instead of going stale.
+    SYNC_EXTRAS = <<~YAML.chomp.gsub(/^/, '  ')
+      source: . # optional; host path to mirror (default: wip.yml directory)
+      # target: /app # optional; in-container mount point for the mirror (default: the container's workdir, else /app)
+      mount: /host-src # optional; read-only host mount inside the container
+      # volume: app-src # optional; named volume holding the mirrored tree (default: "<container>-src")
+      delete: true # optional; rsync --delete so removals on the host are mirrored too
+      exclude: [] # optional; rsync --exclude patterns, e.g. ["node_modules", "*.log"]
+      command: rsync # optional; mirror binary to shell out to
+      options: [] # optional; extra flags appended to the mirror command
+      interval: 2 # optional; seconds between mirrors
+      mode: exec # optional; exec (default, mirrors into the running container) | run (always a fresh container)
+      # image: your/image:tag # only needed if sync.mode: run (or under mode: compose); image the mirror container runs
+      # build: # alternative to image — let wip build a small dedicated mirror image itself
+      #   dockerfile: |
+      #     FROM alpine:latest
+      #     RUN apk add --no-cache rsync
+      #   tag: wip-sync-app:latest # optional (default: wip-sync-<container>:latest)
+    YAML
+
+    # Appended to both templates after dependencies/compose. commands: itself is left
+    # commented since an empty commands: {} is indistinguishable from omitting the key.
+    COMMANDS_EXAMPLE = <<~YAML.chomp
+      # commands: # optional; custom subcommands, e.g. `wip test` — see README
+      #   test:
+      #     type: exec # optional; exec (default, runs in the running container) | run (fresh container) | build
+      #     command: bundle exec rspec # TODO
+    YAML
+
+    CONTAINER_TEMPLATE = <<~YAML.freeze
       version: 1
-      mode: container
+      mode: container # container | compose | compose-native (see README)
       container: app # TODO: rename freely, as long as it matches a key under dependencies: below
+
+      wslc:
+        command: auto # optional; wslc binary/path wip shells out to ("auto" resolves it for you)
+
+      # network: my-network # optional; container network name (mode: container only)
 
       dependencies:
         app: # this is the container wip creates, execs into, and runs commands in
           image: your/image:tag # TODO: image to run
           workdir: /app # TODO: adjust to match your image, or delete this line
+          interactive: false # optional; keep stdin open / allocate a tty
+          remove: true # optional; remove the container after each run
+          env: {} # optional; environment variables passed to the container, e.g. {FOO: bar}
+          ports: [] # optional; published ports, e.g. ["3000:3000"]
+          volumes: [] # optional; extra -v specs beyond the sync mounts below
 
-      sync: {} # optional; mirrors the source into a named volume instead of bind-mounting it live
+      #{COMMANDS_EXAMPLE}
+
+      sync: # optional; mirrors the source into a named volume instead of bind-mounting it live
+      #{SYNC_EXTRAS}
     YAML
 
     def initialize(dir: Dir.pwd)
@@ -35,6 +82,11 @@ module Wip
       @compose_file ||= ComposeBridge::FILENAMES.find { |name| File.file?(File.join(@dir, name)) }
     end
 
+    # Directory name wip.yml would resolve as its default compose.project (and, from
+    # that, its network name) if left unset — shown as a comment so it's discoverable
+    # without duplicating it as a live value that would go stale if the directory moves.
+    def compose_project_default = Pathname(@dir).basename.to_s
+
     def compose_template
       <<~YAML
         version: 1
@@ -42,10 +94,22 @@ module Wip
                               # compose-for-wslc binary needed. Prefer a real compose tool instead? Use
                               # mode: compose (see README "Compose mode") and set compose.command.
 
+        wslc:
+          command: auto # optional; wslc binary/path wip shells out to ("auto" resolves it for you)
+
         compose:
           service: app # TODO: which service in #{compose_file} wip run/exec/NAME target
+          # file: #{compose_file} # optional; override which compose file wip parses (default: auto-detected)
+          # project: #{compose_project_default} # optional; project/network name (default: this directory's name)
+          # command: # only used under mode: compose (external compose-for-wslc binary); unused here under compose-native
 
-        sync: {} # optional; mirrors the source into a named volume instead of bind-mounting it live
+        # network: is derived from compose.project above (or this directory's name) — setting it
+        # directly conflicts with compose: (ConfigError), so it's intentionally left out here.
+
+        #{COMMANDS_EXAMPLE}
+
+        sync: # optional; mirrors the source into a named volume instead of bind-mounting it live
+        #{SYNC_EXTRAS}
       YAML
     end
   end

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.14.0'
+  VERSION = '0.14.1'
 end

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.14.1'
+  VERSION = '0.14.0'
 end

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.14.1'
+  VERSION = '0.14.2'
 end


### PR DESCRIPTION
## Summary
PR #33 merged with only its first commit — the one that turned every declarable key into a comment, losing the working `sync.build` recipe and other decided defaults in a wall of inactive text. This PR carries the follow-up correction that was pushed to the same branch afterward, so it never made it into #33.

- Reverts that first commit, then reapplies it correctly: every real key that was already live (`container:`, `dependencies.app.image/workdir`, `compose.service`, `sync:` enabled by default, etc.) stays exactly as it was.
- Adds the rest of what Config/SyncSettings understand, split by kind:
  - **Safe constant defaults** are stated live (matches current behavior exactly): `wslc.command`, `dependencies.app.{interactive,remove,env,ports,volumes}`, and sync's `source/mount/delete/exclude/command/options/interval/mode`.
  - **Choices, or values derived from another key**, stay commented so they keep tracking that key instead of going stale: `network`, `compose.file`, `compose.project`, `sync.target` (derived from workdir), `sync.volume` (derived from the container/service name), and `sync.image`/`sync.build` — restoring the concrete alpine+rsync `sync.build` recipe that existed before compose-native mode was introduced.
- Bumps VERSION to 0.14.2 (patch; 0.14.1 was already used/merged as part of #33).

## Test plan
- [x] `bundle exec rspec` (full suite, 200 examples)
- [x] `bundle exec rubocop lib/wip/initializer.rb`
- [x] Manually rendered both templates, parsed with `YAML.safe_load` and loaded through `Wip::ConfigLoader`/`Config` end-to-end
- [x] Confirmed `sync.target` follows a compose service's `working_dir` when left commented out, instead of a hardcoded value overriding it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * コンテナおよびCompose用テンプレートに、同期設定やカスタムコマンドの設定例を追加しました。
  * Composeプロジェクト名やネットワーク設定の既定値・説明を分かりやすく表示するよう改善しました。

* **改善**
  * 生成される設定テンプレートの既定値とコメントを整理し、設定内容を確認しやすくしました。

* **その他**
  * バージョンを0.14.2に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->