### PR TITLE
fix(build): drop unsupported --cache-from, add profiles: support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,7 @@ Metrics/ClassLength:
   Max: 160
   Exclude:
     - lib/wip/cli.rb
+    - lib/wip/compose_file.rb
 Metrics/BlockLength:
   Exclude:
     - spec/**/*

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ valid compose.yml over sections it doesn't need to look at:
 | `wip version` | wip's version, plus WSLC's if it can be detected |
 | `wip doctor` | Diagnose WSL2, interop, WSLC, config, architecture, and Git |
 | `wip config` | Print the effective configuration (secrets masked) |
-| `wip build [--no-cache] [-- OPTIONS]` | Build the image from the `build` definition. By default, wip passes the target tag as `--cache-from` so previous layers can be reused; `--no-cache` disables that cache path. |
+| `wip build [--no-cache] [-- OPTIONS]` | Build the image from the `build` definition. `wslc build` reuses matching local layers by default; `--no-cache` disables that. |
 | `wip up [-d] [--no-sync] [--no-cache]` | Start the primary `dependencies:` entry (`container:` names which one) and its sidecars (creating any that are missing, on `network:` if set). `-d` runs the main container in the background; with `sync:` configured, the source is mirrored into the volume first unless `--no-sync` |
 | `wip down` | Stop and remove the primary container and its sidecar `dependencies:` |
 | `wip exec [--no-interactive] COMMAND...` | Run a command in the existing container |

--- a/lib/wip/command_builder.rb
+++ b/lib/wip/command_builder.rb
@@ -136,14 +136,16 @@ module Wip
       [@wslc, 'remove', '-f', name.to_s]
     end
 
+    # `wslc build` reuses matching local layers by default (like `docker build`
+    # without `--pull`) — it has no `--cache-from` flag to ask for that explicitly,
+    # and passing one is a hard error (unrecognized argument).
     def build(settings:, extra: [])
       values = primary_values.merge(settings)
       context = values['context'] || '.'
       tag = values['tag'] || values['image']
       raise ConfigError, 'Build image/tag must not be empty' if tag.to_s.empty?
 
-      cache_options = extra.include?('--no-cache') ? [] : ['--cache-from', tag]
-      [@wslc, 'build', '-t', tag, *cache_options, *extra, context]
+      [@wslc, 'build', '-t', tag, *extra, context]
     end
 
     def custom(name, arguments)

--- a/lib/wip/compose_file.rb
+++ b/lib/wip/compose_file.rb
@@ -20,13 +20,13 @@ module Wip
 
     SERVICE_KEYS = %w[image build command environment ports volumes working_dir user depends_on profiles].freeze
     # Real Compose keys that read as meaningful here but have nothing to map onto: TTY/stdin
-    # allocation is already decided per invocation (see CommandBuilder#tty?), not fixed per
-    # service; there's no per-service network to join beyond the one project network `network`
-    # (config.rb) already puts every service on; and `wslc run`/`exec` has no restart-policy or
-    # capability flag to forward `restart:`/`cap_add:` to.
+    # allocation is decided per invocation (CommandBuilder#tty?), not per service; every
+    # service already shares one project network (config.rb); and `wslc run`/`exec` has no
+    # restart-policy or capability flag to forward `restart:`/`cap_add:` to.
     IGNORED_SERVICE_KEYS = %w[tty stdin_open networks restart cap_add].freeze
     BUILD_KEYS = %w[context dockerfile args].freeze
     SUPPORTED_CONDITIONS = %w[service_started].freeze
+    LIST_HINT = 'only supports short syntax ("host:container"), not long-syntax mappings'
 
     # env interpolates compose.yml's ${VAR} references the way `docker compose` does,
     # so values like `user: ${USER_ID}:${GROUP_ID}` reach wslc already substituted
@@ -50,6 +50,9 @@ module Wip
     end
 
     def service_names_in_dependency_order = @order.dup
