### PR TITLE
fix(runner): fall back to inherited stdio for interactive commands on native Windows

### DIFF
--- a/lib/wip/command_runner.rb
+++ b/lib/wip/command_runner.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'open3'
-require 'pty'
+require 'pty' unless Gem.win_platform?
 require 'io/console'
 
 module Wip
@@ -18,7 +18,7 @@ module Wip
 
     def run(command, env: {}, interactive: false, chdir: nil)
       @stderr.puts "+ #{CommandDisplay.for_debug(command)}" if @debug
-      return run_attached(command, env, chdir) if interactive
+      return run_interactive(command, env, chdir) if interactive
 
       opts = chdir ? { chdir: chdir } : {}
       captured = +''
@@ -40,6 +40,10 @@ module Wip
     end
 
     private
+
+    def run_interactive(command, env, chdir)
+      Gem.win_platform? ? run_inherited(command, env, chdir) : run_attached(command, env, chdir)
+    end
 
     # exitstatus is nil when the process was killed by a signal instead of
     # exiting normally; fall back to the conventional 128+signal shell code
@@ -73,6 +77,26 @@ module Wip
         _, status = Process.wait2(pid)
       end
       report_hint(captured) unless status.success?
+      exitstatus(status)
+    rescue Errno::ENOENT => e
+      @stderr.puts e.message
+      127
+    rescue Interrupt
+      @stderr.puts "\nwip: interrupted"
+      130
+    end
+
+    # Ruby's PTY library wraps openpty(3), which native Windows builds don't
+    # ship (require 'pty' is skipped there entirely, see the top of this
+    # file). Fall back to letting the child inherit wip's real stdio
+    # directly, same as `run` would've done pre-pty for the piped case: it
+    # still gives the child a real console (job control, Ctrl-C, isatty
+    # rendering all work), just without a way for wip to see the output, so
+    # report_hint can't run on failure here.
+    def run_inherited(command, env, chdir)
+      opts = chdir ? { chdir: chdir } : {}
+      pid = Process.spawn(env, *command, opts)
+      _, status = Process.wait2(pid)
       exitstatus(status)
     rescue Errno::ENOENT => e
       @stderr.puts e.message

--- a/lib/wip/command_runner.rb
+++ b/lib/wip/command_runner.rb
@@ -95,6 +95,10 @@ module Wip
     # report_hint can't run on failure here.
     def run_inherited(command, env, chdir)
       opts = chdir ? { chdir: chdir } : {}
+      opts[:in] = @stdin if io_stream?(@stdin)
+      opts[:out] = @stdout if io_stream?(@stdout)
+      opts[:err] = @stderr if io_stream?(@stderr)
+      pid = nil
       pid = Process.spawn(env, *command, opts)
       _, status = Process.wait2(pid)
       exitstatus(status)
@@ -102,8 +106,28 @@ module Wip
       @stderr.puts e.message
       127
     rescue Interrupt
+      reap_interrupted_child(pid)
       @stderr.puts "\nwip: interrupted"
       130
+    end
+
+    # Process.spawn can only redirect to real OS-backed streams (an IO, or
+    # something that wraps one via to_io) — StringIO and friends (used by
+    # tests, and by wip's own quiet/capture modes) aren't valid redirection
+    # targets. Fall back to the process's own inherited fds for those rather
+    # than passing them through and having Process.spawn reject them.
+    def io_stream?(stream) = stream.respond_to?(:to_io)
+
+    # The child shares wip's real controlling terminal here (unlike the pty
+    # path), so it already received the same Ctrl-C the terminal delivered to
+    # wip; there's nothing to kill, just something to reap so it doesn't
+    # linger as a zombie once wip moves on.
+    def reap_interrupted_child(pid)
+      return unless pid
+
+      Process.wait2(pid)
+    rescue Errno::ECHILD, Interrupt
+      nil
     end
 
     def pump_attached(output, input, captured)

--- a/spec/wip/command_runner_spec.rb
+++ b/spec/wip/command_runner_spec.rb
@@ -78,6 +78,25 @@ RSpec.describe Wip::CommandRunner do
     end
   end
 
