### PR TITLE
fix(command_runner): scrub captured output before interpreting errors

### DIFF
--- a/lib/wip/command_runner.rb
+++ b/lib/wip/command_runner.rb
@@ -26,8 +26,7 @@ module Wip
         threads.each(&:join)
         status = wait.value
       end
-      hint = @interpreter.interpret(captured.force_encoding(Encoding::UTF_8).scrub)
-      @stderr.puts("\n#{hint}") if !status.success? && hint
+      report_hint(captured) unless status.success?
       status.exitstatus
     rescue Errno::ENOENT => e
       @stderr.puts e.message
@@ -38,6 +37,11 @@ module Wip
     end
 
     private
+
+    def report_hint(captured)
+      hint = @interpreter.interpret(captured.force_encoding(Encoding::UTF_8).scrub)
+      @stderr.puts("\n#{hint}") if hint
+    end
 
     # Piping stdin/stdout/stderr (as `run` does above) closes the child's
     # stdin immediately, which breaks anything that reads from the terminal

--- a/lib/wip/command_runner.rb
+++ b/lib/wip/command_runner.rb
@@ -26,7 +26,7 @@ module Wip
         threads.each(&:join)
         status = wait.value
       end
-      hint = @interpreter.interpret(captured)
+      hint = @interpreter.interpret(captured.force_encoding(Encoding::UTF_8).scrub)
       @stderr.puts("\n#{hint}") if !status.success? && hint
       status.exitstatus
     rescue Errno::ENOENT => e

--- a/spec/wip/command_runner_spec.rb
+++ b/spec/wip/command_runner_spec.rb
@@ -29,6 +29,22 @@ RSpec.describe Wip::CommandRunner do
     expect(stderr.string).to include('wip: interrupted')
   end
 
+  it 'interprets output containing invalid UTF-8 bytes instead of raising an encoding error' do
+    stderr = StringIO.new
+    runner = described_class.new(stderr: stderr)
+    script = <<~'RUBY'
+      STDOUT.binmode
+      STDOUT.write("\xFF\xFE".b)
+      STDOUT.write('too many mounted volumes')
+      exit 1
+    RUBY
+
+    expect {
+      runner.run([RbConfig.ruby, '-e', script])
+    }.not_to raise_error
+    expect(stderr.string).to include('mounted-volume limit')
+  end
+
   it "doesn't let a pump thread's IOError escape when its stream is closed early" do
     source = Object.new
     def source.readpartial(_size)

--- a/spec/wip/command_runner_spec.rb
+++ b/spec/wip/command_runner_spec.rb
@@ -30,8 +30,9 @@ RSpec.describe Wip::CommandRunner do
   end
 
   it 'interprets output containing invalid UTF-8 bytes instead of raising an encoding error' do
+    stdout = StringIO.new(+''.b)
     stderr = StringIO.new
-    runner = described_class.new(stderr: stderr)
+    runner = described_class.new(stdout: stdout, stderr: stderr)
     script = <<~'RUBY'
       STDOUT.binmode
       STDOUT.write("\xFF\xFE".b)
@@ -39,9 +40,11 @@ RSpec.describe Wip::CommandRunner do
       exit 1
     RUBY
 
+    status = nil
     expect do
-      runner.run([RbConfig.ruby, '-e', script])
+      status = runner.run([RbConfig.ruby, '-e', script])
     end.not_to raise_error
+    expect(status).to eq(1)
     expect(stderr.string).to include('mounted-volume limit')
   end
 

--- a/spec/wip/command_runner_spec.rb
+++ b/spec/wip/command_runner_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe Wip::CommandRunner do
       exit 1
     RUBY
 
-    expect {
+    expect do
       runner.run([RbConfig.ruby, '-e', script])
-    }.not_to raise_error
+    end.not_to raise_error
     expect(stderr.string).to include('mounted-volume limit')
   end
 


### PR DESCRIPTION
## Summary
- `CommandRunner#run` captures subprocess stdout/stderr into a string that starts tagged UTF-8, but appending raw bytes can flip it to BINARY (ASCII-8BIT) when a multi-byte character (e.g. from Docker/buildkit progress output) is split across a chunk boundary.
- `ErrorInterpreter#interpret` then matches that BINARY string against a UTF-8 regex containing Japanese text, and Ruby raises `Encoding::CompatibilityError` instead of returning a hint — crashing `wip` entirely rather than surfacing the underlying command failure.
- Fix: sanitize captured output (`force_encoding(UTF_8).scrub`) before handing it to the interpreter.

## Test plan
- [x] Added a regression test in `spec/wip/command_runner_spec.rb` that feeds invalid UTF-8 bytes mixed with error text and asserts no exception is raised
- [x] `bundle exec rspec` — 213 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid text in captured command output.
  * Commands with malformed output now complete without raising an error and provide the appropriate failure status and message.

* **Tests**
  * Added regression coverage for commands producing invalid UTF-8 output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->