### PR TITLE
fix(build): report staging progress every interval

### DIFF
--- a/lib/wip/build_context.rb
+++ b/lib/wip/build_context.rb
@@ -14,9 +14,8 @@ module Wip
       @ignore = ignore || DockerIgnore.load(@root.join('.dockerignore'))
     end
 
-    # on_progress fires once per file copied, as `|count, total|` — so a caller
-    # can show that staging a large context (thousands of small files can take
-    # tens of seconds) is still moving instead of looking hung.
+    # on_progress fires before copying and after each file, as `|count, total|`,
+    # so a caller can report elapsed progress even while copying one large file.
     def stage(on_progress: nil)
       return yield @root.to_s if @ignore.empty?
 
@@ -30,6 +29,7 @@ module Wip
 
     def copy_included_files(destination, on_progress)
       files = included_files
+      on_progress&.call(0, files.size)
       files.each_with_index do |relative_path, index|
         target = destination.join(relative_path)
         FileUtils.mkdir_p(target.dirname)

--- a/lib/wip/staging_progress.rb
+++ b/lib/wip/staging_progress.rb
@@ -1,35 +1,61 @@
 # frozen_string_literal: true
 
 module Wip
-  # Prints a self-overwriting "copying build context files: N/total" line, at
-  # most every half second, while a slow, silent step (staging a large build
-  # context file by file can take tens of seconds) is still moving — so it
-  # doesn't read as hung.
+  # Prints a self-overwriting "copying build context files: N/total" line
+  # every half second while a slow, silent step is running. Reporting runs on
+  # its own thread so a single large file does not make progress appear hung.
   class StagingProgress
     def initialize(out: $stderr, interval: 0.5)
       @out = out
       @interval = interval
-      # Backdated so the very first tick always prints immediately, rather
-      # than waiting a full interval before the first sign of life.
-      @last = Process.clock_gettime(Process::CLOCK_MONOTONIC) - interval
+      @mutex = Mutex.new
+      @condition = ConditionVariable.new
+      @worker = nil
+      @stopped = false
       @printed = false
     end
 
     def tick(count, total)
-      now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      return if now - @last < @interval && count != total
-
-      @last = now
-      @printed = true
-      @out.print "\rwip: copying build context files: #{count}/#{total}"
+      @mutex.synchronize do
+        @count = count
+        @total = total
+        print_progress if @worker.nil? || count == total
+        @worker ||= Thread.new { report_on_interval }
+      end
     end
 
     # Idempotent: a caller can't know in advance whether tick ever fired.
     def finish
-      return unless @printed
+      worker = @mutex.synchronize do
+        return unless @worker
 
-      @printed = false
-      @out.puts
+        @stopped = true
+        @condition.broadcast
+        @worker
+      end
+      worker.join
+
+      @mutex.synchronize do
+        @worker = nil
+        @printed = false
+        @out.puts
+      end
+    end
+
+    private
+
+    def report_on_interval
+      @mutex.synchronize do
+        until @stopped
+          @condition.wait(@mutex, @interval)
+          print_progress unless @stopped
+        end
+      end
+    end
+
+    def print_progress
+      @printed = true
+      @out.print "\rwip: copying build context files: #{@count}/#{@total}"
     end
   end
 end

--- a/lib/wip/staging_progress.rb
+++ b/lib/wip/staging_progress.rb
@@ -12,7 +12,6 @@ module Wip
       @condition = ConditionVariable.new
       @worker = nil
       @stopped = false
-      @printed = false
     end
 
     def tick(count, total)
@@ -20,7 +19,10 @@ module Wip
         @count = count
         @total = total
         print_progress if @worker.nil? || count == total
-        @worker ||= Thread.new { report_on_interval }
+        unless @worker
+          @stopped = false
+          @worker = Thread.new { report_on_interval }
+        end
       end
     end
 
@@ -37,8 +39,8 @@ module Wip
 
       @mutex.synchronize do
         @worker = nil
-        @printed = false
         @out.puts
+        @out.flush
       end
     end
 
@@ -54,8 +56,8 @@ module Wip
     end
 
     def print_progress
-      @printed = true
       @out.print "\rwip: copying build context files: #{@count}/#{@total}"
+      @out.flush
     end
   end
 end

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.17.3'
+  VERSION = '0.17.4'
 end

--- a/spec/wip/build_context_spec.rb
+++ b/spec/wip/build_context_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Wip::BuildContext do
     end
   end
 
-  it 'calls on_progress with (count, total) once per staged file, and not at all when there is nothing to copy' do
+  it 'calls on_progress before copying and after every staged file, and not at all when staging is skipped' do
     Dir.mktmpdir do |dir|
       File.write(File.join(dir, '.dockerignore'), "node_modules\n")
       File.write(File.join(dir, 'app.rb'), '')
@@ -60,7 +60,7 @@ RSpec.describe Wip::BuildContext do
       described_class.new(dir).stage(on_progress: ->(count, total) { calls << [count, total] }) { |_staged| nil }
 
       # .dockerignore, app.rb, app_spec.rb — node_modules/pkg.js is excluded.
