### PR TITLE
fix(build): reuse image cache by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,8 +370,8 @@ valid compose.yml over sections it doesn't need to look at:
 | `wip version` | wip's version, plus WSLC's if it can be detected |
 | `wip doctor` | Diagnose WSL2, interop, WSLC, config, architecture, and Git |
 | `wip config` | Print the effective configuration (secrets masked) |
-| `wip build -- --no-cache` | Build the image from the `build` definition |
-| `wip up [-d] [--no-sync]` | Start the primary `dependencies:` entry (`container:` names which one) and its sidecars (creating any that are missing, on `network:` if set). `-d` runs the main container in the background; with `sync:` configured, the source is mirrored into the volume first unless `--no-sync` |
+| `wip build [--no-cache] [-- OPTIONS]` | Build the image from the `build` definition. By default, wip passes the target tag as `--cache-from` so previous layers can be reused; `--no-cache` disables that cache path. |
+| `wip up [-d] [--no-sync] [--no-cache]` | Start the primary `dependencies:` entry (`container:` names which one) and its sidecars (creating any that are missing, on `network:` if set). `-d` runs the main container in the background; with `sync:` configured, the source is mirrored into the volume first unless `--no-sync` |
 | `wip down` | Stop and remove the primary container and its sidecar `dependencies:` |
 | `wip exec [--no-interactive] COMMAND...` | Run a command in the existing container |
 | `wip run [--no-interactive] COMMAND...` | Run a command in a new `--rm` container (mode: compose `exec`s into `compose.service` instead — see "Compose mode" above) |

--- a/lib/wip/cli.rb
+++ b/lib/wip/cli.rb
@@ -68,8 +68,7 @@ module Wip
     desc 'build [OPTIONS]', 'Build the configured image'
     option :no_cache, type: :boolean, default: false, desc: 'Build without using cached layers'
     def build(*extra)
-      extra.shift if extra.first == '--'
-      extra.unshift('--no-cache') if options[:no_cache] && !extra.include?('--no-cache')
+      extra = build_extra_options(extra)
       settings = load_config.command('build') || {}
       context = Pathname(load_config.path).dirname.join(settings['context'] || '.').to_s
       warn "wip: staging build context (#{context})"
@@ -311,18 +310,33 @@ module Wip
     # Stages spec['context'] the same way `wip build` does, so a .dockerignore next to
     # a compose-native service's build: is honored and progress is reported here too.
     def build_compose_image(spec)
-      extra = spec['dockerfile'] ? ['-f', spec['dockerfile']] : []
-      spec['args']&.each { |key, value| extra.push('--build-arg', "#{key}=#{value}") }
+      extra = compose_build_extra(spec)
       warn "wip: staging build context (#{spec['context']})"
       progress = StagingProgress.new
       BuildContext.new(spec['context']).stage(on_progress: progress.method(:tick)) do |staged_context|
         progress.finish
         settings = { 'context' => staged_context, 'tag' => spec['tag'] }
-        extra.unshift('--no-cache') if options[:no_cache] && !extra.include?('--no-cache')
         execute(builder.build(settings: settings, extra: extra), interactive: tty?(true))
       end
     ensure
       progress&.finish
+    end
+
+    def build_extra_options(extra)
+      extra = extra.dup
+      extra.shift if extra.first == '--'
+      with_no_cache_option(extra)
+    end
+
+    def compose_build_extra(spec)
+      extra = spec['dockerfile'] ? ['-f', spec['dockerfile']] : []
+      spec['args']&.each { |key, value| extra.push('--build-arg', "#{key}=#{value}") }
+      with_no_cache_option(extra)
+    end
+
+    def with_no_cache_option(extra)
+      extra.unshift('--no-cache') if options[:no_cache] && !extra.include?('--no-cache')
+      extra
     end
 
     # Builds sync.build's image once per invocation (not per --watch tick, which

--- a/lib/wip/cli.rb
+++ b/lib/wip/cli.rb
@@ -66,8 +66,10 @@ module Wip
     end
 
     desc 'build [OPTIONS]', 'Build the configured image'
+    option :no_cache, type: :boolean, default: false, desc: 'Build without using cached layers'
     def build(*extra)
       extra.shift if extra.first == '--'
+      extra.unshift('--no-cache') if options[:no_cache] && !extra.include?('--no-cache')
       settings = load_config.command('build') || {}
       context = Pathname(load_config.path).dirname.join(settings['context'] || '.').to_s
       warn "wip: staging build context (#{context})"
@@ -84,6 +86,7 @@ module Wip
     desc 'up', 'Start the configured container and its dependencies, creating them if necessary'
     option :detach, type: :boolean, default: false, aliases: '-d'
     option :sync, type: :boolean, default: true, desc: 'Mirror the source into the sync volume first (--no-sync skips)'
+    option :no_cache, type: :boolean, default: false, desc: 'Build compose-native images without cached layers'
     def up
       if load_config.compose?
         sync_before_boot if options[:sync]
@@ -315,6 +318,7 @@ module Wip
       BuildContext.new(spec['context']).stage(on_progress: progress.method(:tick)) do |staged_context|
         progress.finish
         settings = { 'context' => staged_context, 'tag' => spec['tag'] }
+        extra.unshift('--no-cache') if options[:no_cache] && !extra.include?('--no-cache')
         execute(builder.build(settings: settings, extra: extra), interactive: tty?(true))
       end
     ensure

