### PR TITLE
feat(build): add Windows shadow contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ commands:
     type: build
     context: .
     tag: slidict/slidict:development
+    shadow_context: /mnt/c/Users/me/AppData/Local/wip/build-contexts
 sync: # optional; mirror the source into a named volume instead of bind-mounting it live
   exclude:
     - .git
@@ -270,12 +271,12 @@ to load a different file instead.
 ### .dockerignore
 
 `wip build` reads `.dockerignore` from the build context and excludes anything it matches before
-handing the context to `wslc build`, since `wslc` sends the context as-is otherwise. On WSL, a
-project outside `/mnt/<drive>` is mirrored into a persistent shadow context on the Windows
-filesystem. The first build copies every included file; later builds only copy added or changed
-files and remove deleted or newly ignored files. Projects already on `/mnt/c` (or another mounted
-Windows drive) continue to build directly. Set `WIP_SHADOW_ROOT` to override the default shadow
-location (`/mnt/c/Users/Public/.wip/build-contexts`).
+handing the context to `wslc build`, since `wslc` sends the context as-is otherwise. Set
+`commands.build.shadow_context` in `wip.yml` to a directory on the Windows filesystem to enable a
+persistent shadow context for projects outside `/mnt/<drive>`. The first build copies every
+included file; later builds only copy added or changed files and remove deleted or newly ignored
+files. Without this setting the optimization is disabled. Projects already on `/mnt/c` (or another
+mounted Windows drive) continue to build directly even when the setting is present.
 
 ### Source sync
 