-      expect(calls).to eq([[1, 3], [2, 3], [3, 3]])
+      expect(calls).to eq([[0, 3], [1, 3], [2, 3], [3, 3]])
     end
 
     Dir.mktmpdir do |dir|
@@ -93,7 +93,7 @@ RSpec.describe Wip::BuildContext do
         counts_seen_by_progress << [count, completed]
       }) { |_staged| nil }
 
-      expect(counts_seen_by_progress).to eq([[1, 1], [2, 2], [3, 3]])
+      expect(counts_seen_by_progress).to eq([[0, 0], [1, 1], [2, 2], [3, 3]])
     end
   end
 

--- a/spec/wip/staging_progress_spec.rb
+++ b/spec/wip/staging_progress_spec.rb
@@ -2,21 +2,22 @@
 
 require 'spec_helper'
 require 'stringio'
+require 'timeout'
 
 RSpec.describe Wip::StagingProgress do
   it 'prints the latest count/total every interval even when no new tick arrives' do
-    out = StringIO.new
+    writes = Queue.new
+    out = instance_double(IO, print: nil, puts: nil, flush: nil)
+    allow(out).to receive(:print) { |text| writes << text }
     progress = described_class.new(out: out, interval: 0.01)
 
     progress.tick(1, 10)
-    expect(out.string).to eq("\rwip: copying build context files: 1/10")
+    expect(writes.pop).to eq("\rwip: copying build context files: 1/10")
 
     progress.tick(2, 10)
-    expect(out.string).to eq("\rwip: copying build context files: 1/10")
-
-    sleep 0.03
+    expect(Timeout.timeout(1) { writes.pop }).to eq("\rwip: copying build context files: 2/10")
     progress.finish
-    expect(out.string).to include("\rwip: copying build context files: 2/10")
+    expect(out).to have_received(:flush).at_least(:twice)
   end
 
   it 'always prints the final count/total, even mid-interval' do

--- a/spec/wip/staging_progress_spec.rb
+++ b/spec/wip/staging_progress_spec.rb
@@ -4,22 +4,19 @@ require 'spec_helper'
 require 'stringio'
 
 RSpec.describe Wip::StagingProgress do
-  it 'prints a count/total line, throttled to at most one per interval' do
+  it 'prints the latest count/total every interval even when no new tick arrives' do
     out = StringIO.new
-    clock = [0.0]
-    allow(Process).to(receive(:clock_gettime).and_wrap_original { clock.first })
-    progress = described_class.new(out: out, interval: 1)
+    progress = described_class.new(out: out, interval: 0.01)
 
     progress.tick(1, 10)
     expect(out.string).to eq("\rwip: copying build context files: 1/10")
 
-    clock[0] = 0.5
     progress.tick(2, 10)
     expect(out.string).to eq("\rwip: copying build context files: 1/10")
 
-    clock[0] = 1.5
-    progress.tick(3, 10)
-    expect(out.string).to eq("\rwip: copying build context files: 1/10\rwip: copying build context files: 3/10")
+    sleep 0.03
+    progress.finish
+    expect(out.string).to include("\rwip: copying build context files: 2/10")
   end
 
   it 'always prints the final count/total, even mid-interval' do


### PR DESCRIPTION
### Motivation
- Staging progress only appeared when copying finished or on ticks, so long single-file copies looked hung; progress should be emitted every 0.5s while staging is active.
- The patch version is bumped to reflect this bugfix.

### Description
- Implement a background reporter in `Wip::StagingProgress` using `Mutex`, `ConditionVariable`, and a worker `Thread` to print the latest `count/total` every `@interval` and to stop/join cleanly in `finish`.
- Emit an initial `on_progress` callback before any file is copied by adding `on_progress&.call(0, files.size)` in `BuildContext#copy_included_files` so progress starts immediately even for large first file copies.
- Update specs in `spec/wip/staging_progress_spec.rb` and `spec/wip/build_context_spec.rb` to reflect the new periodic reporting and initial `0/total` callback behavior.
- Bump `Wip::VERSION` from `0.17.3` to `0.17.4`.

### Testing
- `ruby -c lib/wip/staging_progress.rb` succeeded.
- `ruby -c lib/wip/build_context.rb` succeeded.
- Executed a runtime timing assertion with `ruby -Ilib -e 'require "stringio"; require "wip/staging_progress"; ...'` which validated repeated interval output and final newline and succeeded.
- `git diff --check` succeeded.
- `bundle exec rake` could not be run because required gems (`rspec (~> 3.13)`) were not installed, and `bundle install` failed due to rubygems.org returning HTTP 403, so full test suite execution was blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70ceb4dd7483229e9400007f8c35b5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Staging progress now updates periodically in the background, even when no new files are reported.
  * Progress callbacks now report an initial zero-completed state before copying begins, followed by updates after each file.

* **Bug Fixes**
  * Improved progress reporting shutdown and completion handling.

* **Chores**
  * Updated the release version to 0.17.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->