### PR TITLE
fix(build): chdir into build context instead of passing wslc an absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,9 +245,9 @@ real Compose tools, not by `wip`, so `wip` silently ignores it rather than rejec
 valid compose.yml over sections it doesn't need to look at:
 
 - Per service: `image`, `build` (string or `{context:, dockerfile:, args:, shadow_context:}`;
-  `context`/`dockerfile` are resolved relative to `compose.yml`, not wherever `wip` is invoked
-  from — see [.dockerignore](#dockerignore) for what `shadow_context` does), `command` (shell or
-  exec form), `environment`
+  `context` is resolved relative to `compose.yml`, not wherever `wip` is invoked from; `dockerfile`
+  stays relative to `context` itself — see [.dockerignore](#dockerignore) for what `shadow_context`
+  does), `command` (shell or exec form), `environment`
   (mapping or `KEY=VALUE` array — a mapping value must not be null; host environment pass-through
   isn't supported), `ports`/`volumes` (short syntax only — `"host:container"` strings, not
   long-syntax mappings), `working_dir`, `user`, `depends_on` (ordering only — a `condition:` other

--- a/README.md
+++ b/README.md
@@ -244,8 +244,10 @@ top level (`networks:`, `volumes:`, `configs:`, `secrets:`, ...) is the one exce
 real Compose tools, not by `wip`, so `wip` silently ignores it rather than rejecting an otherwise
 valid compose.yml over sections it doesn't need to look at:
 
-- Per service: `image`, `build` (string or `{context:, dockerfile:}`; resolved relative to
-  `compose.yml`, not wherever `wip` is invoked from), `command` (shell or exec form), `environment`
+- Per service: `image`, `build` (string or `{context:, dockerfile:, args:, shadow_context:}`;
+  `context`/`dockerfile` are resolved relative to `compose.yml`, not wherever `wip` is invoked
+  from — see [.dockerignore](#dockerignore) for what `shadow_context` does), `command` (shell or
+  exec form), `environment`
   (mapping or `KEY=VALUE` array — a mapping value must not be null; host environment pass-through
   isn't supported), `ports`/`volumes` (short syntax only — `"host:container"` strings, not
   long-syntax mappings), `working_dir`, `user`, `depends_on` (ordering only — a `condition:` other
@@ -272,13 +274,14 @@ to load a different file instead.
 
 `wip build` reads `.dockerignore` from the build context and excludes anything it matches before
 handing the context to `wslc build`, since `wslc` sends the context as-is otherwise. Set
-`commands.build.shadow_context` in `wip.yml` to a directory on the Windows filesystem to enable a
-persistent shadow context for projects outside `/mnt/<drive>`. The first build copies every
-included file; later builds only copy added or changed files and remove deleted or newly ignored
-files. Without this setting the optimization is disabled, and it only applies under WSL2 — on WSL1
-(or anywhere else) the context is handed to `wslc build` directly. Projects already on `/mnt/c` (or
-another mounted Windows drive) also continue to build directly even when the setting is present.
-The path must live outside the build context itself, or `wip build` refuses it.
+`commands.build.shadow_context` in `wip.yml` (or `build.shadow_context` on a compose-native
+`build:` service in `compose.yml`) to a directory on the Windows filesystem to enable a persistent
+shadow context for projects outside `/mnt/<drive>`. The first build copies every included file;
+later builds only copy added or changed files and remove deleted or newly ignored files. Without
+this setting the optimization is disabled, and it only applies under WSL2 — on WSL1 (or anywhere
+else) the context is handed to `wslc build` directly. Projects already on `/mnt/c` (or another
+mounted Windows drive) also continue to build directly even when the setting is present. The path
+must live outside the build context itself, or `wip build`/`wip up` refuses it.
 
 ### Source sync
 

--- a/lib/wip/build_context.rb
+++ b/lib/wip/build_context.rb
@@ -30,6 +30,11 @@ module Wip
       end
     end
 
+    # Whether the upcoming stage will use the Windows-side shadow directory
+    # (configured shadow_root, on WSL2, with a context outside /mnt) rather
+    # than staging in place or under a WSL-side tmpdir.
+    def shadow? = shadow_required?
+
     private
 
     # A shadow root under the context would itself be walked by included_files

--- a/lib/wip/cli.rb
+++ b/lib/wip/cli.rb
@@ -76,8 +76,7 @@ module Wip
       build_context = BuildContext.new(context, shadow_root: settings['shadow_context'])
       build_context.stage(on_progress: progress.method(:tick)) do |staged_context|
         progress.finish
-        built = builder.build(settings: settings.merge('context' => staged_context), extra: extra)
-        execute(built, interactive: tty?(true))
+        run_staged_build(build_context, staged_context, settings, extra)
       end
     ensure
       progress&.finish
@@ -248,10 +247,12 @@ module Wip
       execute(exec_target(command, interactive: interactive), interactive: tty?(interactive))
     end
 
-    def execute(command, interactive: false, exit_on_failure: true)
+    def execute(command, interactive: false, exit_on_failure: true, chdir: nil)
       runner = CommandRunner.new(debug: debug?)
+      run_options = { interactive: interactive }
+      run_options[:chdir] = chdir if chdir
       code = reporter.step("running: #{CommandDisplay.for_debug(command)}", live: !interactive) do
-        runner.run(command, interactive: interactive)
+        runner.run(command, **run_options)
       end
       exit(code) if exit_on_failure && !code.zero?
       code
@@ -322,13 +323,21 @@ module Wip
       extra = compose_build_extra(spec)
       warn "wip: building service '#{name}' (tag: #{spec['tag']}) from #{spec['context']}"
       progress = StagingProgress.new
-      BuildContext.new(spec['context']).stage(on_progress: progress.method(:tick)) do |staged_context|
+      build_context = BuildContext.new(spec['context'], shadow_root: spec['shadow_context'])
+      build_context.stage(on_progress: progress.method(:tick)) do |staged_context|
         progress.finish
-        settings = { 'context' => staged_context, 'tag' => spec['tag'] }
-        execute(builder.build(settings: settings, extra: extra), interactive: tty?(true))
+        run_staged_build(build_context, staged_context, { 'tag' => spec['tag'] }, extra)
       end
     ensure
       progress&.finish
+    end
+
+    # wslc build crashes (ERROR_UNHANDLED_EXCEPTION) when handed an absolute
+    # context path; running from inside the context and passing "." avoids it.
+    def run_staged_build(build_context, staged_context, settings, extra)
+      warn "wip: using shadow build context at #{staged_context}" if build_context.shadow?
+      built = builder.build(settings: settings.merge('context' => '.'), extra: extra)
+      execute(built, interactive: tty?(true), chdir: staged_context)
     end
 
     def build_extra_options(extra)
@@ -356,7 +365,9 @@ module Wip
 
       Dir.mktmpdir('wip-sync-build-') do |dir|
         File.write(File.join(dir, 'Dockerfile'), settings.build['dockerfile'])
-        execute(builder.sync_build(dir))
+        # wslc build crashes (ERROR_UNHANDLED_EXCEPTION) when handed an absolute
+        # context path; running from inside the context and passing "." avoids it.
+        execute(builder.sync_build('.'), chdir: dir)
       end
     end
 

--- a/lib/wip/command_runner.rb
+++ b/lib/wip/command_runner.rb
@@ -14,13 +14,14 @@ module Wip
       @debug = debug
     end
 
-    def run(command, env: {}, interactive: false)
+    def run(command, env: {}, interactive: false, chdir: nil)
       @stderr.puts "+ #{CommandDisplay.for_debug(command)}" if @debug
-      return run_attached(command, env) if interactive
+      return run_attached(command, env, chdir) if interactive
 
+      opts = chdir ? { chdir: chdir } : {}
       captured = +''
       status = nil
-      Open3.popen3(env, *command) do |input, output, error, wait|
+      Open3.popen3(env, *command, opts) do |input, output, error, wait|
         input.close
         threads = [pump(output, @stdout, captured), pump(error, @stderr, captured)]
         threads.each(&:join)
@@ -54,8 +55,9 @@ module Wip
     # stdin immediately, which breaks anything that reads from the terminal
     # (a shell, `rails console`, ...). Inherit the real file descriptors
     # instead so the child gets a genuine TTY.
-    def run_attached(command, env)
-      pid = Process.spawn(env, *command)
+    def run_attached(command, env, chdir)
+      opts = chdir ? { chdir: chdir } : {}
+      pid = Process.spawn(env, *command, opts)
       _, status = Process.wait2(pid)
       exitstatus(status)
     rescue Errno::ENOENT => e

--- a/lib/wip/compose_file.rb
+++ b/lib/wip/compose_file.rb
@@ -24,7 +24,7 @@ module Wip
     # service already shares one project network (config.rb); and `wslc run`/`exec` has no
     # restart-policy or capability flag to forward `restart:`/`cap_add:` to.
     IGNORED_SERVICE_KEYS = %w[tty stdin_open networks restart cap_add].freeze
-    BUILD_KEYS = %w[context dockerfile args].freeze
+    BUILD_KEYS = %w[context dockerfile args shadow_context].freeze
     SUPPORTED_CONDITIONS = %w[service_started].freeze
     LIST_HINT = 'only supports short syntax ("host:container"), not long-syntax mappings'
 
@@ -140,9 +140,11 @@ module Wip
         unless unknown.empty?
 
       context = resolve_context(presence(value['context']) || '.')
-      dockerfile = presence(value['dockerfile'])
-      { 'context' => context, 'dockerfile' => dockerfile && Pathname(context).join(dockerfile).to_s,
-        'args' => normalize_kv(name, value['args'], 'build.args') }.compact
+      # Kept relative to context (not resolved against it) so `-f` still finds it once
+      # `wip up`/`wip build` chdir into a staged or shadowed copy of that context.
+      { 'context' => context, 'dockerfile' => presence(value['dockerfile']),
+        'args' => normalize_kv(name, value['args'], 'build.args'),
+        'shadow_context' => presence(value['shadow_context']) }.compact
     end
 
     # build.context is relative to compose.yml's own directory (Compose's own rule),

--- a/spec/wip/cli_spec.rb
+++ b/spec/wip/cli_spec.rb
@@ -265,8 +265,8 @@ RSpec.describe Wip::CLI do
               RUN apk add --no-cache rsync
       YAML
       runner = stub_runner('')
-      expect(runner).to receive(:run).with(a_collection_including('build', '-t', 'wip-sync-app:latest'),
-                                           interactive: false).and_return(0).ordered
+      expect(runner).to receive(:run).with(a_collection_including('build', '-t', 'wip-sync-app:latest', '.'),
+                                           interactive: false, chdir: a_kind_of(String)).and_return(0).ordered
       expect(runner).to receive(:run).with(a_collection_including('--rm', 'wip-sync-app:latest', 'rsync'),
                                            interactive: false).and_return(0).ordered
 
@@ -287,7 +287,8 @@ RSpec.describe Wip::CLI do
       YAML
       runner = stub_runner('')
       builds = 0
-      allow(runner).to receive(:run).with(a_collection_including('build'), interactive: false) do
+      allow(runner).to receive(:run)
+        .with(a_collection_including('build'), interactive: false, chdir: a_kind_of(String)) do
         builds += 1
         0
       end
@@ -377,10 +378,11 @@ RSpec.describe Wip::CLI do
                                                                             resolve: 'wslc.exe'))
     staged_context = nil
     dockerfile_present = node_modules_present = nil
-    expect(runner).to receive(:run) do |command, **_kwargs|
-      staged_context = command.last
+    expect(runner).to receive(:run) do |command, **kwargs|
+      staged_context = kwargs[:chdir]
       dockerfile_present = File.exist?(File.join(staged_context, 'Dockerfile'))
       node_modules_present = File.exist?(File.join(staged_context, 'node_modules'))
+      expect(command.last).to eq('.')
       0
     end
 
@@ -412,8 +414,9 @@ RSpec.describe Wip::CLI do
       allow(Wip::CommandResolver).to receive(:new).and_return(instance_double(Wip::CommandResolver,
                                                                               resolve: 'wslc.exe'))
       staged_context = nil
-      expect(runner).to receive(:run) do |command, **_kwargs|
-        staged_context = command.last
+      expect(runner).to receive(:run) do |command, **kwargs|
+        staged_context = kwargs[:chdir]
+        expect(command.last).to eq('.')
         0
       end
 
@@ -640,8 +643,55 @@ RSpec.describe Wip::CLI do
       described_class.start(%w[up -d])
 
       expect(runner).to have_received(:run).with(
-        ['wslc.exe', 'build', '-t', 'wip-compose-app:latest', File.expand_path('.')], interactive: false
+        ['wslc.exe', 'build', '-t', 'wip-compose-app:latest', '.'], interactive: false, chdir: File.expand_path('.')
       )
+    end
+
+    it 'passes build.dockerfile to -f relative to the context, so it still resolves after chdir' do
+      File.write('compose.yml', <<~YAML)
+        services:
+          app:
+            build:
+              context: .
+              dockerfile: docker/Dockerfile.dev
+      YAML
+      runner = instance_double(Wip::CommandRunner, run: 0)
+      allow(Wip::CommandRunner).to receive(:new).and_return(runner)
+      allow(runner).to receive(:run).and_return(0)
+
+      described_class.start(%w[up -d])
+
+      expect(runner).to have_received(:run).with(
+        ['wslc.exe', 'build', '-t', 'wip-compose-app:latest', '-f', 'docker/Dockerfile.dev', '.'],
+        interactive: false, chdir: File.expand_path('.')
+      )
+    end
+
+    it 'stages a compose build: through its shadow_context when configured on WSL2' do
+      allow(Wip::Environment).to receive(:new)
+        .and_return(instance_double(Wip::Environment, wsl2?: true, interactive?: false))
+
+      Dir.mktmpdir do |shadow_root|
+        File.write('compose.yml', <<~YAML)
+          services:
+            app:
+              build:
+                context: .
+                shadow_context: #{shadow_root}
+        YAML
+        runner = instance_double(Wip::CommandRunner, run: 0)
+        allow(Wip::CommandRunner).to receive(:new).and_return(runner)
+        chdir = nil
+        expect(runner).to receive(:run) do |command, **kwargs|
+          chdir = kwargs[:chdir]
+          expect(command.last).to eq('.')
+          0
+        end
+
+        expect { described_class.start(%w[up -d]) }.to output(/using shadow build context at/).to_stderr
+
+        expect(chdir).to start_with(shadow_root)
+      end
     end
 
     it 'names the service being built so multiple build: entries are distinguishable' do
@@ -672,7 +722,8 @@ RSpec.describe Wip::CLI do
       described_class.start(%w[up --no-cache -d])
 
       expect(runner).to have_received(:run).with(
-        ['wslc.exe', 'build', '-t', 'wip-compose-app:latest', '--no-cache', File.expand_path('.')], interactive: false
+        ['wslc.exe', 'build', '-t', 'wip-compose-app:latest', '--no-cache', '.'],
+        interactive: false, chdir: File.expand_path('.')
       )
     end
 

--- a/spec/wip/command_runner_spec.rb
+++ b/spec/wip/command_runner_spec.rb
@@ -10,6 +10,29 @@ RSpec.describe Wip::CommandRunner do
     expect(described_class.new.run([RbConfig.ruby, '-e', 'exit 7'], interactive: true)).to eq(7)
   end
 
+  it 'runs the command inside chdir instead of the process working directory' do
+    Dir.mktmpdir do |dir|
+      stdout = StringIO.new
+      runner = described_class.new(stdout: stdout)
+      script = 'print Dir.pwd'
+
+      runner.run([RbConfig.ruby, '-e', script], chdir: dir)
+
+      expect(stdout.string).to eq(File.realpath(dir))
+    end
+  end
+
+  it 'runs an interactive command inside chdir too' do
+    Dir.mktmpdir do |dir|
+      marker = File.join(dir, 'marker')
+      script = "File.write('marker', Dir.pwd)"
+
+      described_class.new.run([RbConfig.ruby, '-e', script], interactive: true, chdir: dir)
+
+      expect(File.read(marker)).to eq(File.realpath(dir))
+    end
+  end
+
   it 'returns 130 and reports the interrupt instead of raising when Ctrl-C hits while waiting on pump threads' do
     raised = false
     allow_any_instance_of(Thread).to receive(:join).and_wrap_original do |original, *args|

--- a/spec/wip/compose_file_spec.rb
+++ b/spec/wip/compose_file_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Wip::ComposeFile do
     YAML
 
     spec = described_class.load(path).build_specs['app']
-    expect(spec['dockerfile']).to eq(File.expand_path('Dockerfile.dev'))
+    expect(spec['dockerfile']).to eq('Dockerfile.dev')
     expect(described_class.load(path).to_dependencies_hash['app']['image']).to eq('wip-compose-app:latest')
   end
 
@@ -164,6 +164,30 @@ RSpec.describe Wip::ComposeFile do
               - FOO=bar
     YAML
     expect(described_class.load(array).build_specs['app']['args']).to eq('FOO' => 'bar')
+  end
+
+  it 'passes build.shadow_context through untouched, unlike context which is resolved' do
+    path = write_compose(<<~YAML)
+      services:
+        app:
+          build:
+            context: .
+            shadow_context: /mnt/c/Users/me/AppData/Local/wip/build-contexts
+    YAML
+
+    expect(described_class.load(path).build_specs['app']['shadow_context'])
+      .to eq('/mnt/c/Users/me/AppData/Local/wip/build-contexts')
+  end
+
+  it 'omits shadow_context from the build spec when not configured' do
+    path = write_compose(<<~YAML)
+      services:
+        app:
+          build:
+            context: .
+    YAML
+
+    expect(described_class.load(path).build_specs['app']).not_to have_key('shadow_context')
   end
 
   it 'rejects unsupported build keys' do


### PR DESCRIPTION
## Summary
- `wslc build` crashes with `ERROR_UNHANDLED_EXCEPTION` whenever it's handed an absolute context path. `wip build`, `wip up`'s compose-native `build:` services, and `sync.build` now `chdir` into the (staged/shadowed) context and pass `.` instead.
- `compose.yml`'s `build:` block can now set `shadow_context` (mirroring `commands.build.shadow_context`), so compose-native builds can use the persistent Windows-side shadow cache too.
- `build.dockerfile` is now kept relative to `context` instead of being resolved to an absolute path — an absolute `-f` path broke once builds started running from inside a (possibly shadowed) staged context.
- `wip build` now reports the shadow directory it staged into (`wip: using shadow build context at ...`) when `shadow_context` is actually in effect.

## Test plan
- [x] `bundle exec rspec` (263 examples, 0 failures)
- [x] `bundle exec rubocop` (no offenses)
- [x] Manually verified against a real project on WSL2: `wip build` and `wip up` both build successfully via the shadow context, where they previously crashed with `ERROR_UNHANDLED_EXCEPTION` / `ERROR_FILE_NOT_FOUND`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compose-native build definitions now support `args` and `shadow_context`.
  * Added support for configuring shadow build contexts where needed.
* **Bug Fixes**
  * Improved builds using relative or absolute contexts and Dockerfiles.
  * Standardized staged build execution across regular and compose-native builds.
  * Ensured options such as `--no-cache` continue to work correctly.
* **Documentation**
  * Updated build configuration and `.dockerignore` guidance for shadow contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->