### PR TITLE
fix(cli): log which compose-native service is being built

### DIFF
--- a/lib/wip/cli.rb
+++ b/lib/wip/cli.rb
@@ -312,14 +312,14 @@ module Wip
     # `wip up` invocation, mirroring ensure_sync_image's "build once, not every tick"
     # approach. A no-op for mode: container/compose and for build:-less services.
     def ensure_compose_images
-      load_config.compose_build_specs.each_value { |spec| build_compose_image(spec) }
+      load_config.compose_build_specs.each_pair { |name, spec| build_compose_image(name, spec) }
     end
 
     # Stages spec['context'] the same way `wip build` does, so a .dockerignore next to
     # a compose-native service's build: is honored and progress is reported here too.
-    def build_compose_image(spec)
+    def build_compose_image(name, spec)
       extra = compose_build_extra(spec)
-      warn "wip: staging build context (#{spec['context']})"
+      warn "wip: building service '#{name}' (tag: #{spec['tag']}) from #{spec['context']}"
       progress = StagingProgress.new
       BuildContext.new(spec['context']).stage(on_progress: progress.method(:tick)) do |staged_context|
         progress.finish

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '0.18.0'
+  VERSION = '0.18.1'
 end

--- a/spec/wip/cli_spec.rb
+++ b/spec/wip/cli_spec.rb
@@ -644,6 +644,21 @@ RSpec.describe Wip::CLI do
       )
     end
 
+    it 'names the service being built so multiple build: entries are distinguishable' do
+      File.write('compose.yml', <<~YAML)
+        services:
+          app:
+            build: .
+      YAML
+      runner = instance_double(Wip::CommandRunner, run: 0)
+      allow(Wip::CommandRunner).to receive(:new).and_return(runner)
+      allow(runner).to receive(:run).and_return(0)
+
+      expect { described_class.start(%w[up -d]) }.to output(
+        /wip: building service 'app' \(tag: wip-compose-app:latest\) from/
+      ).to_stderr
+    end
+
     it 'disables compose-native build cache when --no-cache is passed to up' do
       File.write('compose.yml', <<~YAML)
         services:


### PR DESCRIPTION
## Summary
- `wip up` builds every compose-native `build:` service sequentially (e.g. a base image followed by an app image extending it), but only logged the staged build context path — with multiple builds in one run there was no way to tell which one was in progress.
- Now logs `wip: building service '<name>' (tag: <tag>) from <context>` for each one.
- Bumped version to 0.18.1.

## Test plan
- [x] `bundle exec rspec` (243 examples, 0 failures)
- [x] `bundle exec rubocop` (no offenses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved compose-native image build output to clearly show the service name and generated image tag.

* **Bug Fixes**
  * Improved build progress reporting for compose-native services.

* **Tests**
  * Added coverage verifying service and image tag details appear during builds.

* **Chores**
  * Updated the application version to 0.18.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->