### PR TITLE
fix(build): show staging progress and stream build output live

### DIFF
--- a/lib/wip/build_context.rb
+++ b/lib/wip/build_context.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'find'
 require 'fileutils'
 require 'pathname'
 require 'tmpdir'
@@ -41,13 +42,28 @@ module Wip
       end
     end
 
+    # Walks the tree by hand (rather than Dir.glob-ing it all up front) so an
+    # ignored directory — node_modules, vendor/bundle, a multi-gigabyte
+    # storage/ — is never descended into just to be thrown away afterward.
     def included_files
-      Dir.glob('**/*', File::FNM_DOTMATCH, base: @root.to_s).select do |entry|
-        next false if %w[. ..].include?(entry)
+      result = []
+      Find.find(@root.to_s) do |path|
+        next if path == @root.to_s
 
-        path = @root.join(entry)
-        (path.file? || path.symlink?) && !@ignore.ignored?(entry)
+        entry = Pathname(path).relative_path_from(@root).to_s
+        result << entry if visit?(path, entry)
       end
+      result
+    end
+
+    # Returns whether `path` belongs in the staged context, pruning the walk
+    # when it's an ignored directory so nothing under it is even visited.
+    def visit?(path, entry)
+      ignored = @ignore.ignored?(entry)
+      return !ignored unless !File.symlink?(path) && File.directory?(path)
+
+      Find.prune if ignored
+      false
     end
   end
 end

--- a/lib/wip/build_context.rb
+++ b/lib/wip/build_context.rb
@@ -57,13 +57,16 @@ module Wip
     end
 
     # Returns whether `path` belongs in the staged context, pruning the walk
-    # when it's an ignored directory so nothing under it is even visited.
+    # when it's an ignored directory so nothing under it is even visited —
+    # unless a later negated rule could still re-include something beneath it.
     def visit?(path, entry)
       ignored = @ignore.ignored?(entry)
-      return !ignored unless !File.symlink?(path) && File.directory?(path)
+      if !File.symlink?(path) && File.directory?(path)
+        Find.prune if ignored && @ignore.prunable?(entry)
+        return false
+      end
 
-      Find.prune if ignored
-      false
+      !ignored && (File.file?(path) || File.symlink?(path))
     end
   end
 end

--- a/lib/wip/cli.rb
+++ b/lib/wip/cli.rb
@@ -74,7 +74,8 @@ module Wip
       progress = StagingProgress.new
       BuildContext.new(context).stage(on_progress: progress.method(:tick)) do |staged_context|
         progress.finish
-        execute(builder.build(settings: settings.merge('context' => staged_context), extra: extra))
+        built = builder.build(settings: settings.merge('context' => staged_context), extra: extra)
+        execute(built, interactive: tty?(true))
       end
     ensure
       progress&.finish
@@ -313,7 +314,8 @@ module Wip
       progress = StagingProgress.new
       BuildContext.new(spec['context']).stage(on_progress: progress.method(:tick)) do |staged_context|
         progress.finish
-        execute(builder.build(settings: { 'context' => staged_context, 'tag' => spec['tag'] }, extra: extra))
+        settings = { 'context' => staged_context, 'tag' => spec['tag'] }
+        execute(builder.build(settings: settings, extra: extra), interactive: tty?(true))
       end
     ensure
       progress&.finish

--- a/lib/wip/cli.rb
+++ b/lib/wip/cli.rb
@@ -69,7 +69,7 @@ module Wip
     def build(*extra)
       extra.shift if extra.first == '--'
       settings = load_config.command('build') || {}
-      context = settings['context'] || '.'
+      context = Pathname(load_config.path).dirname.join(settings['context'] || '.').to_s
       warn "wip: staging build context (#{context})"
       progress = StagingProgress.new
       BuildContext.new(context).stage(on_progress: progress.method(:tick)) do |staged_context|
@@ -301,11 +301,22 @@ module Wip
     # `wip up` invocation, mirroring ensure_sync_image's "build once, not every tick"
     # approach. A no-op for mode: container/compose and for build:-less services.
     def ensure_compose_images
-      load_config.compose_build_specs.each_value do |spec|
-        extra = spec['dockerfile'] ? ['-f', spec['dockerfile']] : []
-        spec['args']&.each { |key, value| extra.push('--build-arg', "#{key}=#{value}") }
-        execute(builder.build(settings: { 'context' => spec['context'], 'tag' => spec['tag'] }, extra: extra))
+      load_config.compose_build_specs.each_value { |spec| build_compose_image(spec) }
+    end
+
+    # Stages spec['context'] the same way `wip build` does, so a .dockerignore next to
+    # a compose-native service's build: is honored and progress is reported here too.
+    def build_compose_image(spec)
+      extra = spec['dockerfile'] ? ['-f', spec['dockerfile']] : []
+      spec['args']&.each { |key, value| extra.push('--build-arg', "#{key}=#{value}") }
+      warn "wip: staging build context (#{spec['context']})"
+      progress = StagingProgress.new
+      BuildContext.new(spec['context']).stage(on_progress: progress.method(:tick)) do |staged_context|
+        progress.finish
+        execute(builder.build(settings: { 'context' => staged_context, 'tag' => spec['tag'] }, extra: extra))
       end
