### PR TITLE
docs/readme reorganize

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,11 @@ sync: # optional; mirror the source into a named volume instead of bind-mounting
 credential, or auth. Keep real secrets out of the config file and in your runtime environment
 instead.
 
+`commands:` can also be spelled `interaction:` — dip's name for the same block — so a `dip.yml`
+can become a `wip.yml` with fewer edits. The two are aliases for the same feature, not separate
+ones: pick whichever name you like, but declaring both `commands:` and `interaction:` in the same
+`wip.yml` is a `ConfigError`.
+
 #### Dependency containers
 
 `dependencies:` holds every container uniformly — the primary one `container:` points at and any
@@ -572,6 +577,11 @@ is meant to stay untracked) rather than committing them in `wip.yml`.
 
 **`wslc.exe`/`wslc` isn't found — what do I do?**
 See [WSLC not found](#wslc-not-found) under Common errors.
+
+**I'm migrating from `dip` — do I have to rename `interaction:` to `commands:`?**
+No, `wip.yml` accepts `interaction:` as an alias for `commands:` — same shape, same behavior, just
+dip's original name for it. Use whichever you prefer, but not both in the same file (that's a
+`ConfigError`). See [Container mode](#container-mode).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ commands into a single `wip.yml`, and forwards them to `wslc.exe` / `wslc` as sa
 - [Commands](#commands)
 - [doctor](#doctor)
 - [Common errors](#common-errors)
+- [FAQ](#faq)
 - [Development](#development)
 - [Contributing](#contributing)
 - [Roadmap](#roadmap)
@@ -509,6 +510,68 @@ docker buildx build \
   -t <image> \
   --push .
 ```
+
+## FAQ
+
+**Which mode should I start with?**
+Pick whichever `mode:` fits your project — see [Which mode should you use?](#which-mode-should-you-use)
+for the breakdown.
+
+**Can I use `dependencies:` and `compose:` together?**
+No — `compose:` is mutually exclusive with `dependencies:`/`network`. Pick one orchestration path
+per project; see [Configuration](#configuration).
+
+**What's the difference between `mode: compose` and `mode: compose-native`?**
+`compose` delegates to a third-party compose-for-`wslc` binary you install yourself
+(`compose.command`); `compose-native` parses `compose.yml` itself and drives `wslc` directly, no
+external tool required. `compose-native`'s Compose coverage isn't frozen at whatever it handles
+today — it keeps growing until `wslc` ships native Compose support of its own. See
+[Compose mode](#compose-mode) and [Compose mode (native)](#compose-mode-native).
+
+**`dependencies:` already gives me sidecar containers — why would I need `compose-native` too?**
+`dependencies:` and `compose-native` aren't really alternatives to each other — they're for two
+different starting points. No `compose.yml`? Declare containers directly in `wip.yml`'s own shape
+with `dependencies:`. Already have a `compose.yml`? Reusing it is where `compose-native` and
+`mode: compose` both come in, so the real comparison is between those two, not against
+`dependencies:`: `mode: compose` reuses it too, but only by delegating to a third-party
+compose-for-`wslc` binary you install yourself; `compose-native` reuses the same `compose.yml`
+without installing anything external, parsing it and driving `wslc` directly — and gets a real
+`wslc run --rm` for `wip run` instead of the `exec` fallback `mode: compose` falls back to.
+`mode: compose`'s coverage is whatever the external tool you point it at supports; `compose-native`'s
+is maintained in this repo and actively extended, not treated as a permanent ceiling. See
+[Which mode should you use?](#which-mode-should-you-use) for the full picture.
+
+**What happens to `compose-native` once `wslc` gets official Compose support?**
+`compose-native` exists to close the gap for as long as `wslc` has no native Compose support of its
+own (tracked upstream in [microsoft/WSL#40948](https://github.com/microsoft/WSL/issues/40948)), and
+we intend to keep extending its Compose coverage until that lands — see
+[Compose mode (native)](#compose-mode-native) and [Roadmap](#roadmap). `wip.yml`'s shape (`mode:`,
+`compose:`) isn't planned to change for existing `container`/`compose`/`compose-native` setups, so
+whatever we do once `wslc` catches up won't require rewriting your config.
+
+**Is `sync:` required?**
+No, it's entirely optional. Add it if boot times feel slow with a bind-mounted app directory — see
+[Slow boot when the app directory is bind-mounted](#slow-boot-when-the-app-directory-is-bind-mounted).
+
+**How does `wip` actually fix the slow bind-mount boot problem?**
+The slowness comes from `.:/app`-style bind mounts going through virtiofs, where frameworks that
+stat/open many small files at startup (e.g. Ruby's Zeitwerk) pay a round trip per file. A `sync:`
+block moves the app off that path entirely: the host source is mounted read-only, the app itself
+runs off a named volume (fast native storage inside the VM), and `wip` mirrors the read-only
+source into that volume with `rsync` — once before boot, and on demand afterward via `wip sync`
+(or continuously with `wip sync --watch`). Since the app never touches the bind mount directly, its
+own file access is no longer paying the virtiofs cost; the trade-off is a one-way, slightly-delayed
+mirror instead of an always-live view of host edits. See [Source sync](#source-sync) for the full
+config and [Slow boot when the app directory is bind-mounted](#slow-boot-when-the-app-directory-is-bind-mounted)
+for the root cause.
+
+**Is it safe to put passwords/secrets in `wip.yml`?**
+`wip config` masks any key matching token/password/secret/credential/auth when printing, but the
+raw file itself is not encrypted. Keep real secrets in your runtime environment (or `.env`, which
+is meant to stay untracked) rather than committing them in `wip.yml`.
+
+**`wslc.exe`/`wslc` isn't found — what do I do?**
+See [WSLC not found](#wslc-not-found) under Common errors.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@
 
 Homepage: https://wslc-wip.slidict.com/
 
+`wip` is a Ruby-built OSS CLI wrapper that brings a [`dip`](https://github.com/bibendi/dip)-like
+workflow to Microsoft WSLC. It collects a project's container, image, environment variables, and
+commands into a single `wip.yml`, and forwards them to `wslc.exe` / `wslc` as safe argument arrays
+(no shell interpolation).
+
+![wip demo](https://raw.githubusercontent.com/slidict/wip/main/docs/demo.gif)
+
+> **Status:** early release. Expect to track WSLC's own interface as it evolves.
+
 ## Contents
 
 - [Which mode should you use?](#which-mode-should-you-use)
@@ -26,15 +35,6 @@ Homepage: https://wslc-wip.slidict.com/
 - [Contributing](#contributing)
 - [Roadmap](#roadmap)
 - [License](#license)
-
-`wip` is a Ruby-built OSS CLI wrapper that brings a [`dip`](https://github.com/bibendi/dip)-like
-workflow to Microsoft WSLC. It collects a project's container, image, environment variables, and
-commands into a single `wip.yml`, and forwards them to `wslc.exe` / `wslc` as safe argument arrays
-(no shell interpolation).
-
-![wip demo](https://raw.githubusercontent.com/slidict/wip/main/docs/demo.gif)
-
-> **Status:** early release. Expect to track WSLC's own interface as it evolves.
 
 ## Which mode should you use?
 

--- a/README.md
+++ b/README.md
@@ -572,8 +572,9 @@ for the root cause.
 
 **Is it safe to put passwords/secrets in `wip.yml`?**
 `wip config` masks any key matching token/password/secret/credential/auth when printing, but the
-raw file itself is not encrypted. Keep real secrets in your runtime environment (or `.env`, which
-is meant to stay untracked) rather than committing them in `wip.yml`.
+raw file itself is not encrypted. Keep real secrets in your runtime environment or `.env` instead
+of committing them in `wip.yml` — but `.env` is only safe if it's actually untracked: add `.env` to
+`.gitignore` (and confirm with `git check-ignore .env`) before putting anything sensitive in it.
 
 **`wslc.exe`/`wslc` isn't found — what do I do?**
 See [WSLC not found](#wslc-not-found) under Common errors.

--- a/lib/wip/config.rb
+++ b/lib/wip/config.rb
@@ -27,7 +27,11 @@ module Wip
     end
 
     def wslc_command = @raw.dig('wslc', 'command') || 'auto'
-    def commands = @raw['commands'] || {}
+    # interaction: is dip's name for the same concept — accepted as an alias so a
+    # dip.yml can be renamed to wip.yml with fewer edits. The two are mutually
+    # exclusive (validate_commands!) rather than merged, so a project doesn't end up
+    # with the same command split across both keys.
+    def commands = @raw['commands'] || @raw['interaction'] || {}
     # Raw dependencies: block as written in wip.yml. Under compose-native mode this stays
     # empty by construction (validate_compose! forbids combining the two) — #dependencies
     # below is what callers actually want, since it's synthesized from compose.yml there.
@@ -126,6 +130,8 @@ module Wip
     end
 
     def validate_commands!
+      raise ConfigError, 'commands is mutually exclusive with interaction — pick one' \
+        if @raw.key?('commands') && @raw.key?('interaction')
       raise ConfigError, 'commands must be a mapping' unless commands.is_a?(Hash)
 
       commands.each { |name, entry| validate_command!(name, entry) }

--- a/lib/wip/config.rb
+++ b/lib/wip/config.rb
@@ -27,11 +27,18 @@ module Wip
     end
 
     def wslc_command = @raw.dig('wslc', 'command') || 'auto'
+
     # interaction: is dip's name for the same concept — accepted as an alias so a
     # dip.yml can be renamed to wip.yml with fewer edits. The two are mutually
     # exclusive (validate_commands!) rather than merged, so a project doesn't end up
     # with the same command split across both keys.
-    def commands = @raw['commands'] || @raw['interaction'] || {}
+    def commands
+      return @raw['commands'] if @raw.key?('commands')
+      return @raw['interaction'] if @raw.key?('interaction')
+
+      {}
+    end
+
     # Raw dependencies: block as written in wip.yml. Under compose-native mode this stays
     # empty by construction (validate_compose! forbids combining the two) — #dependencies
     # below is what callers actually want, since it's synthesized from compose.yml there.

--- a/spec/wip/config_spec.rb
+++ b/spec/wip/config_spec.rb
@@ -29,6 +29,16 @@ RSpec.describe Wip::Config do
       .to raise_error(Wip::ConfigError, /commands is mutually exclusive with interaction/)
   end
 
+  it 'rejects a falsey commands: instead of silently falling back to {}' do
+    expect { described_class.new('commands' => false) }
+      .to raise_error(Wip::ConfigError, 'commands must be a mapping')
+  end
+
+  it 'rejects a falsey interaction: instead of silently falling back to {}' do
+    expect { described_class.new('interaction' => false) }
+      .to raise_error(Wip::ConfigError, 'commands must be a mapping')
+  end
+
   it 'exposes container and the primary dependency it points at, with no implicit default' do
     config = described_class.new('container' => 'app',
                                  'dependencies' => { 'app' => { 'image' => 'example:dev', 'command' => 'local' } })

--- a/spec/wip/config_spec.rb
+++ b/spec/wip/config_spec.rb
@@ -16,6 +16,19 @@ RSpec.describe Wip::Config do
     expect(config.to_h.dig('commands', 'x', 'env', 'API_TOKEN')).to eq('[REDACTED]')
   end
 
+  it 'accepts interaction: as a dip-style alias for commands:' do
+    config = described_class.new('interaction' => { 'web' => { 'command' => 'server' } })
+    expect(config.commands).to eq('web' => { 'command' => 'server' })
+  end
+
+  it 'rejects commands: and interaction: together' do
+    expect do
+      described_class.new('commands' => { 'a' => { 'command' => 'a' } },
+                          'interaction' => { 'b' => { 'command' => 'b' } })
+    end
+      .to raise_error(Wip::ConfigError, /commands is mutually exclusive with interaction/)
+  end
+
   it 'exposes container and the primary dependency it points at, with no implicit default' do
     config = described_class.new('container' => 'app',
                                  'dependencies' => { 'app' => { 'image' => 'example:dev', 'command' => 'local' } })


### PR DESCRIPTION
- **docs: reorganize README around mode selection**
- **docs: move intro paragraph and demo gif before the table of contents**
- **docs: add README FAQ section**
- **feat(config): accept interaction: as a dip-style alias for commands:**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for using `interaction:` as an alternative to `commands:` in configuration.
  * Added a project overview, demo image, early-release notice, and FAQ to the documentation.

* **Bug Fixes**
  * Configuration now rejects conflicting or invalid `commands:` and `interaction:` values.

* **Documentation**
  * Added navigation to the FAQ.
  * Documented configuration aliasing and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->