### PR TITLE
fix(ci): check out main tip and gate gem publish on remote version

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -7,6 +7,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: gem-push
+  cancel-in-progress: false
+
 jobs:
   build:
     name: Build + Publish
@@ -71,21 +75,30 @@ jobs:
             gpr_endpoint="users/${OWNER}/packages/rubygems/${GEM_NAME}/versions"
           fi
 
-          gpr_status=$(curl -s -o /tmp/gpr_versions.json -w '%{http_code}' \
-            -H "Authorization: Bearer ${GH_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/${gpr_endpoint}")
-          if [ "$gpr_status" = "200" ]; then
+          if gh api --paginate "${gpr_endpoint}" > /tmp/gpr_versions.json 2>/tmp/gpr_error.log; then
             if jq -e --arg v "$PLAIN_VERSION" 'any(.[]; .name == $v)' /tmp/gpr_versions.json >/dev/null; then
               echo "gpr_exists=true" >> "$GITHUB_OUTPUT"
             else
               echo "gpr_exists=false" >> "$GITHUB_OUTPUT"
             fi
-          elif [ "$gpr_status" = "404" ]; then
+          elif grep -qi 'HTTP 404' /tmp/gpr_error.log; then
             echo "gpr_exists=false" >> "$GITHUB_OUTPUT"
           else
-            echo "Unexpected GitHub Packages API status: $gpr_status" >&2
+            cat /tmp/gpr_error.log >&2
+            echo "Unexpected GitHub Packages API failure" >&2
             exit 1
+          fi
+
+      - name: Check GitHub release
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Publish to GPR
@@ -112,7 +125,7 @@ jobs:
           gem push *.gem
 
       - name: Publish release notes
-        if: steps.existing.outputs.rubygems_exists == 'false'
+        if: steps.release.outputs.exists == 'false'
         uses: release-drafter/release-drafter@v7
         with:
           config-name: release-drafter.yml

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -26,7 +26,12 @@ jobs:
       - name: Extract version
         id: version
         run: |
-          version=$(grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" lib/wip/version.rb | head -n 1)
+          set -euo pipefail
+          version=$(grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" lib/wip/version.rb | head -n 1 || true)
+          if [ -z "$version" ]; then
+            echo "Failed to extract version from lib/wip/version.rb" >&2
+            exit 1
+          fi
           echo "tag=v$version" >> "$GITHUB_OUTPUT"
 
       - name: Set up Ruby 3.4

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -20,33 +20,21 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: main
           fetch-depth: 0
 
-      - name: Check if version file changed
-        id: version_file
-        run: |
-          if git diff --name-only HEAD~1 HEAD | grep -qx "lib/wip/version.rb"; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Extract version
-        if: steps.version_file.outputs.changed == 'true'
         id: version
         run: |
           version=$(grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" lib/wip/version.rb | head -n 1)
           echo "tag=v$version" >> "$GITHUB_OUTPUT"
 
       - name: Set up Ruby 3.4
-        if: steps.version_file.outputs.changed == 'true'
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.4.3
 
       - name: Check existing versions
-        if: steps.version_file.outputs.changed == 'true'
         id: existing
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -96,7 +84,7 @@ jobs:
           fi
 
       - name: Publish to GPR
-        if: steps.version_file.outputs.changed == 'true' && steps.existing.outputs.gpr_exists == 'false'
+        if: steps.existing.outputs.gpr_exists == 'false'
         run: |
           mkdir -p $HOME/.gem
           touch $HOME/.gem/credentials
@@ -109,17 +97,17 @@ jobs:
           OWNER: ${{ github.repository_owner }}
 
       - name: Configure RubyGems trusted publishing credentials
-        if: steps.version_file.outputs.changed == 'true' && steps.existing.outputs.rubygems_exists == 'false'
+        if: steps.existing.outputs.rubygems_exists == 'false'
         uses: rubygems/configure-rubygems-credentials@dc5a8d8553e6ee01fc26761a49e99e733d17954a # v2
 
       - name: Publish to RubyGems
-        if: steps.version_file.outputs.changed == 'true' && steps.existing.outputs.rubygems_exists == 'false'
+        if: steps.existing.outputs.rubygems_exists == 'false'
         run: |
           gem build *.gemspec
           gem push *.gem
 
       - name: Publish release notes
-        if: steps.version_file.outputs.changed == 'true'
+        if: steps.existing.outputs.rubygems_exists == 'false'
         uses: release-drafter/release-drafter@v7
         with:
           config-name: release-drafter.yml


### PR DESCRIPTION
## Summary
- `gem-push.yml` checked out the `workflow_run`'s pinned `head_sha` and gated publishing on `git diff HEAD~1 HEAD` touching `lib/wip/version.rb`. That diff is fragile across merge commits: yesterday a stale `bump-version` branch merged into `main` right after another PR, and the merge landed with the same `version.rb` content as its first parent — `changed` came back `false` and every publish step silently no-op'd (the run stayed green, but the gem was never pushed to RubyGems even though `main`'s version had genuinely moved since the last release).
- Now checks out `main` directly instead of the pinned sha (always the latest, per request), and drops the git-diff gate entirely — publishing is now gated purely on the existing "does this version already exist on RubyGems/GPR" check the job already computes, which is agnostic to how the commit landed.

## Test plan
- [ ] Not run in CI yet — this PR itself doesn't change `lib/wip/version.rb`, so on merge the existing-version checks should find v1.1.2 already published and skip publishing (no-op, as intended).
- [ ] Next real version bump should confirm the gem actually gets published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release publishing reliability by consistently processing releases from the main branch.
  * Added stricter version validation to prevent incomplete or invalid release attempts.
  * Improved checks for existing package versions and releases to avoid duplicate publication.
  * Enhanced publishing consistency across package registries and release notes, reducing missed or repeated distribution updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->