### PR TITLE
feat(sync): warn when sync.image/build are set but sync.mode is exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,13 @@ bind-mounted](#slow-boot-when-the-app-directory-is-bind-mounted) for why. A `syn
 that problem to `wip`: the source is mounted read-only, the app runs off a named volume, and wip
 mirrors one into the other with `rsync`.
 
+Under `sync.mode: exec` (the default for `mode: container`/`compose-native`), that `rsync` runs
+inside the already-running primary container, so the image it's built from must have `rsync`
+installed — `sync.image`/`sync.build` are irrelevant here since there's no separate mirror
+container. They only matter under `sync.mode: run`, which mirrors from a throwaway container
+instead and needs its own image with `rsync` (either `sync.image`, or `sync.build` to have `wip`
+build one).
+
 ```yaml
 sync:
   source: .          # host path, relative to wip.yml (default: the wip.yml directory)

--- a/README.md
+++ b/README.md
@@ -153,12 +153,14 @@ bind-mounted](#slow-boot-when-the-app-directory-is-bind-mounted) for why. A `syn
 that problem to `wip`: the source is mounted read-only, the app runs off a named volume, and wip
 mirrors one into the other with `rsync`.
 
-Under `sync.mode: exec` (the default for `mode: container`/`compose-native`), that `rsync` runs
-inside the already-running primary container, so the image it's built from must have `rsync`
-installed — `sync.image`/`sync.build` are irrelevant here since there's no separate mirror
-container. They only matter under `sync.mode: run`, which mirrors from a throwaway container
-instead and needs its own image with `rsync` (either `sync.image`, or `sync.build` to have `wip`
-build one).
+`wip up`'s pre-boot mirror always uses a throwaway container (the primary one isn't running yet),
+so `sync.image`/`sync.build` apply there regardless of `sync.mode` — falling back to the primary
+container's own image if neither is set. Where `sync.mode` actually matters is every mirror
+*after* that: under `sync.mode: exec` (the default for `mode: container`/`compose-native`), `wip
+sync`/`wip sync --watch` run `rsync` inside the already-running primary container instead, so
+*that* image needs `rsync` installed — `sync.image`/`sync.build` are ignored for these. Under
+`sync.mode: run`, every mirror (pre-boot included) uses a throwaway container, so `sync.image`/
+`sync.build` (or the primary image fallback) need `rsync` throughout.
 
 ```yaml
 sync:

--- a/README.md
+++ b/README.md
@@ -155,12 +155,14 @@ mirrors one into the other with `rsync`.
 
 `wip up`'s pre-boot mirror always uses a throwaway container (the primary one isn't running yet),
 so `sync.image`/`sync.build` apply there regardless of `sync.mode` — falling back to the primary
-container's own image if neither is set. Where `sync.mode` actually matters is every mirror
+container's own image if neither is set under `mode: container`/`compose-native` (both have a
+`dependencies:` entry to borrow it from); `mode: compose` has no such entry, so one of
+`sync.image`/`sync.build` is required there. Where `sync.mode` actually matters is every mirror
 *after* that: under `sync.mode: exec` (the default for `mode: container`/`compose-native`), `wip
 sync`/`wip sync --watch` run `rsync` inside the already-running primary container instead, so
 *that* image needs `rsync` installed — `sync.image`/`sync.build` are ignored for these. Under
 `sync.mode: run`, every mirror (pre-boot included) uses a throwaway container, so `sync.image`/
-`sync.build` (or the primary image fallback) need `rsync` throughout.
+`sync.build` (or the primary image fallback, where available) need `rsync` throughout.
 
 ```yaml
 sync:

--- a/lib/wip/doctor.rb
+++ b/lib/wip/doctor.rb
@@ -138,6 +138,10 @@ module Wip
       results << result(File.directory?(sync.source) ? :ok : :fail,
                         "Sync source #{sync.source} mirrors into volume #{sync.volume} at #{sync.target}",
                         "Sync source not found: #{sync.source}")
+      return unless sync.exec? && (sync.image || sync.build)
+
+      results << Result.new(:warn, 'sync.image/sync.build are set but sync.mode is exec, so they are ignored ' \
+                                   '(only sync.mode: run mirrors from a separate image)')
     end
 
     def result(condition, ok_message, fail_message)

--- a/lib/wip/doctor.rb
+++ b/lib/wip/doctor.rb
@@ -140,8 +140,10 @@ module Wip
                         "Sync source not found: #{sync.source}")
       return unless sync.exec? && (sync.image || sync.build)
 
-      results << Result.new(:warn, 'sync.image/sync.build are set but sync.mode is exec, so they are ignored ' \
-                                   '(only sync.mode: run mirrors from a separate image)')
+      results << Result.new(:warn, 'sync.image/sync.build only cover `wip up`’s one-time pre-boot mirror ' \
+                                   '(the primary container isn’t running yet, so that step always uses a ' \
+                                   'throwaway container) — sync.mode: exec’s `wip sync`/`wip sync --watch` run ' \
+                                   'rsync inside the primary container instead, so its image needs rsync too')
     end
 
     def result(condition, ok_message, fail_message)