+    ensure
+      progress&.finish
     end
 
     # Builds sync.build's image once per invocation (not per --watch tick, which

--- a/lib/wip/command_runner.rb
+++ b/lib/wip/command_runner.rb
@@ -27,7 +27,7 @@ module Wip
         status = wait.value
       end
       report_hint(captured) unless status.success?
-      status.exitstatus
+      exitstatus(status)
     rescue Errno::ENOENT => e
       @stderr.puts e.message
       127
@@ -37,6 +37,13 @@ module Wip
     end
 
     private
+
+    # exitstatus is nil when the process was killed by a signal instead of
+    # exiting normally; fall back to the conventional 128+signal shell code
+    # so callers always get a comparable integer.
+    def exitstatus(status)
+      status.exitstatus || (128 + status.termsig)
+    end
 
     def report_hint(captured)
       hint = @interpreter.interpret(captured.force_encoding(Encoding::UTF_8).scrub)
@@ -50,7 +57,7 @@ module Wip
     def run_attached(command, env)
       pid = Process.spawn(env, *command)
       _, status = Process.wait2(pid)
-      status.exitstatus
+      exitstatus(status)
     rescue Errno::ENOENT => e
       @stderr.puts e.message
       127

--- a/lib/wip/docker_ignore.rb
+++ b/lib/wip/docker_ignore.rb
@@ -30,7 +30,25 @@ module Wip
       end
     end
 
+    # Whether a walker can stop descending into an ignored directory without
+    # risking a miss: false if some later negated rule (e.g. `!node_modules/pkg`
+    # after `node_modules`) could still match something beneath it.
+    def prunable?(relative_path)
+      dir_components = relative_path.split('/')
+      @rules.none? { |rule| rule.negate && targets_descendant?(rule.pattern, dir_components) }
+    end
+
     private
+
+    def targets_descendant?(pattern, dir_components)
+      pattern_components = pattern.split('/')
+      return true if pattern_components.first == '**'
+      return false if pattern_components.size <= dir_components.size
+
+      pattern_components.first(dir_components.size).each_with_index.all? do |component, i|
+        File.fnmatch(component, dir_components[i], FNMATCH_FLAGS)
+      end
+    end
 
     def parse(line)
       line = line.strip

--- a/lib/wip/doctor.rb
+++ b/lib/wip/doctor.rb
@@ -151,6 +151,8 @@ module Wip
                  condition == :ok ? ok_message : fail_message)
     end
 
-    def command_available?(name) = ENV.fetch('PATH', '').split(File::PATH_SEPARATOR).any? { |dir| File.executable?(File.join(dir, name)) }
+    def command_available?(name)
+      ENV.fetch('PATH', '').split(File::PATH_SEPARATOR).any? { |dir| File.executable?(File.join(dir, name)) }
+    end
   end
 end

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.17.4'
+  VERSION = '0.17.5'
 end

--- a/spec/wip/build_context_spec.rb
+++ b/spec/wip/build_context_spec.rb
@@ -121,6 +121,42 @@ RSpec.describe Wip::BuildContext do
     end
   end
 
+  it 'stages a file re-included by a negated rule under an otherwise-ignored directory' do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, '.dockerignore'), "node_modules\n!node_modules/pkg/index.js\n")
+      FileUtils.mkdir_p(File.join(dir, 'node_modules', 'pkg'))
+      File.write(File.join(dir, 'node_modules', 'pkg', 'index.js'), '')
+      File.write(File.join(dir, 'node_modules', 'pkg', 'other.js'), '')
+
+      staged_files = nil
+      described_class.new(dir).stage do |staged|
+        staged_files = Dir.glob('**/*', File::FNM_DOTMATCH, base: staged).reject { |f| %w[. ..].include?(f) }
+      end
+
+      expect(staged_files).to include(File.join('node_modules', 'pkg', 'index.js'))
+      expect(staged_files).not_to include(File.join('node_modules', 'pkg', 'other.js'))
+    end
+  end
+
+  it 'excludes special files like named pipes even when not ignored' do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, 'app.rb'), '')
+      # A rule that matches nothing forces staging (an empty .dockerignore
+      # skips staging entirely and would just yield the original directory).
+      File.write(File.join(dir, '.dockerignore'), "nonexistent-dir/\n")
+      fifo = File.join(dir, 'a-fifo')
+      system('mkfifo', fifo, exception: true)
+
+      staged_files = nil
+      described_class.new(dir).stage do |staged|
+        staged_files = Dir.glob('**/*', File::FNM_DOTMATCH, base: staged).reject { |f| %w[. ..].include?(f) }
+      end
+
+      expect(staged_files).to include('app.rb', '.dockerignore')
+      expect(staged_files).not_to include('a-fifo')
+    end
+  end
+
   it 'preserves broken symlinks' do
     Dir.mktmpdir do |dir|
       File.write(File.join(dir, '.dockerignore'), "ignored\n")

