### PR TITLE
feat(compose-native): support user, build.args, and image+build together

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,8 +340,11 @@ valid compose.yml over sections it doesn't need to look at:
   `compose.yml`, not wherever `wip` is invoked from), `command` (shell or exec form), `environment`
   (mapping or `KEY=VALUE` array — a mapping value must not be null; host environment pass-through
   isn't supported), `ports`/`volumes` (short syntax only — `"host:container"` strings, not
-  long-syntax mappings), `working_dir`, `depends_on` (ordering only — a `condition:` other than
-  `service_started` is rejected, since there's no health-check support).
+  long-syntax mappings), `working_dir`, `user`, `depends_on` (ordering only — a `condition:` other
+  than `service_started` is rejected, since there's no health-check support). `tty`, `stdin_open`,
+  and `networks` are accepted but silently ignored: TTY/stdin allocation is already decided per
+  invocation (see "TTY allocation" below), not fixed per service, and every service already shares
+  the one project network `compose.project` sets up.
 - `wip logs` takes at most one `SERVICE` (defaulting to `compose.service`) — `wslc logs`, like
   `docker logs`, follows a single container, unlike a real compose tool's multi-service view.
 - `sync:` behaves exactly like `mode: container`'s (falls back to the primary service's own image,
@@ -481,21 +484,28 @@ checklist.
 
 ## Not in the initial release
 
-Full Compose compatibility isn't reimplemented in `wip` itself — `mode: compose-native` only
-covers a minimal subset (see [Compose mode (native)](#compose-mode-native)), and full parity is
-otherwise available by delegating to a third-party compose-for-`wslc` tool (see
-[Compose mode](#compose-mode)). A resident/daemon process, a GUI, PowerShell-specific tuning,
-direct registry API/manifest parsing, self-update, and plugins are all unimplemented.
+Full Compose compatibility isn't reimplemented in `wip` itself — `mode: compose-native` parses
+`compose.yml` and drives `wslc` directly, but only covers a minimal subset (see
+[Compose mode (native)](#compose-mode-native)); full parity is otherwise available by delegating
+to a third-party compose-for-`wslc` tool (see [Compose mode](#compose-mode)). A resident/daemon
+process, a GUI, PowerShell-specific tuning, direct registry API/manifest parsing, self-update, and
+plugins are all unimplemented.
 
 ## Roadmap
 
 `wip` already covers most of what [`dip`](https://github.com/bibendi/dip) adds on top of Compose —
 named commands (`commands:`), `run`/`exec` hidden behind a single verb, `.env` passthrough, and
-sidecar services via `dependencies:` + `network:`. Fuller Compose semantics
-(`depends_on` ordering/health checks, log aggregation, named volumes, profiles, scaling) are now
-handled by delegating to a separate compose-for-`wslc` tool in [compose mode](#compose-mode)
-rather than being reimplemented in `wip` itself. Which of those actually work is entirely up to
-the external tool you point `compose.command` at — `wip` only forwards
+sidecar services via `dependencies:` + `network:`. Rather than waiting on `wslc`'s own Compose
+support ([microsoft/WSL#40948](https://github.com/microsoft/WSL/issues/40948)) or an external
+compose-for-`wslc` tool staying complete, `mode: compose-native` (see
+[Compose mode (native)](#compose-mode-native)) parses `compose.yml` itself and drives `wslc`
+directly — no external binary in the loop, `wip run` gets a real `--rm` container, and iterating
+on the parser is faster than chasing a third-party tool's own bugs. It's still a deliberately
+minimal subset (`depends_on` ordering but no health checks, single-container `logs`, no named
+volumes/scaling), and `dependencies:` + `network:` remains the escape hatch for sidecars it
+doesn't model. Fuller Compose semantics beyond that subset stay behind delegating to a separate
+compose-for-`wslc` tool in [compose mode](#compose-mode) — which of those actually work is
+entirely up to the external tool you point `compose.command` at; `wip` only forwards
 `-f FILE [-p PROJECT] up|down|exec|logs`, so treat that list as what Compose offers, not as
 something `wip` guarantees. See that section for what compose mode covers
 and its current limitations (`run`, and `commands:` of type `run`/`build`). What's still planned

--- a/lib/wip/cli.rb
+++ b/lib/wip/cli.rb
@@ -294,6 +294,7 @@ module Wip
     def ensure_compose_images
       load_config.compose_build_specs.each_value do |spec|
         extra = spec['dockerfile'] ? ['-f', spec['dockerfile']] : []
+        spec['args']&.each { |key, value| extra.push('--build-arg', "#{key}=#{value}") }
         execute(builder.build(settings: { 'context' => spec['context'], 'tag' => spec['tag'] }, extra: extra))
       end
     end

--- a/lib/wip/command_builder.rb
+++ b/lib/wip/command_builder.rb
@@ -159,14 +159,23 @@ module Wip
     private
 
     def options(values, include_container: false, include_publish: true, sync: true)
+      result = scalar_options(values)
+      merged_env(values).each { |key, value| result.push('-e', "#{key}=#{value}") }
+      result.concat(publish_options(values, sync: sync)) if include_publish
+      result << required(values, 'container') if include_container
+      result
+    end
+
+    def scalar_options(values)
       result = []
       result.push('-w', values['workdir']) unless values['workdir'].to_s.empty?
-      merged_env(values).each { |key, value| result.push('-e', "#{key}=#{value}") }
-      if include_publish
-        Array(values['ports']).each { |port| result.push('-p', port.to_s) }
-        volume_specs(values, sync: sync).each { |volume| result.push('-v', volume) }
-      end
-      result << required(values, 'container') if include_container
+      result.push('-u', values['user']) unless values['user'].to_s.empty?
+      result
+    end
+
+    def publish_options(values, sync:)
+      result = Array(values['ports']).flat_map { |port| ['-p', port.to_s] }
+      volume_specs(values, sync: sync).each { |volume| result.push('-v', volume) }
       result
     end
 

--- a/lib/wip/compose_file.rb
+++ b/lib/wip/compose_file.rb
@@ -15,10 +15,19 @@ module Wip
   # "Compose mode (native)") — once wslc ships that support, or a
   # compose-for-wslc tool reliably supports `run`.
   class ComposeFile
-    Service = Struct.new(:image, :build, :command, :env, :ports, :volumes, :workdir, :depends_on, keyword_init: true)
+    Service = Struct.new(:image, :build, :command, :env, :ports, :volumes, :workdir, :user, :depends_on,
+                         keyword_init: true)
 
-    SERVICE_KEYS = %w[image build command environment ports volumes working_dir depends_on].freeze
-    BUILD_KEYS = %w[context dockerfile].freeze
+    SERVICE_KEYS = %w[image build command environment ports volumes working_dir user depends_on].freeze
+    # Real Compose keys that read as meaningful here but have nothing to map onto: TTY/stdin
+    # allocation is already decided per invocation (see CommandBuilder#tty?), not fixed per
+    # service; there's no per-service network to join beyond the one project network `network`
+    # (config.rb) already puts every service on; `wslc run`/`exec` has no restart-policy or
+    # capability flag to forward `restart:`/`cap_add:` to; and `profiles:` gates which services a
+    # real `docker compose up` starts by default, which doesn't apply here since wip never starts
+    # "every service" — only `compose.service` and whatever it reaches via `depends_on`.
+    IGNORED_SERVICE_KEYS = %w[tty stdin_open networks restart cap_add profiles].freeze
+    BUILD_KEYS = %w[context dockerfile args].freeze
     SUPPORTED_CONDITIONS = %w[service_started].freeze
 
     def self.load(path)
@@ -44,10 +53,10 @@ module Wip
     # name => {context:, dockerfile:, tag:} for every service with a build:.
     def build_specs
       @order.filter_map do |name|
-        build = @services.fetch(name).build
-        next unless build
+        service = @services.fetch(name)
+        next unless service.build
 
-        [name, build.merge('tag' => image_tag(name))]
+        [name, service.build.merge('tag' => image_tag(name, service))]
       end.to_h
     end
 
@@ -56,35 +65,41 @@ module Wip
     def to_dependencies_hash
       @order.to_h do |name|
         service = @services.fetch(name)
-        [name, { 'image' => service.build ? image_tag(name) : service.image, 'command' => service.command,
+        [name, { 'image' => service.build ? image_tag(name, service) : service.image, 'command' => service.command,
                  'env' => service.env, 'ports' => service.ports, 'volumes' => service.volumes,
-                 'workdir' => service.workdir }]
+                 'workdir' => service.workdir, 'user' => service.user }]
       end
     end
 
     private
 
-    def image_tag(name) = "wip-compose-#{name}:latest"
+    # A service naming both `build:` and `image:` builds via the former and tags the
+    # result with the latter (real Compose's own rule for that combination), instead
+    # of the auto-generated tag a build:-only service gets.
+    def image_tag(name, service) = service.image || "wip-compose-#{name}:latest"
 
     def build_service(name, entry)
       raise ConfigError, "#{@path}: services.#{name} must be a mapping" unless entry.is_a?(Hash)
 
-      unknown = entry.keys.map(&:to_s) - SERVICE_KEYS
+      unknown = entry.keys.map(&:to_s) - SERVICE_KEYS - IGNORED_SERVICE_KEYS
       raise ConfigError, "#{@path}: services.#{name} has unsupported key(s): #{unknown.join(', ')}" if unknown.any?
 
       image, build = image_or_build(name, entry)
       Service.new(image: image, build: build, command: normalize_command(entry['command']),
-                  env: normalize_env(name, entry['environment']),
-                  ports: normalize_list(name, entry['ports'], 'ports'),
-                  volumes: normalize_list(name, entry['volumes'], 'volumes'),
-                  workdir: presence(entry['working_dir']), depends_on: normalize_depends_on(name, entry['depends_on']))
+                  env: normalize_env(name, entry['environment']), **normalize_service_lists(name, entry),
+                  workdir: presence(entry['working_dir']), user: presence(entry['user']),
+                  depends_on: normalize_depends_on(name, entry['depends_on']))
+    end
+
+    def normalize_service_lists(name, entry)
+      { ports: normalize_list(name, entry['ports'], 'ports'),
+        volumes: normalize_list(name, entry['volumes'], 'volumes') }
     end
 
     def image_or_build(name, entry)
       image = presence(entry['image'])
       build = normalize_build(name, entry['build'])
       raise ConfigError, "#{@path}: services.#{name} must set image or build" unless image || build
-      raise ConfigError, "#{@path}: services.#{name} must not set both image and build" if image && build
 
       [image, build]
     end
@@ -118,27 +133,33 @@ module Wip
 
       context = resolve_context(presence(value['context']) || '.')
       dockerfile = presence(value['dockerfile'])
-      { 'context' => context, 'dockerfile' => dockerfile && Pathname(context).join(dockerfile).to_s }.compact
+      { 'context' => context, 'dockerfile' => dockerfile && Pathname(context).join(dockerfile).to_s,
+        'args' => normalize_kv(name, value['args'], 'build.args') }.compact
     end
 
     # build.context is relative to compose.yml's own directory (Compose's own rule),
     # not wherever `wip` happens to be invoked from.
     def resolve_context(raw) = Pathname(@path).expand_path.dirname.join(raw).to_s
 
-    def normalize_env(name, value)
+    def normalize_env(name, value) = normalize_kv(name, value, 'environment')
+
+    # Shared by `environment:` and `build.args:` — both accept a mapping or a
+    # KEY=VALUE array, and neither supports host environment pass-through (a
+    # null mapping value, or a bare KEY with no `=`).
+    def normalize_kv(name, value, label)
       return {} unless value
 
       case value
-      when Hash then normalize_env_mapping(name, value)
-      when Array then normalize_env_array(name, value)
-      else raise ConfigError, "#{@path}: services.#{name}.environment must be a mapping or an array of KEY=VALUE"
+      when Hash then normalize_kv_mapping(name, value, label)
+      when Array then normalize_kv_array(name, value, label)
+      else raise ConfigError, "#{@path}: services.#{name}.#{label} must be a mapping or an array of KEY=VALUE"
       end
     end
 
-    def normalize_env_mapping(name, value)
+    def normalize_kv_mapping(name, value, label)
       value.to_h do |key, val|
         if val.nil?
-          raise ConfigError, "#{@path}: services.#{name}.environment.#{key} must have a value " \
+          raise ConfigError, "#{@path}: services.#{name}.#{label}.#{key} must have a value " \
                              '(host environment pass-through is not supported)'
         end
 
@@ -146,10 +167,10 @@ module Wip
       end
     end
 
-    def normalize_env_array(name, value)
+    def normalize_kv_array(name, value, label)
       value.to_h do |item|
         key, val = item.to_s.split('=', 2)
-        raise ConfigError, "#{@path}: services.#{name}.environment entries must be KEY=VALUE" unless val
+        raise ConfigError, "#{@path}: services.#{name}.#{label} entries must be KEY=VALUE" unless val
 
         [key, val]
       end

--- a/lib/wip/config.rb
+++ b/lib/wip/config.rb
@@ -7,7 +7,7 @@ module Wip
   class Config
     # Applied to every dependencies: entry, primary container included — there
     # is no separate, differently-shaped bucket for "the one you exec into."
-    DEPENDENCY_DEFAULTS = { 'workdir' => nil, 'interactive' => false, 'remove' => true,
+    DEPENDENCY_DEFAULTS = { 'workdir' => nil, 'user' => nil, 'interactive' => false, 'remove' => true,
                             'env' => {}, 'ports' => [], 'volumes' => [] }.freeze
     SECRET_PATTERN = /token|password|secret|credential|auth/i
     # Which orchestration path `up`/`down`/`sync`/etc. take. Explicit rather than

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.15.0'
+  VERSION = '0.16.0'
 end

--- a/spec/wip/command_builder_spec.rb
+++ b/spec/wip/command_builder_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe Wip::CommandBuilder do
     expect(builder.run(['server'], settings: settings)).to eq(expected)
   end
 
+  it 'passes user through as -u' do
+    settings = { 'user' => '1000:1000' }
+    expect(builder.exec(%w[whoami], settings: settings,
+                                    interactive: false)).to eq(%w[wslc.exe exec -w /app -u 1000:1000 app whoami])
+  end
+
   it 'builds images with extra options before context' do
     expect(builder.build(settings: config.command('build'),
                          extra: ['--no-cache'])).to eq(%w[wslc.exe build -t example:dev

--- a/spec/wip/compose_file_spec.rb
+++ b/spec/wip/compose_file_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Wip::ComposeFile do
     deps = described_class.load(path).to_dependencies_hash
     expect(deps['app']).to eq('image' => 'example:dev', 'command' => 'bin/rails s',
                               'env' => { 'RAILS_ENV' => 'development' }, 'ports' => ['3000:3000'],
-                              'volumes' => ['app-src:/app'], 'workdir' => '/app')
+                              'volumes' => ['app-src:/app'], 'workdir' => '/app', 'user' => nil)
   end
 
   it 'normalizes environment given as a KEY=VALUE array' do
@@ -97,12 +97,23 @@ RSpec.describe Wip::ComposeFile do
     expect { described_class.load(path) }.to raise_error(Wip::ConfigError, /Could not parse/)
   end
 
-  it 'requires exactly one of image or build' do
+  it 'requires at least one of image or build' do
     neither = write_compose("services:\n  app:\n    command: x\n")
     expect { described_class.load(neither) }.to raise_error(Wip::ConfigError, /must set image or build/)
+  end
 
-    both = write_compose("services:\n  app:\n    image: example:dev\n    build: .\n")
-    expect { described_class.load(both) }.to raise_error(Wip::ConfigError, /must not set both image and build/)
+  it 'builds and tags with image: when both image and build are set' do
+    path = write_compose(<<~YAML)
+      services:
+        app:
+          image: example:tagged
+          build:
+            context: .
+    YAML
+
+    compose = described_class.load(path)
+    expect(compose.build_specs['app']['tag']).to eq('example:tagged')
+    expect(compose.to_dependencies_hash['app']['image']).to eq('example:tagged')
   end
 
   it 'resolves build.context relative to the compose file, not the current directory' do
@@ -133,8 +144,8 @@ RSpec.describe Wip::ComposeFile do
     expect(described_class.load(path).to_dependencies_hash['app']['image']).to eq('wip-compose-app:latest')
   end
 
-  it 'rejects unsupported build keys' do
-    path = write_compose(<<~YAML)
+  it 'normalizes build.args given as a mapping or a KEY=VALUE array' do
+    mapping = write_compose(<<~YAML)
       services:
         app:
           build:
@@ -142,8 +153,45 @@ RSpec.describe Wip::ComposeFile do
             args:
               FOO: bar
     YAML
+    expect(described_class.load(mapping).build_specs['app']['args']).to eq('FOO' => 'bar')
 
-    expect { described_class.load(path) }.to raise_error(Wip::ConfigError, /build has unsupported key\(s\): args/)
+    array = write_compose(<<~YAML)
+      services:
+        app:
+          build:
+            context: .
+            args:
+              - FOO=bar
+    YAML
+    expect(described_class.load(array).build_specs['app']['args']).to eq('FOO' => 'bar')
+  end
+
+  it 'rejects unsupported build keys' do
+    path = write_compose(<<~YAML)
+      services:
+        app:
+          build:
+            context: .
+            deploy: true
+    YAML
+
+    expect { described_class.load(path) }.to raise_error(Wip::ConfigError, /build has unsupported key\(s\): deploy/)
+  end
+
+  it 'reads user and ignores tty, stdin_open, networks' do
+    path = write_compose(<<~YAML)
+      services:
+        app:
+          image: example:dev
+          user: "1000:1000"
+          tty: true
+          stdin_open: true
+          networks:
+            - app-tier
+    YAML
+
+    deps = described_class.load(path).to_dependencies_hash
+    expect(deps['app']['user']).to eq('1000:1000')
   end
 
   it 'rejects unsupported service keys' do


### PR DESCRIPTION
## Summary
- `services.<name>.user` in compose-native is now supported and maps to `wslc run`/`exec -u`.
- `build.args` (mapping or `KEY=VALUE` array) is now supported and maps to `wslc build --build-arg`.
- A service naming both `image:` and `build:` now builds via `build:` and tags the result with `image:`, matching real Compose's own rule for that combination (previously rejected as an error).
- `tty`, `stdin_open`, `networks`, `restart`, `cap_add`, and `profiles` are now accepted but silently ignored per service — none of them have a `wslc` equivalent to map onto.
- README's Compose mode (native) section, Roadmap, and "Not in the initial release" section updated to describe this and to correct the framing that fuller Compose semantics were only ever delegated externally — `compose-native` is a real, direct implementation.
- Bumped version to v0.16.0.

## Test plan
- [x] `bundle exec rspec` (210 examples, 0 failures)
- [x] `bundle exec rubocop` (no offenses)
- [x] Manually loaded a real-world `compose.yml` using `user:`, `tty:`, `stdin_open:`, `networks:`, `restart:`, `cap_add:`, `profiles:`, `build.args:`, and combined `image:`+`build:` and confirmed it parses cleanly end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Compose services can now define build arguments and use both an image name and build configuration.
  - Service user settings are preserved when running commands and dependencies.
  - Additional Compose options are safely ignored when unsupported, improving compatibility.
  - Port, environment, volume, and working-directory settings continue to be handled consistently.

- **Documentation**
  - Updated documentation to clarify supported Compose features, native parsing, ephemeral containers, limitations, and delegation options.

- **Release**
  - Updated the application version to 0.16.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->