### PR TITLE
feat(runner): route interactive commands through a pty so hints still fire

### DIFF
--- a/lib/wip/command_runner.rb
+++ b/lib/wip/command_runner.rb
@@ -69,7 +69,7 @@ module Wip
       status = nil
       PTY.spawn(env, *command, opts) do |output, input, pid|
         sync_winsize(output)
-        with_raw_stdin { pump_attached(output, input, captured) }
+        with_winsize_sync(output) { with_raw_stdin { pump_attached(output, input, captured) } }
         _, status = Process.wait2(pid)
       end
       report_hint(captured) unless status.success?
@@ -100,6 +100,20 @@ module Wip
     # (piped output, tests) has no size to read, so the pty keeps its default.
     def sync_winsize(output)
       output.winsize = @stdout.winsize if @stdout.respond_to?(:winsize) && @stdout.tty?
+    end
+
+    # The child's pty only gets the terminal size wip had at spawn time
+    # (sync_winsize, above) — it's a separate pty from wip's own real one, so
+    # later resizes of wip's terminal don't reach it on their own. Trap
+    # SIGWINCH for the duration to re-sync it live, restoring whatever handler
+    # was already installed (if any) once the command finishes.
+    def with_winsize_sync(output)
+      return yield unless @stdout.respond_to?(:winsize) && @stdout.tty?
+
+      previous = Signal.trap('WINCH') { sync_winsize(output) }
+      yield
+    ensure
+      Signal.trap('WINCH', previous) if previous
     end
 
     # A non-tty @stdin (piped input, tests) has no raw mode to switch to, so

--- a/lib/wip/command_runner.rb
+++ b/lib/wip/command_runner.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'open3'
+require 'pty'
+require 'io/console'
 
 module Wip
   # Executes a built command, pumping its I/O and returning the exit status.
@@ -53,16 +55,70 @@ module Wip
 
     # Piping stdin/stdout/stderr (as `run` does above) closes the child's
     # stdin immediately, which breaks anything that reads from the terminal
-    # (a shell, `rails console`, ...). Inherit the real file descriptors
-    # instead so the child gets a genuine TTY.
+    # (a shell, `rails console`, ...). Run it behind a pseudo-terminal instead
+    # of inheriting wip's real fds directly: a pty still gives the child a
+    # genuine controlling terminal (job control, Ctrl-C -> SIGINT, isatty-gated
+    # rendering all work the same as direct inheritance), but routes output
+    # through wip first, so report_hint can still see it — inherited fds go
+    # straight to the terminal and wip never would. wip's own terminal is
+    # switched to raw mode for the duration so only the pty's line discipline
+    # echoes input; without that, every keystroke would echo twice.
     def run_attached(command, env, chdir)
       opts = chdir ? { chdir: chdir } : {}
-      pid = Process.spawn(env, *command, opts)
-      _, status = Process.wait2(pid)
+      captured = +''
+      status = nil
+      PTY.spawn(env, *command, opts) do |output, input, pid|
+        sync_winsize(output)
+        with_raw_stdin { pump_attached(output, input, captured) }
+        _, status = Process.wait2(pid)
+      end
+      report_hint(captured) unless status.success?
       exitstatus(status)
     rescue Errno::ENOENT => e
       @stderr.puts e.message
       127
+    rescue Interrupt
+      @stderr.puts "\nwip: interrupted"
+      130
+    end
+
+    def pump_attached(output, input, captured)
+      stdin_thread = forward_stdin(input)
+      loop do
+        chunk = output.readpartial(4096)
+        @stdout.write(chunk)
+        captured << chunk
+      end
+    rescue Errno::EIO, IOError
+      # the pty's slave side closed when the child exited
+    ensure
+      stdin_thread.kill
+    end
+
+    # Keeps the child's pty sized to wip's real terminal so full-screen
+    # programs (an editor, `less`, ...) render correctly. A non-tty @stdout
+    # (piped output, tests) has no size to read, so the pty keeps its default.
+    def sync_winsize(output)
+      output.winsize = @stdout.winsize if @stdout.respond_to?(:winsize) && @stdout.tty?
+    end
+
+    # A non-tty @stdin (piped input, tests) has no raw mode to switch to, so
+    # it's forwarded to the child as-is.
+    def with_raw_stdin(&)
+      return yield unless @stdin.respond_to?(:raw) && @stdin.tty?
+
+      @stdin.raw(&)
+    end
+
+    def forward_stdin(input)
+      Thread.new do
+        loop do
+          chunk = @stdin.readpartial(4096)
+          input.write(chunk)
+        end
+      rescue IOError, Errno::EIO, Errno::EBADF
+        nil
+      end
     end
 
     # An Interrupt during the main thread's `join` closes these pipes out from

--- a/spec/wip/command_runner_spec.rb
+++ b/spec/wip/command_runner_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'pty'
+
 RSpec.describe Wip::CommandRunner do
   it 'returns the external command exit status' do
     expect(described_class.new.run([RbConfig.ruby, '-e', 'exit 23'])).to eq(23)