--- a/README.md
+++ b/README.md
@@ -600,7 +600,8 @@ bundle exec rake
 ```
 
 The test suite doesn't need WSLC — the resolution, build, and execution layers are all
-swappable. GitHub Actions runs RSpec and RuboCop on Ruby 3.2, 3.3, 3.4, and 4.0.
+swappable. This project uses RuboCop for Ruby style and static analysis; `bundle exec rake` runs
+both RSpec and RuboCop. GitHub Actions checks them on Ruby 3.2, 3.3, 3.4, and 4.0.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -275,8 +275,10 @@ handing the context to `wslc build`, since `wslc` sends the context as-is otherw
 `commands.build.shadow_context` in `wip.yml` to a directory on the Windows filesystem to enable a
 persistent shadow context for projects outside `/mnt/<drive>`. The first build copies every
 included file; later builds only copy added or changed files and remove deleted or newly ignored
-files. Without this setting the optimization is disabled. Projects already on `/mnt/c` (or another
-mounted Windows drive) continue to build directly even when the setting is present.
+files. Without this setting the optimization is disabled, and it only applies under WSL2 — on WSL1
+(or anywhere else) the context is handed to `wslc build` directly. Projects already on `/mnt/c` (or
+another mounted Windows drive) also continue to build directly even when the setting is present.
+The path must live outside the build context itself, or `wip build` refuses it.
 
 ### Source sync
 

--- a/README.md
+++ b/README.md
@@ -269,10 +269,13 @@ to load a different file instead.
 
 ### .dockerignore
 
-`wip build` reads `.dockerignore` from the build context and stages a filtered copy of the
-context (skipping anything it matches) before handing it to `wslc build`, since `wslc` sends the
-context as-is otherwise. If there's no `.dockerignore`, the original context directory is used
-directly with no copying.
+`wip build` reads `.dockerignore` from the build context and excludes anything it matches before
+handing the context to `wslc build`, since `wslc` sends the context as-is otherwise. On WSL, a
+project outside `/mnt/<drive>` is mirrored into a persistent shadow context on the Windows
+filesystem. The first build copies every included file; later builds only copy added or changed
+files and remove deleted or newly ignored files. Projects already on `/mnt/c` (or another mounted
+Windows drive) continue to build directly. Set `WIP_SHADOW_ROOT` to override the default shadow
+location (`/mnt/c/Users/Public/.wip/build-contexts`).
 
 ### Source sync
 

--- a/lib/wip/build_context.rb
+++ b/lib/wip/build_context.rb
@@ -15,22 +15,34 @@ module Wip
       @root = Pathname(context).expand_path
       @ignore = ignore || DockerIgnore.load(@root.join('.dockerignore'))
       @environment = environment
-      @shadow_root = Pathname(shadow_root).expand_path if shadow_root
+      @shadow_root = validated_shadow_root(shadow_root) if shadow_root
     end
 
     # on_progress fires before copying and after each file, as `|count, total|`,
     # so a caller can report elapsed progress even while copying one large file.
-    def stage(on_progress: nil)
-      return stage_shadow(on_progress) { |context| yield context } if shadow_required?
-      return yield @root.to_s if @ignore.empty?
+    def stage(on_progress: nil, &block)
+      return stage_shadow(on_progress, &block) if shadow_required?
+      return block.call(@root.to_s) if @ignore.empty?
 
       Dir.mktmpdir('wip-build-context-') do |dir|
         copy_included_files(Pathname(dir), on_progress)
-        yield dir
+        block.call(dir)
       end
     end
 
     private
+
+    # A shadow root under the context would itself be walked by included_files
+    # on the next build and copied into itself at ever-deeper paths, so the
+    # cache would grow without bound and the build would eventually fail.
+    def validated_shadow_root(shadow_root)
+      root = Pathname(shadow_root).expand_path
+      if root == @root || root.to_s.start_with?("#{@root}/")
+        raise ConfigError, "shadow_context (#{root}) must not be inside the build context (#{@root})"
+      end
+
+      root
+    end
 
     def shadow_required?
       return false unless @shadow_root
@@ -55,30 +67,53 @@ module Wip
     end
 
     def synchronize_shadow(context, manifest_path, on_progress)
-      previous = context.directory? ? load_manifest(manifest_path) : {}
       current = included_files.to_h { |entry| [entry, fingerprint(@root.join(entry))] }
-      changed = current.keys.select { |entry| current[entry] != previous[entry] }
+      previous = previous_manifest(context, manifest_path)
+      changed = current.keys.reject { |entry| current[entry] == previous[entry] }
       removed = previous.keys - current.keys
-      on_progress&.call(0, changed.size + removed.size)
 
-      removed.each_with_index do |entry, index|
-        FileUtils.rm_rf(context.join(entry))
-        prune_empty_parents(context.join(entry).dirname, context)
-        on_progress&.call(index + 1, changed.size + removed.size)
-      end
-      changed.each_with_index do |entry, index|
-        copy_entry_atomically(@root.join(entry), context.join(entry))
-        on_progress&.call(removed.size + index + 1, changed.size + removed.size)
-      end
-
+      apply_shadow_changes(context, changed, removed, on_progress)
       FileUtils.mkdir_p(context)
       write_manifest(manifest_path, current)
     end
 
-    def load_manifest(path)
-      path.file? ? JSON.parse(path.read) : {}
-    rescue JSON::ParserError, Errno::ENOENT
+    # A context we can't describe is a context we can't update incrementally:
+    # with no manifest there is no way to tell which of its entries are stale,
+    # so it gets discarded and rebuilt rather than left holding deleted or
+    # newly ignored files.
+    def previous_manifest(context, manifest_path)
+      return {} unless context.directory?
+
+      manifest = load_manifest(manifest_path)
+      return manifest if manifest
+
+      FileUtils.rm_rf(context)
       {}
+    end
+
+    def apply_shadow_changes(context, changed, removed, on_progress)
+      total = changed.size + removed.size
+      on_progress&.call(0, total)
+
+      removed.each_with_index do |entry, index|
+        FileUtils.rm_rf(context.join(entry))
+        prune_empty_parents(context.join(entry).dirname, context)
+        on_progress&.call(index + 1, total)
+      end
+      changed.each_with_index do |entry, index|
+        copy_entry_atomically(@root.join(entry), context.join(entry))
+        on_progress&.call(removed.size + index + 1, total)
+      end
+    end
+
+    # Returns nil — not an empty manifest — when the manifest is missing,
+    # unreadable, or not a manifest at all, so callers can tell "nothing was
+    # synced yet" apart from "we no longer know what was synced".
+    def load_manifest(path)
+      manifest = JSON.parse(path.read)
+      manifest if manifest.is_a?(Hash)
+    rescue JSON::ParserError, SystemCallError
+      nil
     end
 
     def write_manifest(path, contents)
@@ -99,15 +134,28 @@ module Wip
       end
     end
 
+    # preserve: true keeps the source mode, so an executable stays executable
+    # even when the shadow lives on a DrvFs mount whose fmask would otherwise
+    # strip the bit and break a `RUN ./script` in the image build.
     def copy_entry_atomically(source, target)
       FileUtils.mkdir_p(target.dirname)
       temporary = target.dirname.join(".#{target.basename}.wip-#{Process.pid}")
       FileUtils.rm_rf(temporary)
-      FileUtils.copy_entry(source, temporary, false, false, false)
-      FileUtils.rm_rf(target)
-      File.rename(temporary, target)
+      FileUtils.copy_entry(source, temporary, true, false, false)
+      replace_atomically(temporary, target)
     ensure
       FileUtils.rm_rf(temporary) if temporary
+    end
+
+    # rename replaces an existing entry in a single step, so an interrupted
+    # update leaves the previous copy in place instead of no copy at all. Only
+    # a target rename can't overwrite — a directory where a file now lives, or
+    # a filesystem without overwrite semantics — needs the unsafe fallback.
+    def replace_atomically(temporary, target)
+      File.rename(temporary, target)
+    rescue Errno::EISDIR, Errno::ENOTDIR, Errno::ENOTEMPTY, Errno::EEXIST, Errno::EPERM, Errno::EACCES
+      FileUtils.rm_rf(target)
+      File.rename(temporary, target)
     end
 
     def prune_empty_parents(directory, root)
@@ -131,7 +179,7 @@ module Wip
         # Keep links as links. Dereferencing a link here could copy arbitrary
         # host files outside the build context (for example, ~/.ssh/id_rsa)
         # into the staged directory and expose them to the image build.
-        FileUtils.copy_entry(@root.join(relative_path), target, false, false, false)
+        FileUtils.copy_entry(@root.join(relative_path), target, true, false, false)
         on_progress&.call(index + 1, files.size)
       end
     end

--- a/lib/wip/build_context.rb
+++ b/lib/wip/build_context.rb
@@ -1,23 +1,29 @@
 # frozen_string_literal: true
 
-require 'find'
+require 'digest'
 require 'fileutils'
+require 'find'
+require 'json'
 require 'pathname'
 require 'tmpdir'
 
 module Wip
-  # Stages a build context into a scratch directory with anything matched by
-  # .dockerignore left out, since wslc build (unlike `docker build`) sends the
-  # context as-is instead of filtering it itself.
+  # Filters build contexts for wslc and keeps WSL-hosted sources in a fast,
+  # persistent Windows-side shadow directory.
   class BuildContext
-    def initialize(context, ignore: nil)
+    DEFAULT_SHADOW_ROOT = '/mnt/c/Users/Public/.wip/build-contexts'
+
+    def initialize(context, ignore: nil, environment: Environment.new, shadow_root: nil)
       @root = Pathname(context).expand_path
       @ignore = ignore || DockerIgnore.load(@root.join('.dockerignore'))
+      @environment = environment
+      @shadow_root = Pathname(shadow_root || ENV['WIP_SHADOW_ROOT'] || DEFAULT_SHADOW_ROOT)
     end
 
     # on_progress fires before copying and after each file, as `|count, total|`,
     # so a caller can report elapsed progress even while copying one large file.
     def stage(on_progress: nil)
+      return stage_shadow(on_progress) { |context| yield context } if shadow_required?
       return yield @root.to_s if @ignore.empty?
 
       Dir.mktmpdir('wip-build-context-') do |dir|
@@ -27,6 +33,94 @@ module Wip
     end
 
     private
+
+    def shadow_required?
+      @environment.wsl2? && !@root.to_s.match?(%r{\A/mnt/[a-z](?:/|\z)}i)
+    end
+
+    # Keep one stable Windows-side context per source path. Its manifest lives
+    # beside (rather than inside) the context so it is never sent to wslc.
+    def stage_shadow(on_progress)
+      key = Digest::SHA256.hexdigest(@root.to_s)
+      cache = @shadow_root.join(key)
+      context = cache.join('context')
+      FileUtils.mkdir_p(cache)
+
+      File.open(cache.join('lock'), File::RDWR | File::CREAT, 0o600) do |lock|
+        lock.flock(File::LOCK_EX)
+        synchronize_shadow(context, cache.join('manifest.json'), on_progress)
+        # Keep the shadow immutable until wslc has finished reading it.
+        yield context.to_s
+      end
+    end
+
+    def synchronize_shadow(context, manifest_path, on_progress)
+      previous = context.directory? ? load_manifest(manifest_path) : {}
+      current = included_files.to_h { |entry| [entry, fingerprint(@root.join(entry))] }
+      changed = current.keys.select { |entry| current[entry] != previous[entry] }
+      removed = previous.keys - current.keys
+      on_progress&.call(0, changed.size + removed.size)
+
+      removed.each_with_index do |entry, index|
+        FileUtils.rm_rf(context.join(entry))
+        prune_empty_parents(context.join(entry).dirname, context)
+        on_progress&.call(index + 1, changed.size + removed.size)
+      end
+      changed.each_with_index do |entry, index|
+        copy_entry_atomically(@root.join(entry), context.join(entry))
+        on_progress&.call(removed.size + index + 1, changed.size + removed.size)
+      end
+
+      FileUtils.mkdir_p(context)
+      write_manifest(manifest_path, current)
+    end
+
+    def load_manifest(path)
+      path.file? ? JSON.parse(path.read) : {}
+    rescue JSON::ParserError, Errno::ENOENT
+      {}
+    end
+
+    def write_manifest(path, contents)
+      temporary = Pathname("#{path}.tmp-#{Process.pid}")
+      temporary.write(JSON.generate(contents))
+      File.rename(temporary, path)
+    ensure
+      FileUtils.rm_f(temporary) if temporary
+    end
+
+    def fingerprint(path)
+      stat = path.lstat
+      if stat.symlink?
+        { 'type' => 'link', 'target' => path.readlink.to_s }
+      else
+        { 'type' => 'file', 'size' => stat.size, 'mtime_ns' => stat.mtime.nsec + (stat.mtime.to_i * 1_000_000_000),
+          'mode' => stat.mode }
+      end
+    end
+
+    def copy_entry_atomically(source, target)
+      FileUtils.mkdir_p(target.dirname)
+      temporary = target.dirname.join(".#{target.basename}.wip-#{Process.pid}")
+      FileUtils.rm_rf(temporary)
+      FileUtils.copy_entry(source, temporary, false, false, false)
+      FileUtils.rm_rf(target)
+      File.rename(temporary, target)
+    ensure
+      FileUtils.rm_rf(temporary) if temporary
+    end
+
+    def prune_empty_parents(directory, root)
+      while empty_descendant?(directory, root)
+        directory.rmdir
+        directory = directory.dirname
+      end
+    end
+
+    def empty_descendant?(directory, root)
+      directory != root && directory.to_s.start_with?("#{root}/") &&
+        directory.directory? && directory.children.empty?
+    end
 
     def copy_included_files(destination, on_progress)
       files = included_files

--- a/lib/wip/build_context.rb
+++ b/lib/wip/build_context.rb
@@ -11,13 +11,11 @@ module Wip
   # Filters build contexts for wslc and keeps WSL-hosted sources in a fast,
   # persistent Windows-side shadow directory.
   class BuildContext
-    DEFAULT_SHADOW_ROOT = '/mnt/c/Users/Public/.wip/build-contexts'
-
     def initialize(context, ignore: nil, environment: Environment.new, shadow_root: nil)
       @root = Pathname(context).expand_path
       @ignore = ignore || DockerIgnore.load(@root.join('.dockerignore'))
       @environment = environment
-      @shadow_root = Pathname(shadow_root || ENV['WIP_SHADOW_ROOT'] || DEFAULT_SHADOW_ROOT)
+      @shadow_root = Pathname(shadow_root).expand_path if shadow_root
     end
 
     # on_progress fires before copying and after each file, as `|count, total|`,
@@ -35,7 +33,7 @@ module Wip
     private
 
     def shadow_required?
-      @environment.wsl2? && !@root.to_s.match?(%r{\A/mnt/[a-z](?:/|\z)}i)
+      @shadow_root && @environment.wsl2? && !@root.to_s.match?(%r{\A/mnt/[a-z](?:/|\z)}i)
     end
 
     # Keep one stable Windows-side context per source path. Its manifest lives

--- a/lib/wip/build_context.rb
+++ b/lib/wip/build_context.rb
@@ -33,7 +33,9 @@ module Wip
     private
 
     def shadow_required?
-      @shadow_root && @environment.wsl2? && !@root.to_s.match?(%r{\A/mnt/[a-z](?:/|\z)}i)
+      return false unless @shadow_root
+
+      @environment.wsl2? && !@root.to_s.match?(%r{\A/mnt/[a-z](?:/|\z)}i)
     end
 
     # Keep one stable Windows-side context per source path. Its manifest lives

--- a/lib/wip/cli.rb
+++ b/lib/wip/cli.rb
@@ -73,7 +73,8 @@ module Wip
       context = Pathname(load_config.path).dirname.join(settings['context'] || '.').to_s
       warn "wip: staging build context (#{context})"
       progress = StagingProgress.new
-      BuildContext.new(context).stage(on_progress: progress.method(:tick)) do |staged_context|
+      build_context = BuildContext.new(context, shadow_root: settings['shadow_context'])
+      build_context.stage(on_progress: progress.method(:tick)) do |staged_context|
         progress.finish
         built = builder.build(settings: settings.merge('context' => staged_context), extra: extra)
         execute(built, interactive: tty?(true))

--- a/lib/wip/config.rb
+++ b/lib/wip/config.rb
@@ -188,12 +188,20 @@ module Wip
       type = entry['type'] || (name == 'build' ? 'build' : 'exec')
       raise ConfigError, "Invalid command type for #{name}: #{type}" unless %w[exec run build].include?(type)
 
-      shadow_context = entry['shadow_context']
-      if entry.key?('shadow_context') && (type != 'build' || !shadow_context.is_a?(String) || shadow_context.empty?)
-        raise ConfigError, "commands.#{name}.shadow_context must be a non-empty path for a build command"
-      end
+      validate_shadow_context!(name, entry, type)
 
       entry['env']&.transform_values!(&:to_s)
+    end
+
+    # shadow_context names a Windows-side mirror of the build context, so it only
+    # means anything on a build command — and only as a real path.
+    def validate_shadow_context!(name, entry, type)
+      return unless entry.key?('shadow_context')
+
+      shadow_context = entry['shadow_context']
+      return if type == 'build' && shadow_context.is_a?(String) && !shadow_context.empty?
+
+      raise ConfigError, "commands.#{name}.shadow_context must be a non-empty path for a build command"
     end
 
     def validate_dependency!(name, entry)

--- a/lib/wip/config.rb
+++ b/lib/wip/config.rb
@@ -188,6 +188,11 @@ module Wip
       type = entry['type'] || (name == 'build' ? 'build' : 'exec')
       raise ConfigError, "Invalid command type for #{name}: #{type}" unless %w[exec run build].include?(type)
 
+      shadow_context = entry['shadow_context']
+      if entry.key?('shadow_context') && (type != 'build' || !shadow_context.is_a?(String) || shadow_context.empty?)
+        raise ConfigError, "commands.#{name}.shadow_context must be a non-empty path for a build command"
+      end
+
       entry['env']&.transform_values!(&:to_s)
     end
 

--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/spec/wip/build_context_spec.rb
+++ b/spec/wip/build_context_spec.rb
@@ -198,6 +198,16 @@ RSpec.describe Wip::BuildContext do
     end
   end
 
+  it 'leaves the shadow optimization disabled when no shadow root is configured' do
+    Dir.mktmpdir do |source|
+      File.write(File.join(source, 'app.rb'), '')
+
+      described_class.new(source, environment: wsl).stage do |staged|
+        expect(staged).to eq(source)
+      end
+    end
+  end
+
   it 'removes deleted and newly ignored files from an existing shadow context' do
     Dir.mktmpdir do |parent|
       source = File.join(parent, 'source')

--- a/spec/wip/build_context_spec.rb
+++ b/spec/wip/build_context_spec.rb
@@ -3,6 +3,8 @@
 require 'spec_helper'
 require 'fileutils'
 RSpec.describe Wip::BuildContext do
+  let(:wsl) { instance_double(Wip::Environment, wsl2?: true) }
+
   it 'yields the original context untouched when there is no .dockerignore' do
     Dir.mktmpdir do |dir|
       FileUtils.touch(File.join(dir, 'app.rb'))
@@ -165,6 +167,79 @@ RSpec.describe Wip::BuildContext do
       described_class.new(dir).stage do |staged|
         expect(File).to be_symlink(File.join(staged, 'broken'))
       end
+    end
+  end
+
+  it 'uses a persistent Windows-side shadow and only copies added or changed files after the first build' do
+    Dir.mktmpdir do |parent|
+      source = File.join(parent, 'source')
+      shadow_root = File.join(parent, 'windows-cache')
+      FileUtils.mkdir_p(source)
+      File.write(File.join(source, 'unchanged.rb'), 'same')
+      File.write(File.join(source, 'changed.rb'), 'old')
+
+      contexts = []
+      described_class.new(source, environment: wsl, shadow_root: shadow_root).stage { |path| contexts << path }
+      expect(File.read(File.join(contexts.first, 'unchanged.rb'))).to eq('same')
+
+      copied_sources = []
+      allow(FileUtils).to receive(:copy_entry).and_wrap_original do |original, source_path, *args|
+        copied_sources << source_path.to_s
+        original.call(source_path, *args)
+      end
+      File.write(File.join(source, 'changed.rb'), 'new content')
+      File.write(File.join(source, 'added.rb'), 'added')
+      described_class.new(source, environment: wsl, shadow_root: shadow_root).stage { |path| contexts << path }
+
+      expect(contexts.last).to eq(contexts.first)
+      expect(copied_sources.map { |path| File.basename(path) }).to contain_exactly('changed.rb', 'added.rb')
+      expect(File.read(File.join(contexts.last, 'changed.rb'))).to eq('new content')
+      expect(File.read(File.join(contexts.last, 'added.rb'))).to eq('added')
+    end
+  end
+
+  it 'removes deleted and newly ignored files from an existing shadow context' do
+    Dir.mktmpdir do |parent|
+      source = File.join(parent, 'source')
+      shadow_root = File.join(parent, 'windows-cache')
+      FileUtils.mkdir_p(source)
+      File.write(File.join(source, 'deleted.rb'), 'delete me')
+      File.write(File.join(source, 'ignored.log'), 'ignore me later')
+      builder = -> { described_class.new(source, environment: wsl, shadow_root: shadow_root) }
+
+      staged = nil
+      builder.call.stage { |path| staged = path }
+      FileUtils.rm(File.join(source, 'deleted.rb'))
+      File.write(File.join(source, '.dockerignore'), "*.log\n")
+      builder.call.stage { |path| staged = path }
+
+      expect(File).not_to exist(File.join(staged, 'deleted.rb'))
+      expect(File).not_to exist(File.join(staged, 'ignored.log'))
+      expect(File.read(File.join(staged, '.dockerignore'))).to eq("*.log\n")
+    end
+  end
+
+  it 'reports only shadow changes as progress and reports zero work when nothing changed' do
+    Dir.mktmpdir do |parent|
+      source = File.join(parent, 'source')
+      shadow_root = File.join(parent, 'windows-cache')
+      FileUtils.mkdir_p(source)
+      File.write(File.join(source, 'app.rb'), '')
+      builder = -> { described_class.new(source, environment: wsl, shadow_root: shadow_root) }
+
+      initial = []
+      builder.call.stage(on_progress: ->(count, total) { initial << [count, total] }) { nil }
+      unchanged = []
+      builder.call.stage(on_progress: ->(count, total) { unchanged << [count, total] }) { nil }
+
+      expect(initial).to eq([[0, 1], [1, 1]])
+      expect(unchanged).to eq([[0, 0]])
+    end
+  end
+
+  it 'builds a context on a mounted Windows drive directly, even under WSL' do
+    described_class.new('/mnt/c/project', environment: wsl, shadow_root: '/unused').stage do |staged|
+      expect(staged).to eq('/mnt/c/project')
     end
   end
 end

--- a/spec/wip/build_context_spec.rb
+++ b/spec/wip/build_context_spec.rb
@@ -5,6 +5,11 @@ require 'fileutils'
 RSpec.describe Wip::BuildContext do
   let(:wsl) { instance_double(Wip::Environment, wsl2?: true) }
 
+  # Examples that don't care about WSL shouldn't behave differently depending on
+  # whether the suite happens to be running under it. The shadow examples inject
+  # their own environment.
+  before { allow(Wip::Environment).to receive(:new).and_return(instance_double(Wip::Environment, wsl2?: false)) }
+
   it 'yields the original context untouched when there is no .dockerignore' do
     Dir.mktmpdir do |dir|
       FileUtils.touch(File.join(dir, 'app.rb'))
@@ -250,6 +255,61 @@ RSpec.describe Wip::BuildContext do
   it 'builds a context on a mounted Windows drive directly, even under WSL' do
     described_class.new('/mnt/c/project', environment: wsl, shadow_root: '/unused').stage do |staged|
       expect(staged).to eq('/mnt/c/project')
+    end
+  end
+
+  it 'refuses a shadow root inside the build context, which would copy itself into itself' do
+    Dir.mktmpdir do |source|
+      expect { described_class.new(source, environment: wsl, shadow_root: File.join(source, 'cache')) }
+        .to raise_error(Wip::ConfigError, /must not be inside the build context/)
+      expect { described_class.new(source, environment: wsl, shadow_root: source) }
+        .to raise_error(Wip::ConfigError, /must not be inside the build context/)
+    end
+  end
+
+  it 'rebuilds the shadow from scratch when its manifest is missing or unreadable' do
+    Dir.mktmpdir do |parent|
+      source = File.join(parent, 'source')
+      shadow_root = File.join(parent, 'windows-cache')
+      FileUtils.mkdir_p(source)
+      File.write(File.join(source, 'kept.rb'), 'kept')
+      File.write(File.join(source, 'deleted.rb'), 'delete me')
+      builder = -> { described_class.new(source, environment: wsl, shadow_root: shadow_root) }
+
+      staged = nil
+      builder.call.stage { |path| staged = path }
+      manifest = File.join(File.dirname(staged), 'manifest.json')
+      File.write(manifest, 'not json at all')
+      FileUtils.rm(File.join(source, 'deleted.rb'))
+      builder.call.stage { |path| staged = path }
+
+      expect(File.read(File.join(staged, 'kept.rb'))).to eq('kept')
+      expect(File).not_to exist(File.join(staged, 'deleted.rb'))
+
+      File.write(manifest, JSON.generate(%w[not a manifest hash]))
+      builder.call.stage { |path| staged = path }
+      expect(File.read(File.join(staged, 'kept.rb'))).to eq('kept')
+    end
+  end
+
+  it 'keeps executable bits when staging, so a RUN of a staged script still works' do
+    Dir.mktmpdir do |parent|
+      source = File.join(parent, 'source')
+      shadow_root = File.join(parent, 'windows-cache')
+      FileUtils.mkdir_p(source)
+      # A rule that matches nothing forces the filtered copy instead of yielding
+      # the source directory untouched.
+      File.write(File.join(source, '.dockerignore'), "nonexistent-dir/\n")
+      script = File.join(source, 'entrypoint.sh')
+      File.write(script, "#!/bin/sh\n")
+      File.chmod(0o755, script)
+
+      described_class.new(source).stage do |staged|
+        expect(File.stat(File.join(staged, 'entrypoint.sh')).mode & 0o777).to eq(0o755)
+      end
+      described_class.new(source, environment: wsl, shadow_root: shadow_root).stage do |staged|
+        expect(File.stat(File.join(staged, 'entrypoint.sh')).mode & 0o777).to eq(0o755)
+      end
     end
   end
 end

--- a/spec/wip/config_spec.rb
+++ b/spec/wip/config_spec.rb
@@ -39,6 +39,20 @@ RSpec.describe Wip::Config do
       .to raise_error(Wip::ConfigError, 'commands must be a mapping')
   end
 
+  it 'accepts a shadow context path on the build command' do
+    config = described_class.new('commands' => { 'build' => { 'tag' => 'example:dev',
+                                                              'shadow_context' => '/mnt/c/wip-cache' } })
+
+    expect(config.command('build')['shadow_context']).to eq('/mnt/c/wip-cache')
+  end
+
+  it 'rejects an empty shadow context path or one attached to a non-build command' do
+    expect { described_class.new('commands' => { 'build' => { 'shadow_context' => '' } }) }
+      .to raise_error(Wip::ConfigError, /shadow_context must be a non-empty path/)
+    expect { described_class.new('commands' => { 'shell' => { 'shadow_context' => '/mnt/c/cache' } }) }
+      .to raise_error(Wip::ConfigError, /shadow_context must be a non-empty path for a build command/)
+  end
+
   it 'exposes container and the primary dependency it points at, with no implicit default' do
     config = described_class.new('container' => 'app',
                                  'dependencies' => { 'app' => { 'image' => 'example:dev', 'command' => 'local' } })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional persistent shadow-context builds for WSL2 environments.
  - Improved incremental file synchronization, cleanup, progress reporting, and preservation of file permissions and symbolic links.
  - Added configuration support for specifying a shadow-context path.

- **Bug Fixes**
  - Improved recovery from invalid or unreadable build manifests.
  - Added validation for invalid shadow-context locations and configuration values.

- **Documentation**
  - Expanded configuration and Docker ignore guidance.
  - Clarified development test and linting commands.

- **Chores**
  - Updated the application version to 1.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->