+  it 'falls back to inheriting real stdio on native Windows, where the pty gem is unavailable' do
+    allow(Gem).to receive(:win_platform?).and_return(true)
+
+    expect(described_class.new.run([RbConfig.ruby, '-e', 'exit 9'], interactive: true)).to eq(9)
+  end
+
+  it 'runs the Windows fallback inside chdir too' do
+    allow(Gem).to receive(:win_platform?).and_return(true)
+
+    Dir.mktmpdir do |dir|
+      marker = File.join(dir, 'marker')
+      script = "File.write('marker', Dir.pwd)"
+
+      described_class.new.run([RbConfig.ruby, '-e', script], interactive: true, chdir: dir)
+
+      expect(File.read(marker)).to eq(File.realpath(dir))
+    end
+  end
+
   it 'returns 130 and reports the interrupt instead of raising when Ctrl-C hits while waiting on pump threads' do
     raised = false
     allow_any_instance_of(Thread).to receive(:join).and_wrap_original do |original, *args|

--- a/spec/wip/command_runner_spec.rb
+++ b/spec/wip/command_runner_spec.rb
@@ -84,8 +84,25 @@ RSpec.describe Wip::CommandRunner do
 
   it 'falls back to inheriting real stdio on native Windows, where the pty gem is unavailable' do
     allow(Gem).to receive(:win_platform?).and_return(true)
+    runner = described_class.new
+    expect(runner).to receive(:run_inherited).and_call_original
+    expect(runner).not_to receive(:run_attached)
 
-    expect(described_class.new.run([RbConfig.ruby, '-e', 'exit 9'], interactive: true)).to eq(9)
+    expect(runner.run([RbConfig.ruby, '-e', 'exit 9'], interactive: true)).to eq(9)
+  end
+
+  it 'forwards real IO stdio (not just the process defaults) on the Windows fallback', skip: !defined?(PTY) do
+    allow(Gem).to receive(:win_platform?).and_return(true)
+
+    PTY.open do |master, slave|
+      runner = described_class.new(stdin: slave, stdout: slave, stderr: slave)
+
+      status = runner.run([RbConfig.ruby, '-e', "STDOUT.write('hello-from-child')"], interactive: true)
+
+      expect(status).to eq(0)
+      expect(master.read_nonblock(4096)).to include('hello-from-child')
+      master.close
+    end
   end
 
   it 'runs the Windows fallback inside chdir too' do

--- a/spec/wip/command_runner_spec.rb
+++ b/spec/wip/command_runner_spec.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'pty'
+begin
+  require 'pty'
+rescue LoadError
+  # PTY is unavailable on native Windows; PTY-dependent examples are skipped below
+end
 
 RSpec.describe Wip::CommandRunner do
   it 'returns the external command exit status' do
@@ -50,7 +54,7 @@ RSpec.describe Wip::CommandRunner do
     expect(stderr.string).to include('mounted-volume limit')
   end
 
-  it 'propagates a terminal resize (SIGWINCH) to the child pty while attached' do
+  it 'propagates a terminal resize (SIGWINCH) to the child pty while attached', skip: !defined?(PTY) do
     PTY.open do |master, slave|
       slave.winsize = [24, 80]
       runner = described_class.new(stdin: slave, stdout: slave, stderr: StringIO.new)
@@ -67,7 +71,7 @@ RSpec.describe Wip::CommandRunner do
     end
   end
 
-  it 'puts a real controlling terminal in raw mode and syncs the pty size, without raising' do
+  it 'puts a real controlling terminal in raw mode and syncs the pty size, without raising', skip: !defined?(PTY) do
     PTY.open do |master, slave|
       runner = described_class.new(stdin: slave, stdout: slave, stderr: StringIO.new)
 


### PR DESCRIPTION
## Summary
- Ruby's `pty` stdlib wraps `openpty(3)`, which native Windows Ruby builds (e.g. RubyInstaller, as used from PowerShell) don't ship — `require 'pty'` and any `PTY.spawn` call raise there.
- `require 'pty'` is now skipped on native Windows (`Gem.win_platform?`), and interactive commands fall back to letting the child inherit wip's real stdio directly instead of routing through a pty.
- This trades away hint detection on failure for interactive commands on native Windows only (the pty-attached path, WSL, and macOS/Linux are unaffected), in exchange for interactive commands working at all instead of crashing at load time.

## Test plan
- [x] `bundle exec rspec` (268 examples, 0 failures)
- [x] `bundle exec rubocop` (no offenses)
- [x] Added specs stubbing `Gem.win_platform?` to exercise the new fallback path (exit status propagation, `chdir` handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Interactive commands now run correctly on Windows, even when PTY support is unavailable.
  * Windows commands preserve the configured working directory and use the expected standard input and output.
  * Interactive command exit statuses are reported correctly, including after interruptions.
  * Missing-command handling remains supported.
  * Non-Windows interactive command behavior continues through the established execution flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->