@@ -30,6 +32,32 @@ RSpec.describe Wip::CommandRunner do
       described_class.new.run([RbConfig.ruby, '-e', script], interactive: true, chdir: dir)
 
       expect(File.read(marker)).to eq(File.realpath(dir))
+    end
+  end
+
+  it 'reports a hint for an interactive command too, unlike the plain fd-inheriting attach it replaced' do
+    stdout = StringIO.new
+    stderr = StringIO.new
+    runner = described_class.new(stdout: stdout, stderr: stderr)
+    script = <<~RUBY
+      STDOUT.write('too many mounted volumes')
+      exit 1
+    RUBY
+
+    status = runner.run([RbConfig.ruby, '-e', script], interactive: true)
+
+    expect(status).to eq(1)
+    expect(stderr.string).to include('mounted-volume limit')
+  end
+
+  it 'puts a real controlling terminal in raw mode and syncs the pty size, without raising' do
+    PTY.open do |master, slave|
+      runner = described_class.new(stdin: slave, stdout: slave, stderr: StringIO.new)
+
+      status = runner.run([RbConfig.ruby, '-e', 'exit 0'], interactive: true)
+
+      expect(status).to eq(0)
+      master.close
     end
   end
 

--- a/spec/wip/command_runner_spec.rb
+++ b/spec/wip/command_runner_spec.rb
@@ -50,6 +50,23 @@ RSpec.describe Wip::CommandRunner do
     expect(stderr.string).to include('mounted-volume limit')
   end
 
+  it 'propagates a terminal resize (SIGWINCH) to the child pty while attached' do
+    PTY.open do |master, slave|
+      slave.winsize = [24, 80]
+      runner = described_class.new(stdin: slave, stdout: slave, stderr: StringIO.new)
+      script = 'sleep 0.4; require "io/console"; STDOUT.write($stdout.winsize.join(","))'
+
+      thread = Thread.new { runner.run([RbConfig.ruby, '-e', script], interactive: true) }
+      sleep 0.1
+      slave.winsize = [50, 120] # simulates the terminal emulator resizing wip's own pty
+      Process.kill('WINCH', Process.pid) # simulates the kernel notifying wip of that resize
+      thread.join
+
+      expect(master.read_nonblock(4096)).to include('50,120')
+      master.close
+    end
+  end
+
   it 'puts a real controlling terminal in raw mode and syncs the pty size, without raising' do
     PTY.open do |master, slave|
       runner = described_class.new(stdin: slave, stdout: slave, stderr: StringIO.new)


### PR DESCRIPTION
## Summary
- Stacked on #65 — targets that branch, not `main`, since it reuses the `chdir:` plumbing added there.
- `report_hint` (the wslc volume-limit / registry / rsync / arch hints in `ErrorInterpreter`) only ever fired on the non-interactive, piped `run` path. Interactive commands (`wip build`/`wip up` on a real terminal, `wip shell`, `wip exec`, any custom `interactive: true` command) went through `run_attached`, which inherited wip's real fds directly — output went straight to the terminal and wip itself never saw it, so hints never fired there.
- `run_attached` now runs the child behind a pty (`PTY.spawn`) instead of inheriting fds directly. This still gives the child a genuine controlling terminal — job control, Ctrl-C → SIGINT, isatty-gated rendering — but routes output through wip first, so it can be captured for `report_hint` the same way the piped path already does. wip's own terminal is switched to raw mode for the duration (`io/console`) so only the pty's line discipline echoes input — otherwise every keystroke would echo twice.

## Test plan
- [x] `bundle exec rspec` (265 examples, 0 failures), including new specs that exercise the pty path directly (one nesting a real `PTY.open` pair as a stand-in controlling terminal to exercise raw-mode/winsize, one asserting the hint fires for a failing interactive command)
- [x] `bundle exec rubocop` (no offenses)
- [x] Reran the new specs 5x back-to-back to check for flakiness — stable
- [ ] **Not verified**: real interactive use (`wip shell`, `rails console`, arrow-key/readline editing, Ctrl-C behavior, terminal resize) on an actual attached terminal. This sandbox has no real controlling terminal, so I could only validate the underlying pty mechanics (spawn/env/chdir/stderr-merging/EOF-via-EIO) with standalone Ruby scripts and PTY-in-PTY specs — **please manually verify `wip shell` / an interactive `bin/rails console` / Ctrl-C still behave normally before merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive commands now support terminal-based input and output.
  * Terminal dimensions synchronize automatically during interactive sessions.
  * Output is captured to provide more helpful failure hints, including mounted-volume guidance.
  * Interactive sessions temporarily enable raw input mode for improved terminal support.

* **Bug Fixes**
  * Improved handling of interrupts and terminal session shutdowns.
  * Non-interactive commands continue using standard execution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->