### PR TITLE
feat(cli): add wip stop, fix wip down printing names twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ valid compose.yml over sections it doesn't need to look at:
 | `wip config` | Print the effective configuration (secrets masked) |
 | `wip build [--no-cache] [-- OPTIONS]` | Build the image from the `build` definition. `wslc build` reuses matching local layers by default; `--no-cache` disables that. |
 | `wip up [-d] [--no-sync] [--no-cache]` | Start the primary `dependencies:` entry (`container:` names which one) and its sidecars (creating any that are missing, on `network:` if set). `-d` runs the main container in the background; with `sync:` configured, the source is mirrored into the volume first unless `--no-sync` |
+| `wip stop` | Stop the primary container and its sidecar `dependencies:` without removing them |
 | `wip down` | Stop and remove the primary container and its sidecar `dependencies:` |
 | `wip exec [--no-interactive] COMMAND...` | Run a command in the existing container |
 | `wip run [--no-interactive] COMMAND...` | Run a command in a new `--rm` container (mode: compose `exec`s into `compose.service` instead — see "Compose mode" above) |

--- a/lib/wip/cli.rb
+++ b/lib/wip/cli.rb
@@ -119,14 +119,22 @@ module Wip
       warn "\nwip: sync stopped"
     end
 
+    desc 'stop', 'Stop the configured container and its dependencies without removing them'
+    def stop
+      return execute(compose_bridge.stop, exit_on_failure: false) if load_config.compose?
+
+      execute(builder.stop, exit_on_failure: false)
+      sidecar_names.each do |name|
+        execute(builder.dependency_stop(name), exit_on_failure: false)
+      end
+    end
+
     desc 'down', 'Stop and remove the configured container and its dependencies'
     def down
       return execute(compose_bridge.down, exit_on_failure: false) if load_config.compose?
 
-      execute(builder.down, exit_on_failure: false)
       execute(builder.remove, exit_on_failure: false)
       sidecar_names.each do |name|
-        execute(builder.dependency_down(name), exit_on_failure: false)
         execute(builder.dependency_remove(name), exit_on_failure: false)
       end
     end

--- a/lib/wip/command_builder.rb
+++ b/lib/wip/command_builder.rb
@@ -84,10 +84,6 @@ module Wip
       [@wslc, 'exec', required_container, *required_sync.mirror_command]
     end
 
-    def down
-      [@wslc, 'stop', required_container]
-    end
-
     # Only reachable under mode: compose-native — mode: compose delegates `wip logs`
     # to the external compose command's own `logs` (ComposeBridge#logs) instead.
     # Single container only, mirroring `wslc`/docker's own `logs`: there's no
@@ -96,6 +92,10 @@ module Wip
       command = [@wslc, 'logs']
       command << '-f' if follow
       command.push(name.to_s)
+    end
+
+    def stop
+      [@wslc, 'stop', required_container]
     end
 
     def remove
@@ -128,7 +128,7 @@ module Wip
       [@wslc, 'list', '--all', '--filter', "name=#{name}", '--format', 'json']
     end
 
-    def dependency_down(name)
+    def dependency_stop(name)
       [@wslc, 'stop', name.to_s]
     end
 

--- a/lib/wip/compose_bridge.rb
+++ b/lib/wip/compose_bridge.rb
@@ -45,6 +45,8 @@ module Wip
       command
     end
 
+    def stop = base.push('stop')
+
     def down = base.push('down')
 
     def exec(service, arguments, interactive: true)

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.17.7'
+  VERSION = '0.18.0'
 end

--- a/spec/wip/cli_spec.rb
+++ b/spec/wip/cli_spec.rb
@@ -510,6 +510,15 @@ RSpec.describe Wip::CLI do
       described_class.start(%w[up])
     end
 
+    it 'delegates stop to wslc-compose' do
+      runner = instance_double(Wip::CommandRunner, run: 0)
+      allow(Wip::CommandRunner).to receive(:new).and_return(runner)
+      expect(runner).to receive(:run).with(['wslc-compose', '-f', compose_file, 'stop'],
+                                           interactive: false).and_return(0)
+
+      described_class.start(%w[stop])
+    end
+
     it 'delegates down to wslc-compose' do
       runner = instance_double(Wip::CommandRunner, run: 0)
       allow(Wip::CommandRunner).to receive(:new).and_return(runner)