+
+    # True if `name` is gated behind profiles: (wip has no --profile flag); false for an unknown name.
+    def profiled?(name) = @services[name.to_s]&.profiles&.any? || false
 
     # name => {context:, dockerfile:, tag:} for every service with a build:.
     # Profile-gated services are skipped — see #startable_order.
@@ -75,12 +78,9 @@ module Wip
 
     private
 
-    # `profiles:` gates which services a real `docker compose up` starts by default —
-    # wip has no --profile flag to activate one, so a service that names any profiles
-    # is never among the ones wip starts on its own (real Compose's behavior with no
-    # profile active). It still participates in #topological_order/depends_on
-    # validation, since another (startable) service may legitimately depend on it.
-    def startable_order = @order.reject { |name| @services.fetch(name).profiles.any? }
+    # A profile-gated service (see #profiled?) is never among the ones wip starts
+    # on its own, but still participates in #topological_order/depends_on validation.
+    def startable_order = @order.reject { |name| profiled?(name) }
 
     # A service naming both `build:` and `image:` builds via the former and tags the
     # result with the latter (real Compose's own rule for that combination), instead
@@ -103,7 +103,7 @@ module Wip
     def normalize_service_lists(name, entry)
       { ports: normalize_list(name, entry['ports'], 'ports'),
         volumes: normalize_list(name, entry['volumes'], 'volumes'),
-        profiles: normalize_list(name, entry['profiles'], 'profiles') }
+        profiles: normalize_list(name, entry['profiles'], 'profiles', hint: 'must be an array of strings') }
     end
 
     def image_or_build(name, entry)
@@ -136,10 +136,8 @@ module Wip
 
     def normalize_build_mapping(name, value)
       unknown = value.keys.map(&:to_s) - BUILD_KEYS
-      if unknown.any?
-        raise ConfigError,
-              "#{@path}: services.#{name}.build has unsupported key(s): #{unknown.join(', ')}"
-      end
+      raise ConfigError, "#{@path}: services.#{name}.build has unsupported key(s): #{unknown.join(', ')}" \
+        unless unknown.empty?
 
       context = resolve_context(presence(value['context']) || '.')
       dockerfile = presence(value['dockerfile'])
@@ -186,13 +184,12 @@ module Wip
       end
     end
 
-    def normalize_list(name, value, key)
+    def normalize_list(name, value, key, hint: LIST_HINT)
       return [] unless value
       raise ConfigError, "#{@path}: services.#{name}.#{key} must be an array" unless value.is_a?(Array)
-      if value.any?(Hash)
-        raise ConfigError, "#{@path}: services.#{name}.#{key} only supports short syntax (\"host:container\"), " \
-                           'not long-syntax mappings'
-      end
+
+      nested = value.any? { |item| item.is_a?(Hash) || item.is_a?(Array) }
+      raise ConfigError, "#{@path}: services.#{name}.#{key} #{hint}" if nested
 
       value.map(&:to_s)
     end
@@ -216,10 +213,18 @@ module Wip
       dep.to_s
     end
 
+    # Also rejects a startable (unprofiled) service depending on a profile-gated one —
+    # with no profile activation, real Compose treats that as an invalid model, since
+    # the dependency would silently never start.
     def validate_depends_on!
       @services.each do |name, service|
         service.depends_on.each do |dep|
           raise ConfigError, "#{@path}: services.#{name} depends_on unknown service '#{dep}'" unless @services.key?(dep)
+          next if service.profiles.any? || !profiled?(dep)
+
+          raise ConfigError, "#{@path}: services.#{name} depends_on '#{dep}', gated behind profiles: " \
+                             "(#{@services.fetch(dep).profiles.join(', ')}) wip never activates " \
+                             '(no --profile flag)'
         end
       end
     end

--- a/lib/wip/compose_file.rb
+++ b/lib/wip/compose_file.rb
@@ -15,18 +15,16 @@ module Wip
   # "Compose mode (native)") — once wslc ships that support, or a
   # compose-for-wslc tool reliably supports `run`.
   class ComposeFile