--- a/lib/wip/initializer.rb
+++ b/lib/wip/initializer.rb
@@ -122,7 +122,11 @@ module Wip
         # optional; exec (default, mirrors into the running container) | run (always a fresh container)
         mode: exec
 
-        # only needed if sync.mode: run (or under mode: compose); image the mirror container runs
+        # image/build below only matter under sync.mode: run (a throwaway mirror container) — with
+        # mode: exec above (the default here), rsync runs inside the already-running container
+        # instead, so neither is read. That container's own image needs rsync installed either way.
+
+        # image the mirror container runs, if sync.mode: run
         # image: your/image:tag
 
         # alternative to image — let wip build a small dedicated mirror image itself

--- a/lib/wip/initializer.rb
+++ b/lib/wip/initializer.rb
@@ -122,11 +122,13 @@ module Wip
         # optional; exec (default, mirrors into the running container) | run (always a fresh container)
         mode: exec
 
-        # image/build below only matter under sync.mode: run (a throwaway mirror container) — with
-        # mode: exec above (the default here), rsync runs inside the already-running container
-        # instead, so neither is read. That container's own image needs rsync installed either way.
+        # image/build below always cover `wip up`'s pre-boot mirror (a throwaway container, since
+        # the primary one isn't running yet — falls back to the primary image if neither is set).
+        # With mode: exec above (the default here), `wip sync`/`wip sync --watch` afterward run
+        # rsync inside the already-running primary container instead, so its own image needs
+        # rsync installed too — image/build below aren't read for those.
 
-        # image the mirror container runs, if sync.mode: run
+        # image the pre-boot (and, under sync.mode: run, every) mirror container runs
         # image: your/image:tag
 
         # alternative to image — let wip build a small dedicated mirror image itself

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.15.0'
+  VERSION = '0.16.0'
 end

--- a/spec/wip/doctor_spec.rb
+++ b/spec/wip/doctor_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Wip::Doctor do
                                                            message: a_string_matching(%r{volume app-src at /app})))
   end
 
-  it 'warns when sync.image/sync.build are set but sync.mode is exec' do
+  it 'warns when sync.image is set with sync.mode: exec' do
     results = results_for(<<~YAML)
       version: 1
       container: app
@@ -56,7 +56,26 @@ RSpec.describe Wip::Doctor do
     YAML
 
     expect(results).to include(an_object_having_attributes(
-                                 level: :warn, message: a_string_matching(/ignored/)
+                                 level: :warn, message: a_string_matching(/pre-boot mirror/)
+                               ))
+  end
+
+  it 'warns when sync.build is set with sync.mode: exec' do
+    results = results_for(<<~YAML)
+      version: 1
+      container: app
+      dependencies:
+        app:
+          image: example:dev
+      sync:
+        mode: exec
+        build:
+          dockerfile: |
+            FROM alpine:latest
+    YAML
+
+    expect(results).to include(an_object_having_attributes(
+                                 level: :warn, message: a_string_matching(/pre-boot mirror/)
                                ))
   end
 

--- a/spec/wip/doctor_spec.rb
+++ b/spec/wip/doctor_spec.rb
@@ -43,6 +43,23 @@ RSpec.describe Wip::Doctor do
                                                            message: a_string_matching(%r{volume app-src at /app})))
   end
 
+  it 'warns when sync.image/sync.build are set but sync.mode is exec' do
+    results = results_for(<<~YAML)
+      version: 1
+      container: app
+      dependencies:
+        app:
+          image: example:dev
+      sync:
+        mode: exec
+        image: some/image:tag
+    YAML
+
+    expect(results).to include(an_object_having_attributes(
+                                 level: :warn, message: a_string_matching(/ignored/)
+                               ))
+  end
+
   it 'reports a missing primary container as a failed check' do
     results = results_for(<<~YAML)
       version: 1


### PR DESCRIPTION
## Summary
- `wip doctor` now emits a `[WARN]` when `sync.image`/`sync.build` are set while `sync.mode` is `exec` (the default) — that combination is silently ignored today since `exec` mirrors inside the already-running primary container instead of a separate one, and it's an easy trap to fall into.
- `wip init`'s scaffolded `sync:` block now says explicitly that `image`/`build` only matter under `sync.mode: run`.
- README's Source sync section spells out which mode needs `rsync` installed where (the primary container's own image under `exec`, a separate image under `run`).
- Bumped version to v0.16.0.

## Test plan
- [x] `bundle exec rspec` (207 examples, 0 failures)
- [x] `bundle exec rubocop` (no offenses)
- [x] Added a doctor spec covering the new warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the differences between `sync.mode: exec` and `sync.mode: run`.
  * Documented image and build settings for each mode, including the `rsync` requirement for exec mode.

* **Bug Fixes**
  * Added a warning when image or build settings are ignored in exec mode.

* **Chores**
  * Updated the release version to 0.16.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->