@@ -669,15 +678,22 @@ RSpec.describe Wip::CLI do
       described_class.start(%w[run echo hi])
     end
 
-    it 'stops and removes both the primary service and its sidecars' do
+    it 'removes both the primary service and its sidecars' do
       runner = instance_double(Wip::CommandRunner, run: 0)
       allow(Wip::CommandRunner).to receive(:new).and_return(runner)
-      expect(runner).to receive(:run).with(%w[wslc.exe stop app], interactive: false).and_return(0)
       expect(runner).to receive(:run).with(%w[wslc.exe remove -f app], interactive: false).and_return(0)
-      expect(runner).to receive(:run).with(%w[wslc.exe stop redis], interactive: false).and_return(0)
       expect(runner).to receive(:run).with(%w[wslc.exe remove -f redis], interactive: false).and_return(0)
 
       described_class.start(%w[down])
+    end
+
+    it 'stops both the primary service and its sidecars without removing them' do
+      runner = instance_double(Wip::CommandRunner, run: 0)
+      allow(Wip::CommandRunner).to receive(:new).and_return(runner)
+      expect(runner).to receive(:run).with(%w[wslc.exe stop app], interactive: false).and_return(0)
+      expect(runner).to receive(:run).with(%w[wslc.exe stop redis], interactive: false).and_return(0)
+
+      described_class.start(%w[stop])
     end
 
     it 'follows logs for a single named service' do

--- a/spec/wip/command_builder_spec.rb
+++ b/spec/wip/command_builder_spec.rb
@@ -72,8 +72,8 @@ RSpec.describe Wip::CommandBuilder do
     expect(builder.start(detach: true)).to eq(%w[wslc.exe start app])
   end
 
-  it 'builds down and remove commands for the configured container' do
-    expect(builder.down).to eq(%w[wslc.exe stop app])
+  it 'builds stop and remove commands for the configured container' do
+    expect(builder.stop).to eq(%w[wslc.exe stop app])
     expect(builder.remove).to eq(%w[wslc.exe remove -f app])
   end
 
@@ -132,10 +132,10 @@ RSpec.describe Wip::CommandBuilder do
       expect(builder.dependency_up('redis')).to eq(%w[wslc.exe run --name redis --network app-tier -d redis:latest])
     end
 
-    it 'builds start/find/down/remove commands for a dependency' do
+    it 'builds start/find/stop/remove commands for a dependency' do
       expect(builder.dependency_start('redis')).to eq(%w[wslc.exe start redis])
       expect(builder.dependency_find('redis')).to eq(%w[wslc.exe list --all --filter name=redis --format json])
-      expect(builder.dependency_down('redis')).to eq(%w[wslc.exe stop redis])
+      expect(builder.dependency_stop('redis')).to eq(%w[wslc.exe stop redis])
       expect(builder.dependency_remove('redis')).to eq(%w[wslc.exe remove -f redis])
     end
 

--- a/spec/wip/compose_bridge_spec.rb
+++ b/spec/wip/compose_bridge_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe Wip::ComposeBridge do
     expect(bridge.up(detach: false)).to eq(%w[wslc-compose -f compose.yml up])
   end
 
+  it 'builds a stop command' do
+    expect(bridge.stop).to eq(%w[wslc-compose -f compose.yml stop])
+  end
+
   it 'builds a down command' do
     expect(bridge.down).to eq(%w[wslc-compose -f compose.yml down])
   end


### PR DESCRIPTION
## Summary
- `wip down` used to run `stop` immediately before `remove -f` on every container, so each name printed twice. `remove -f` already stops-then-removes in one step, so `down` now only removes.
- Added a standalone `wip stop` command (stop without remove), delegating to `<compose command> stop` in compose mode.
- Bumped version to 0.18.0.

## Test plan
- [x] `bundle exec rspec` (242 examples, 0 failures)
- [x] `bundle exec rubocop` (no offenses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `wip stop` command to stop the primary container and its dependencies without removing them.
  * Added support for stopping services in Compose mode.
  * Documented the new command in the README.

* **Bug Fixes**
  * Updated `wip down` to remove container resources directly without unnecessary intermediate stop operations.

* **Chores**
  * Released as version 0.18.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->