-    Service = Struct.new(:image, :build, :command, :env, :ports, :volumes, :workdir, :user, :depends_on,
+    Service = Struct.new(:image, :build, :command, :env, :ports, :volumes, :workdir, :user, :depends_on, :profiles,
                          keyword_init: true)
 
-    SERVICE_KEYS = %w[image build command environment ports volumes working_dir user depends_on].freeze
+    SERVICE_KEYS = %w[image build command environment ports volumes working_dir user depends_on profiles].freeze
     # Real Compose keys that read as meaningful here but have nothing to map onto: TTY/stdin
     # allocation is already decided per invocation (see CommandBuilder#tty?), not fixed per
     # service; there's no per-service network to join beyond the one project network `network`
-    # (config.rb) already puts every service on; `wslc run`/`exec` has no restart-policy or
-    # capability flag to forward `restart:`/`cap_add:` to; and `profiles:` gates which services a
-    # real `docker compose up` starts by default, which doesn't apply here since wip never starts
-    # "every service" — only `compose.service` and whatever it reaches via `depends_on`.
-    IGNORED_SERVICE_KEYS = %w[tty stdin_open networks restart cap_add profiles].freeze
+    # (config.rb) already puts every service on; and `wslc run`/`exec` has no restart-policy or
+    # capability flag to forward `restart:`/`cap_add:` to.
+    IGNORED_SERVICE_KEYS = %w[tty stdin_open networks restart cap_add].freeze
     BUILD_KEYS = %w[context dockerfile args].freeze
     SUPPORTED_CONDITIONS = %w[service_started].freeze
 
@@ -54,8 +52,9 @@ module Wip
     def service_names_in_dependency_order = @order.dup
 
     # name => {context:, dockerfile:, tag:} for every service with a build:.
+    # Profile-gated services are skipped — see #startable_order.
     def build_specs
-      @order.filter_map do |name|
+      startable_order.filter_map do |name|
         service = @services.fetch(name)
         next unless service.build
 
@@ -66,7 +65,7 @@ module Wip
     # Shaped like Config::DEPENDENCY_DEFAULTS expects: image/command/env/ports/volumes/workdir,
     # in dependency order so callers iterating sidecars start them before their dependents.
     def to_dependencies_hash
-      @order.to_h do |name|
+      startable_order.to_h do |name|
         service = @services.fetch(name)
         [name, { 'image' => service.build ? image_tag(name, service) : service.image, 'command' => service.command,
                  'env' => service.env, 'ports' => service.ports, 'volumes' => service.volumes,
@@ -75,6 +74,13 @@ module Wip
     end
 
     private
+
+    # `profiles:` gates which services a real `docker compose up` starts by default —
+    # wip has no --profile flag to activate one, so a service that names any profiles
+    # is never among the ones wip starts on its own (real Compose's behavior with no
+    # profile active). It still participates in #topological_order/depends_on
+    # validation, since another (startable) service may legitimately depend on it.
+    def startable_order = @order.reject { |name| @services.fetch(name).profiles.any? }
 
     # A service naming both `build:` and `image:` builds via the former and tags the
     # result with the latter (real Compose's own rule for that combination), instead
@@ -96,7 +102,8 @@ module Wip
 
     def normalize_service_lists(name, entry)
       { ports: normalize_list(name, entry['ports'], 'ports'),
-        volumes: normalize_list(name, entry['volumes'], 'volumes') }
+        volumes: normalize_list(name, entry['volumes'], 'volumes'),
+        profiles: normalize_list(name, entry['profiles'], 'profiles') }
     end
 
     def image_or_build(name, entry)

--- a/lib/wip/config.rb
+++ b/lib/wip/config.rb
@@ -204,6 +204,19 @@ module Wip
 
     def parsed_compose_file
       @parsed_compose_file ||= ComposeFile.load(ComposeBridge.file_path(self), env: compose_interpolation_env)
+                                          .tap { |file| validate_compose_service_startable!(file) }
+    end
+
+    # compose.service is what wip always starts by default (container:) — wip has no
+    # --profile flag to activate one, so naming a profile-gated service here would
+    # otherwise fail later with a misleading "No dependencies.<name> entry" instead
+    # of pointing at the real cause.
+    def validate_compose_service_startable!(file)
+      return unless file.profiled?(compose_service)
+
+      raise ConfigError, "compose.service '#{compose_service}' is gated behind profiles: in compose.yml, " \
+                         'but wip has no --profile flag to activate one — pick a service with no profiles: ' \
+                         'or remove profiles: from it'
     end
 
     # Compose interpolates ${VAR} references in compose.yml from the shell environment

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.17.6'
+  VERSION = '0.17.7'
 end

--- a/spec/wip/cli_spec.rb
+++ b/spec/wip/cli_spec.rb
@@ -614,7 +614,7 @@ RSpec.describe Wip::CLI do
                                       ])
     end
 
