### PR TITLE
chore(init): drop sync.image/build example from the scaffold

### DIFF
--- a/lib/wip/initializer.rb
+++ b/lib/wip/initializer.rb
@@ -122,23 +122,7 @@ module Wip
         # optional; exec (default, mirrors into the running container) | run (always a fresh container)
         mode: exec
 
-        # image/build below always cover `wip up`'s pre-boot mirror (a throwaway container, since
-        # the primary one isn't running yet — falls back to the primary image if neither is set).
-        # With mode: exec above (the default here), `wip sync`/`wip sync --watch` afterward run
-        # rsync inside the already-running primary container instead, so its own image needs
-        # rsync installed too — image/build below aren't read for those.
-
-        # image the pre-boot (and, under sync.mode: run, every) mirror container runs
-        # image: your/image:tag
-
-        # alternative to image — let wip build a small dedicated mirror image itself
-        # build:
-        #   dockerfile: |
-        #     FROM alpine:latest
-        #     RUN apk add --no-cache rsync
-
-        #   optional (default: wip-sync-<container>:latest)
-        #   tag: wip-sync-app:latest
+        # sync.image/sync.build — only needed for sync.mode: run; see README "Source sync"
       YAML
     end
 

--- a/lib/wip/initializer.rb
+++ b/lib/wip/initializer.rb
@@ -122,7 +122,7 @@ module Wip
         # optional; exec (default, mirrors into the running container) | run (always a fresh container)
         mode: exec
 
-        # sync.image/sync.build — only needed for sync.mode: run; see README "Source sync"
+        # sync.image/sync.build — required for mode: compose and used by sync.mode: run; see README "Source sync"
       YAML
     end
 

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.17.0'
+  VERSION = '0.17.1'
 end


### PR DESCRIPTION
## Summary
- `wip init`'s scaffolded `sync:` block no longer includes the `image`/`build` example — it only matters under `sync.mode: run`, and showing it unconditionally (default is `sync.mode: exec` for `mode: container`/`compose-native`) has caused confusion twice over already. Replaced with a one-line pointer to the README's "Source sync" section.
- Bumped version to v0.17.1 (patch, on top of the v0.17.0 already merged via #37/#38).

## Test plan
- [x] `bundle exec rspec` (212 examples, 0 failures)
- [x] `bundle exec rubocop` (no offenses)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Simplified configuration guidance for synchronization settings.
  - Clarified that image and build options are required for compose mode and used by run mode.
  - Removed lengthy examples and comments for a more concise reference.
  - Directed readers to the README for complete configuration details.

- **Chores**
  - Updated the package version to 0.17.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->