--- a/lib/wip/command_builder.rb
+++ b/lib/wip/command_builder.rb
@@ -142,7 +142,8 @@ module Wip
       tag = values['tag'] || values['image']
       raise ConfigError, 'Build image/tag must not be empty' if tag.to_s.empty?
 
-      [@wslc, 'build', '-t', tag, *extra, context]
+      cache_options = extra.include?('--no-cache') ? [] : ['--cache-from', tag]
+      [@wslc, 'build', '-t', tag, *cache_options, *extra, context]
     end
 
     def custom(name, arguments)

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.17.5'
+  VERSION = '0.17.6'
 end

--- a/spec/wip/cli_spec.rb
+++ b/spec/wip/cli_spec.rb
@@ -631,7 +631,25 @@ RSpec.describe Wip::CLI do
       described_class.start(%w[up -d])
 
       expect(runner).to have_received(:run).with(
-        ['wslc.exe', 'build', '-t', 'wip-compose-app:latest', File.expand_path('.')], interactive: false
+        ['wslc.exe', 'build', '-t', 'wip-compose-app:latest', '--cache-from', 'wip-compose-app:latest',
+         File.expand_path('.')], interactive: false
+      )
+    end
+
+    it 'disables compose-native build cache when --no-cache is passed to up' do
+      File.write('compose.yml', <<~YAML)
+        services:
+          app:
+            build: .
+      YAML
+      runner = instance_double(Wip::CommandRunner, run: 0)
+      allow(Wip::CommandRunner).to receive(:new).and_return(runner)
+      allow(runner).to receive(:run).and_return(0)
+
+      described_class.start(%w[up --no-cache -d])
+
+      expect(runner).to have_received(:run).with(
+        ['wslc.exe', 'build', '-t', 'wip-compose-app:latest', '--no-cache', File.expand_path('.')], interactive: false
       )
     end
 

--- a/spec/wip/command_builder_spec.rb
+++ b/spec/wip/command_builder_spec.rb
@@ -30,11 +30,10 @@ RSpec.describe Wip::CommandBuilder do
   end
 
   it 'builds images with extra options before context' do
+    expected = %w[wslc.exe build -t example:dev --cache-from example:dev
+                  --build-arg RAILS_ENV=development .]
     expect(builder.build(settings: config.command('build'),
-                         extra: ['--build-arg', 'RAILS_ENV=development'])).to eq(%w[wslc.exe build -t example:dev
-                                                                                     --cache-from example:dev
-                                                                                     --build-arg
-                                                                                     RAILS_ENV=development .])
+                         extra: ['--build-arg', 'RAILS_ENV=development'])).to eq(expected)
   end
 
   it 'omits cache options when building with --no-cache' do

--- a/spec/wip/command_builder_spec.rb
+++ b/spec/wip/command_builder_spec.rb
@@ -31,8 +31,15 @@ RSpec.describe Wip::CommandBuilder do
 
   it 'builds images with extra options before context' do
     expect(builder.build(settings: config.command('build'),
-                         extra: ['--no-cache'])).to eq(%w[wslc.exe build -t example:dev
-                                                          --no-cache .])
+                         extra: ['--build-arg', 'RAILS_ENV=development'])).to eq(%w[wslc.exe build -t example:dev
+                                                                                     --cache-from example:dev
+                                                                                     --build-arg
+                                                                                     RAILS_ENV=development .])
+  end
+
+  it 'omits cache options when building with --no-cache' do
+    expect(builder.build(settings: config.command('build'),
+                         extra: ['--no-cache'])).to eq(%w[wslc.exe build -t example:dev --no-cache .])
   end
 
   it 'appends custom command arguments' do


### PR DESCRIPTION
### Motivation

- `wip up` and `wip build` were rebuilding images without reusing prior build layers, causing unnecessary rebuild time.
- Provide a way to opt out when desired by adding an explicit `--no-cache` flag while making cache reuse the default behavior.

### Description

- Add a `--no-cache` CLI option to `wip build` that forwards `--no-cache` into the underlying build invocation when requested. 
- Add a `--no-cache` CLI option to `wip up` and make compose-native service builds reuse the previous image by passing `--cache-from <tag>` by default unless `--no-cache` is present. 
- Change `CommandBuilder#build` to insert `--cache-from <tag>` when `--no-cache` is not supplied, and update `build_compose_image` to honor the `up` `--no-cache` option; update README and specs accordingly.

### Testing

- Ran Ruby syntax checks with `ruby -c` for the modified files which reported `Syntax OK` for `lib/wip/cli.rb`, `lib/wip/command_builder.rb`, and updated specs. 
- Ran repository checks (`git diff --check`) which passed with no whitespace errors. 
- Attempted to run `rspec` but `bundle exec rspec` could not be executed in this environment because `rspec` is not installed via the bundle (`bundler`/network fetch failed with HTTP 403), so full spec execution was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72782c1d2c8322b0f38d64f187805e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `--no-cache` options to the `build` and `up` commands.
  - Builds now reuse cached layers by default through `--cache-from`, improving build efficiency.
  - Additional build options, including Dockerfile and build-argument settings, are forwarded correctly.
  - Existing `--no-cache` options are preserved without duplication.

- **Documentation**
  - Updated command documentation to describe caching behavior and available options.

- **Chores**
  - Updated the release version to 0.17.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->