--- a/spec/wip/build_context_spec.rb
+++ b/spec/wip/build_context_spec.rb
@@ -97,6 +97,30 @@ RSpec.describe Wip::BuildContext do
     end
   end
 
+  it 'never descends into an ignored directory, even one full of files' do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, '.dockerignore'), "node_modules\n")
+      File.write(File.join(dir, 'app.rb'), '')
+      FileUtils.mkdir_p(File.join(dir, 'node_modules', 'pkg'))
+      File.write(File.join(dir, 'node_modules', 'pkg', 'index.js'), '')
+
+      visited = []
+      allow(File).to receive(:directory?).and_wrap_original do |original, path, *args|
+        visited << path
+        original.call(path, *args)
+      end
+
+      staged_files = nil
+      described_class.new(dir).stage do |staged|
+        staged_files = Dir.glob('**/*', File::FNM_DOTMATCH, base: staged).reject { |f| %w[. ..].include?(f) }
+      end
+
+      expect(staged_files).to include('app.rb', '.dockerignore')
+      expect(staged_files.grep(/^node_modules/)).to be_empty
+      expect(visited.grep(%r{node_modules/pkg})).to be_empty
+    end
+  end
+
   it 'preserves broken symlinks' do
     Dir.mktmpdir do |dir|
       File.write(File.join(dir, '.dockerignore'), "ignored\n")

--- a/spec/wip/cli_spec.rb
+++ b/spec/wip/cli_spec.rb
@@ -391,6 +391,38 @@ RSpec.describe Wip::CLI do
     expect(node_modules_present).to be false
   end
 
+  it 'uses an absolute build context unchanged instead of resolving it under the config directory' do
+    Dir.mktmpdir do |context_dir|
+      File.write(File.join(context_dir, 'Dockerfile'), "FROM scratch\n")
+      File.write('wip.yml', <<~YAML)
+        version: 1
+        container: app
+        dependencies:
+          app:
+            image: example:dev
+        commands:
+          build:
+            type: build
+            tag: example:dev
+            context: #{context_dir}
+      YAML
+
+      runner = instance_double(Wip::CommandRunner, run: 0)
+      allow(Wip::CommandRunner).to receive(:new).and_return(runner)
+      allow(Wip::CommandResolver).to receive(:new).and_return(instance_double(Wip::CommandResolver,
+                                                                              resolve: 'wslc.exe'))
+      staged_context = nil
+      expect(runner).to receive(:run) do |command, **_kwargs|
+        staged_context = command.last
+        0
+      end
+
+      described_class.start(%w[build])
+
+      expect(staged_context).to eq(context_dir)
+    end
+  end
+
   context 'in compose mode' do
     around do |example|
       Dir.mktmpdir do |dir|


### PR DESCRIPTION
## Summary
- `ensure_compose_images` (compose-native `wip up`) now stages its build context through `BuildContext`/`StagingProgress` instead of bypassing it entirely, so `.dockerignore` is honored and progress prints for compose-native builds too.
- `wip build`'s `context` now resolves relative to the config file's directory (matching every other relative path in `wip.yml`: sync source, env_file, compose network name) instead of `cwd`, fixing silently-wrong staging when using `--config path/to/other/wip.yml`.
- `BuildContext#included_files` now walks the tree by hand and prunes ignored directories during the walk, instead of `Dir.glob`-ing the whole tree up front. A large ignored directory (`node_modules`, `vendor/bundle`, a multi-gigabyte `storage/`) was previously still fully enumerated before being thrown away, making staging look hung.
- `CommandRunner` no longer crashes with `NoMethodError` when a child process is killed by a signal (`Process::Status#exitstatus` is `nil` in that case); falls back to the conventional `128+signal` exit code.
- `wip build` and compose-native builds now attach a real TTY to the build command when the caller has one (`interactive: tty?(true)`), matching `up`/`run`/`exec`. Piped (non-TTY) output was getting fully buffered by the child build process instead of streamed live.

## Test plan
- [x] `bundle exec rspec` (228 examples, 0 failures)
- [x] `bundle exec rubocop`
- [x] Manually verified against a real project (`slidict.io`, `mode: compose-native`) via `--config ../slidict.io/wip.yml`: context resolves correctly, large ignored directories (`storage/`, `vendor/bundle`, `node_modules`) are no longer walked, and staging progress prints live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved build context processing by skipping ignored directories early, reducing unnecessary work for large directories.

* **Bug Fixes**
  * Preserved absolute build context paths during builds.
  * Improved handling of ignored and re-included files, including special files.
  * Standardized exit codes when commands are terminated by signals.
  * Improved compose image builds with staged contexts and progress reporting.

* **Tests**
  * Added coverage for ignore rules, directory traversal, special files, and absolute build contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->