-    it 'builds a build: service before starting it' do
+    it 'builds a build: service before starting it, without an unsupported --cache-from' do
       File.write('compose.yml', <<~YAML)
         services:
           app:
@@ -631,8 +631,7 @@ RSpec.describe Wip::CLI do
       described_class.start(%w[up -d])
 
       expect(runner).to have_received(:run).with(
-        ['wslc.exe', 'build', '-t', 'wip-compose-app:latest', '--cache-from', 'wip-compose-app:latest',
-         File.expand_path('.')], interactive: false
+        ['wslc.exe', 'build', '-t', 'wip-compose-app:latest', File.expand_path('.')], interactive: false
       )
     end
 

--- a/spec/wip/command_builder_spec.rb
+++ b/spec/wip/command_builder_spec.rb
@@ -29,14 +29,13 @@ RSpec.describe Wip::CommandBuilder do
                                     interactive: false)).to eq(%w[wslc.exe exec -w /app -u 1000:1000 app whoami])
   end
 
-  it 'builds images with extra options before context' do
-    expected = %w[wslc.exe build -t example:dev --cache-from example:dev
-                  --build-arg RAILS_ENV=development .]
+  it 'builds images with extra options before context, without an unsupported --cache-from' do
     expect(builder.build(settings: config.command('build'),
-                         extra: ['--build-arg', 'RAILS_ENV=development'])).to eq(expected)
+                         extra: ['--build-arg', 'RAILS_ENV=development']))
+      .to eq(%w[wslc.exe build -t example:dev --build-arg RAILS_ENV=development .])
   end
 
-  it 'omits cache options when building with --no-cache' do
+  it 'passes --no-cache through when building with --no-cache' do
     expect(builder.build(settings: config.command('build'),
                          extra: ['--no-cache'])).to eq(%w[wslc.exe build -t example:dev --no-cache .])
   end

--- a/spec/wip/compose_file_spec.rb
+++ b/spec/wip/compose_file_spec.rb
@@ -194,6 +194,50 @@ RSpec.describe Wip::ComposeFile do
     expect(deps['app']['user']).to eq('1000:1000')
   end
 
+  it 'excludes services with a profiles: entry from to_dependencies_hash, like an inactive `docker compose` profile' do
+    path = write_compose(<<~YAML)
+      services:
+        app:
+          image: example:dev
+        production.build:
+          image: example:dev
+          profiles:
+            - production.build
+    YAML
+
+    expect(described_class.load(path).to_dependencies_hash.keys).to eq(['app'])
+  end
+
+  it 'excludes services with a profiles: entry from build_specs' do
+    path = write_compose(<<~YAML)
+      services:
+        app:
+          image: example:dev
+        production.build:
+          build: .
+          profiles:
+            - production.build
+    YAML
+
+    expect(described_class.load(path).build_specs.keys).to eq([])
+  end
+
+  it 'still validates depends_on against a profile-gated service' do
+    path = write_compose(<<~YAML)
+      services:
+        app:
+          image: example:dev
+          depends_on:
+            - missing.profile
+        missing.profile:
+          image: example:dev
+          profiles:
+            - only-with-profile
+    YAML
+
+    expect(described_class.load(path).to_dependencies_hash.keys).to eq(['app'])
+  end
+
   it 'interpolates ${VAR} references from the given env, like `docker compose` does' do
     path = write_compose(<<~YAML)
       services:

--- a/spec/wip/compose_file_spec.rb
+++ b/spec/wip/compose_file_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe Wip::ComposeFile do
     expect(described_class.load(path).build_specs.keys).to eq([])
   end
 
-  it 'still validates depends_on against a profile-gated service' do
+  it 'rejects a startable service depending on a profile-gated one, since that dependency would never start' do
     path = write_compose(<<~YAML)
       services:
         app:
@@ -235,7 +235,39 @@ RSpec.describe Wip::ComposeFile do
             - only-with-profile
     YAML
 
+    expect do
+      described_class.load(path)
+    end.to raise_error(Wip::ConfigError, /gated behind profiles: \(only-with-profile\)/)
+  end
+
+  it 'allows one profile-gated service to depend on another' do
+    path = write_compose(<<~YAML)
+      services:
+        app:
+          image: example:dev
+        worker:
+          image: example:dev
+          profiles: [batch]
+          depends_on:
+            - db
+        db:
+          image: postgres:16
+          profiles: [batch]
+    YAML
+
     expect(described_class.load(path).to_dependencies_hash.keys).to eq(['app'])
+  end
+
+  it 'rejects a non-array profiles: entry' do
+    path = write_compose(<<~YAML)
+      services:
+        app:
+          image: example:dev
+          profiles:
+            name: batch
+    YAML
+
+    expect { described_class.load(path) }.to raise_error(Wip::ConfigError, /profiles must be an array/)
   end
 
   it 'interpolates ${VAR} references from the given env, like `docker compose` does' do

--- a/spec/wip/config_spec.rb
+++ b/spec/wip/config_spec.rb
@@ -256,6 +256,22 @@ RSpec.describe Wip::Config do
       expect(config.container).to eq('app')
     end
 
+    it 'rejects compose.service naming a profile-gated service, since wip has no --profile flag to activate one' do
+      File.write('compose.yml', <<~YAML)
+        services:
+          app:
+            image: example:dev
+            profiles:
+              - production
+      YAML
+      config = described_class.new({ 'mode' => 'compose-native', 'compose' => { 'service' => 'app' } },
+                                   File.expand_path('wip.yml'))
+
+      expect do
+        config.dependencies
+      end.to raise_error(Wip::ConfigError, /compose\.service 'app' is gated behind profiles:/)
+    end
+
     it 'derives dependencies from compose.yml, in dependency order, image-shaped for CommandBuilder' do
       write_compose_file
       config = described_class.new({ 'mode' => 'compose-native', 'compose' => { 'service' => 'app' } },


### PR DESCRIPTION
## Summary
- `wslc build` has no `--cache-from` flag and errors on unrecognized arguments, so stop passing it (`wslc` reuses matching local layers by default, so behavior is unchanged in practice)
- Add support for compose `profiles:`: services naming any profile are excluded from `build_specs`/`to_dependencies_hash` by default (matching real `docker compose`'s no-active-profile behavior), while still participating in `depends_on` validation
- Bump version to 0.17.7

## Test plan
- [x] `bundle exec rspec` passes, including new specs covering profile-gated services and the removed `--cache-from` flag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Compose service profiles. Profiled services are excluded from default builds and dependency output while remaining available for dependency validation.
* **Bug Fixes**
  * Updated image builds to reuse matching local layers by default without automatically passing the image tag as a cache source.
  * Preserved `--no-cache` support for disabling layer reuse.
  * Added validation to prevent selecting profiled services or using invalid profile configurations.
* **Documentation**
  * Updated build documentation to reflect revised layer reuse behavior.
* **Chores**
  * Updated the release version to 0.17.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->