### PR TITLE
feat: approximate Compose's restart: policy with a foreground wip up --watch poll loop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,7 @@ Metrics/ClassLength:
   Exclude:
     - lib/wip/cli.rb
     - lib/wip/compose_file.rb
+    - lib/wip/config.rb
 Metrics/BlockLength:
   Exclude:
     - spec/**/*

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ allows it.
 
 ```console
 $ wip up --watch
-wip: watching app, mysql every 5s for exited restart: containers (running detached; Ctrl-C to stop)
+wip: watching app, mysql for exited restart: containers every 5s (running detached; Ctrl-C to stop)
 ```
 
 - `restart:` accepts the same values Compose does — `no` (the default), `always`, `unless-stopped`,

--- a/README.md
+++ b/README.md
@@ -159,9 +159,12 @@ The two are aliases for the same feature, not separate ones: pick whichever name
 
 `dependencies:` holds every container uniformly — the primary one `container:` points at and any
 sidecar services (a database, Redis, ...) alongside it. Each entry accepts `image` (required),
-`command`, `env`, `ports`, `volumes`, and `workdir`; there's no separate, differently-shaped block
-for "the one you exec into." `container:` has no default; once `dependencies:` has any entries,
-wip needs to be told explicitly which one is primary rather than guessing a name.
+`command`, `env`, `ports`, `volumes`, `workdir`, and `restart`; there's no separate, differently-shaped
+block for "the one you exec into." `container:` has no default; once `dependencies:` has any entries,
+wip needs to be told explicitly which one is primary rather than guessing a name. `restart` is stored
+but inert on its own — see
+[Restarting exited dependencies](#restarting-exited-dependencies-wip-up---watch) for what actually
+acts on it (`wip up --watch`).
 
 What sets the primary entry apart is operational, not structural: `wip up` brings up every other
 entry by name first (creating `network:` beforehand if it doesn't exist and set), then boots or
@@ -171,6 +174,44 @@ resolve. `wip down` tears the primary container and all sidecars down (the netwo
 in place). Only the primary container is a target for `exec`/`run`/`build`/`interaction:` — sidecars
 are only ever started and stopped, matching Compose's own service-vs-you-exec-into-one-of-them
 split.
+
+#### Restarting exited dependencies (`wip up --watch`)
+
+Real Compose auto-restarts a container tagged `restart: always`/`unless-stopped`/`on-failure` when
+it exits. `wslc` has no such policy, and no push-based "container exited" notification for `wip` to
+hook into, so the closest approximation is polling: `wip up --watch` brings everything up the same
+way `wip up -d` does, then keeps checking (`--interval SECONDS`, default 5) whether any
+dependency — the primary container included — has exited, restarting the ones whose `restart:`
+allows it.
+
+```console
+$ wip up --watch
+wip: watching app, mysql every 5s for exited restart: containers (running detached; Ctrl-C to stop)
+```
+
+- `restart:` accepts the same values Compose does — `no` (the default), `always`, `unless-stopped`,
+  `on-failure`, optionally with a `:MAX_RETRIES` suffix. `wip up --watch` treats the three
+  restarting values identically: it restarts on any exited/dead container regardless of exit code,
+  unlike real `on-failure`, which skips a clean (zero) exit — reading an exit code needs a heavier
+  call this polling loop doesn't make.
+- This is a foreground loop, not a background daemon or service — the project intentionally has
+  neither (see [Roadmap](#roadmap)). Keep the terminal it's running in open, the same as
+  `wip sync --watch`; Ctrl-C (or closing the terminal) stops the supervision.
+- `--watch` implies `-d`: it can't attach a TTY to the primary container and poll in a loop on the
+  same thread, so the primary container always runs detached under `--watch`, whether or not you
+  also passed `-d`.
+- Not available under `mode: compose` — wip never parses a service list in that mode, so there's
+  nothing for it to poll; use whatever restart support your external compose-for-`wslc` tool offers.
+- It's status-based, not event-based: each tick checks whether a dependency is currently exited, not
+  whether it *just* exited. It can't tell "crashed on its own" apart from "you ran `wip stop`/
+  `wip down` in another terminal" — Ctrl-C the `--watch` loop first, or it may race and restart
+  what you just stopped.
+- Re-running `wip up -d --watch` against an already-running stack is safe: an already-running
+  container's `start` is a no-op, the same as it is for plain `wip up`.
+- The exit-detection relies on `wslc list --all --format json` reporting a lowercase `State` field
+  (`exited`/`dead` when stopped), mirroring `docker ps`'s own JSON shape — unconfirmed against a
+  real `wslc` install as of this writing. If `--watch` never restarts anything you believe really
+  exited, run `wip up --watch --debug` and check the logged `list` entry for the actual field name.
 
 ### Compose mode
 
@@ -250,11 +291,13 @@ valid compose.yml over sections it doesn't need to look at:
   does), `command` (shell or exec form), `environment`
   (mapping or `KEY=VALUE` array — a mapping value must not be null; host environment pass-through
   isn't supported), `ports`/`volumes` (short syntax only — `"host:container"` strings, not
-  long-syntax mappings), `working_dir`, `user`, `depends_on` (ordering only — a `condition:` other
-  than `service_started` is rejected, since there's no health-check support). `tty`, `stdin_open`,
-  and `networks` are accepted but silently ignored: TTY/stdin allocation is already decided per
-  invocation (see "TTY allocation" below), not fixed per service, and every service already shares
-  the one project network `compose.project` sets up.
+  long-syntax mappings), `working_dir`, `user`, `restart` (stored as-is; `no` is the default —
+  `wip up --watch` is what actually acts on it, see
+  [Restarting exited dependencies](#restarting-exited-dependencies-wip-up---watch)), `depends_on`
+  (ordering only — a `condition:` other than `service_started` is rejected, since there's no
+  health-check support). `tty`, `stdin_open`, and `networks` are accepted but silently ignored:
+  TTY/stdin allocation is already decided per invocation (see "TTY allocation" below), not fixed
+  per service, and every service already shares the one project network `compose.project` sets up.
 - `wip logs` takes at most one `SERVICE` (defaulting to `compose.service`) — `wslc logs`, like
   `docker logs`, follows a single container, unlike a real compose tool's multi-service view.
 - `sync:` behaves exactly like `mode: container`'s (falls back to the primary service's own image,
@@ -422,7 +465,7 @@ to that tag directly — `sync.build`'s tag wins if both are set, so don't confi
 | `wip doctor` | Diagnose WSL2, interop, WSLC, config, architecture, and Git |
 | `wip config` | Print the effective configuration (secrets masked) |
 | `wip build [--no-cache] [-- OPTIONS]` | Build the image from the `build` definition. `wslc build` reuses matching local layers by default; `--no-cache` disables that. |
-| `wip up [-d] [--no-sync] [--no-cache]` | Start the primary `dependencies:` entry (`container:` names which one) and its sidecars (creating any that are missing, on `network:` if set). `-d` runs the main container in the background; with `sync:` configured, the source is mirrored into the volume first unless `--no-sync` |
+| `wip up [-d] [--no-sync] [--no-cache] [--watch] [--interval N]` | Start the primary `dependencies:` entry (`container:` names which one) and its sidecars (creating any that are missing, on `network:` if set). `-d` runs the main container in the background; with `sync:` configured, the source is mirrored into the volume first unless `--no-sync`. `--watch` polls every `N` seconds (default 5, implies `-d`) and restarts any exited dependency whose `restart:` allows it (not available under mode: compose) |
 | `wip stop` | Stop the primary container and its sidecar `dependencies:` without removing them |
 | `wip down` | Stop and remove the primary container and its sidecar `dependencies:` |
 | `wip exec [--no-interactive] COMMAND...` | Run a command in the existing container |
@@ -635,7 +678,11 @@ and its current limitations (`run`, and `interaction:` of type `run`/`build`).
 
 Beyond Compose parity, a resident/daemon process, a GUI, PowerShell-specific tuning, direct
 registry API/manifest parsing, self-update, and plugins are all unimplemented and not currently
-planned. What's still planned for `wip`, roughly in priority order:
+planned. (`wip up --watch`'s restart-policy poll loop isn't an exception to this — it's a
+foreground, opt-in loop you keep a terminal open for, the same shape as `wip sync --watch`, not a
+background service; see
+[Restarting exited dependencies](#restarting-exited-dependencies-wip-up---watch).) What's still
+planned for `wip`, roughly in priority order:
 
 1. **`wip provision`** — a dip-style one-shot bootstrap hook (build → up deps → install deps →
    create/migrate/seed DB) so a new contributor can go from `git clone` to a working environment

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ wip: watching app, mysql every 5s for exited restart: containers (running detach
 
 - `restart:` accepts the same values Compose does — `no` (the default), `always`, `unless-stopped`,
   `on-failure`, optionally with a `:MAX_RETRIES` suffix. `wip up --watch` treats the three
-  restarting values identically: it restarts on any exited/dead container regardless of exit code,
+  restarting values identically: it restarts on any exited container regardless of exit code,
   unlike real `on-failure`, which skips a clean (zero) exit — reading an exit code needs a heavier
   call this polling loop doesn't make.
 - This is a foreground loop, not a background daemon or service — the project intentionally has
@@ -208,10 +208,12 @@ wip: watching app, mysql every 5s for exited restart: containers (running detach
   what you just stopped.
 - Re-running `wip up -d --watch` against an already-running stack is safe: an already-running
   container's `start` is a no-op, the same as it is for plain `wip up`.
-- The exit-detection relies on `wslc list --all --format json` reporting a lowercase `State` field
-  (`exited`/`dead` when stopped), mirroring `docker ps`'s own JSON shape — unconfirmed against a
-  real `wslc` install as of this writing. If `--watch` never restarts anything you believe really
-  exited, run `wip up --watch --debug` and check the logged `list` entry for the actual field name.
+- The exit-detection reads `wslc list --all --format json`'s `State` field as a raw integer, per
+  `WslcContainerState` ([wsl.dev](https://wsl.dev/api-reference/c/enumerations/wslccontainerstate/)):
+  `0` invalid, `1` created, `2` running, `3` exited, `4` deleted. Unlike Docker, there's no separate
+  `dead` state — a `deleted` container is gone and needs `wip up` (not `--watch`) to recreate it.
+  If `--watch` never restarts anything you believe really exited, run `wip up --watch --debug` and
+  check the logged `list` entry against this enum.
 
 ### Compose mode
 

--- a/lib/wip/cli.rb
+++ b/lib/wip/cli.rb
@@ -82,10 +82,19 @@ module Wip
       progress&.finish
     end
 
-    # Real Compose values that trigger a restart when a container's exited/dead; `no` (the
-    # default) and anything unrecognized both mean "leave it alone." on-failure optionally
-    # takes a `:MAX_RETRIES` suffix (e.g. "on-failure:3") — start_with? handles that.
-    AUTO_RESTART_POLICIES = %w[always unless-stopped on-failure].freeze
+    # Real Compose values that trigger a restart when a container's exited; `no` (the default)
+    # and anything unrecognized both mean "leave it alone." Exact match only — a typo'd value
+    # like "always-invalid" must stay inert, not accidentally match via a loose prefix check.
+    AUTO_RESTART_POLICIES = %w[always unless-stopped].freeze
+    ON_FAILURE_POLICY = /\Aon-failure(?::\d+)?\z/ # optional `:MAX_RETRIES` suffix, e.g. "on-failure:3"
+
+    # WSLC's `WslcContainerState` (confirmed via microsoft/WSL's own docs and
+    # ContainerModel.h — ContainerInformation#State has no custom JSON enum serializer, so
+    # nlohmann::json emits its raw ordinal): 0 invalid, 1 created, 2 running, 3 exited, 4
+    # deleted. Unlike Docker, there's no separate "dead" state — only `exited` is a live,
+    # restartable exit; `deleted` means the container itself is gone (needs `wip up` to
+    # recreate it, not `start`).
+    WSLC_CONTAINER_STATE_EXITED = 3
 
     desc 'up', 'Start the configured container and its dependencies, creating them if necessary'
     option :detach, type: :boolean, default: false, aliases: '-d'
@@ -97,12 +106,17 @@ module Wip
     def up
       return up_via_compose_bridge if load_config.compose?
 
+      # Validated up front, before any startup side effect (image build, network/dependency/
+      # container creation) — otherwise a bad --interval would only surface as a ConfigError
+      # after already bringing everything up.
+      interval = restart_interval if options[:watch]
+
       ensure_compose_images
       ensure_network
       sidecar_names.each { |name| ensure_dependency(name) }
       sync_before_boot if options[:sync]
       ensure_container
-      watch_restarts if options[:watch]
+      watch_restarts(interval) if options[:watch]
     end
 
     desc 'sync', 'Mirror the source tree into the sync volume'
@@ -442,9 +456,8 @@ module Wip
     # Approximates Docker Compose's `restart:` policy via a foreground poll loop — not a
     # background daemon/service (see README "Roadmap"); the same opt-in, keep-a-terminal-open
     # shape as `wip sync --watch`.
-    def watch_restarts
+    def watch_restarts(interval)
       names = load_config.dependencies.keys
-      interval = restart_interval
       warn "wip: watching #{names.join(', ')} for exited restart: containers every #{interval}s " \
            '(running detached; Ctrl-C to stop)'
       loop do
@@ -467,22 +480,17 @@ module Wip
     def restart_if_exited(name)
       policy = load_config.dependency(name)['restart']
       return unless auto_restart?(policy)
+      return unless container_status(name) == WSLC_CONTAINER_STATE_EXITED
 
-      status = container_status(name)
-      return unless %w[exited dead].include?(status)
-
-      warn "wip: '#{name}' is #{status}, restarting it (restart: #{policy})"
+      warn "wip: '#{name}' has exited, restarting it (restart: #{policy})"
       execute(builder.dependency_start(name), exit_on_failure: false)
     end
 
-    def auto_restart?(policy) = AUTO_RESTART_POLICIES.any? { |value| policy.to_s.start_with?(value) }
+    def auto_restart?(policy) = AUTO_RESTART_POLICIES.include?(policy) || ON_FAILURE_POLICY.match?(policy.to_s)
 
-    # ASSUMPTION, unverified against a real wslc install (no test fixture/sample output exists
-    # anywhere in this repo today): `wslc list --all --format json` is presumed to emit a
-    # lowercase `State` field matching `docker ps --format json`'s own shape (created/running/
-    # paused/restarting/exited/removing/dead). Isolated to this one method so correcting a wrong
-    # guess is a one-line change. Logs the raw entry under --debug specifically so a wrong guess
-    # is immediately visible instead of silently no-op'ing forever.
+    # Isolated to this one method: if a future wslc release changes this shape, fixing it here
+    # is a one-line change. Logs the raw entry under --debug so that's immediately visible
+    # instead of silently no-op'ing forever.
     def container_status(name)
       code, output = probe(builder.dependency_find(name))
       return nil unless code.zero?

--- a/lib/wip/cli.rb
+++ b/lib/wip/cli.rb
@@ -82,21 +82,27 @@ module Wip
       progress&.finish
     end
 
+    # Real Compose values that trigger a restart when a container's exited/dead; `no` (the
+    # default) and anything unrecognized both mean "leave it alone." on-failure optionally
+    # takes a `:MAX_RETRIES` suffix (e.g. "on-failure:3") — start_with? handles that.
+    AUTO_RESTART_POLICIES = %w[always unless-stopped on-failure].freeze
+
     desc 'up', 'Start the configured container and its dependencies, creating them if necessary'
     option :detach, type: :boolean, default: false, aliases: '-d'
     option :sync, type: :boolean, default: true, desc: 'Mirror the source into the sync volume first (--no-sync skips)'
     option :no_cache, type: :boolean, default: false, desc: 'Build compose-native images without cached layers'
+    option :watch, type: :boolean, default: false, aliases: '-w',
+                   desc: 'Poll dependencies and restart any exited one whose restart: allows it (implies -d)'
+    option :interval, type: :numeric, default: 5, desc: 'Seconds between --watch polls (default: 5)'
     def up
-      if load_config.compose?
-        sync_before_boot if options[:sync]
-        return execute(compose_bridge.up(detach: options[:detach]), interactive: tty?(!options[:detach]))
-      end
+      return up_via_compose_bridge if load_config.compose?
 
       ensure_compose_images
       ensure_network
       sidecar_names.each { |name| ensure_dependency(name) }
       sync_before_boot if options[:sync]
       ensure_container
+      watch_restarts if options[:watch]
     end
 
     desc 'sync', 'Mirror the source tree into the sync volume'
@@ -407,16 +413,85 @@ module Wip
       warn "wip: run `wip sync --watch` in another terminal to keep #{settings.target} up to date"
     end
 
+    def up_via_compose_bridge
+      if options[:watch]
+        raise ConfigError, '`wip up --watch` is not supported under mode: compose (wip never parses a ' \
+                           'compose.yml service list in that mode, so there is nothing to poll)'
+      end
+
+      sync_before_boot if options[:sync]
+      execute(compose_bridge.up(detach: options[:detach]), interactive: tty?(!options[:detach]))
+    end
+
     def ensure_container
       container = load_config.container
-      interactive = tty?(!options[:detach])
+      interactive = tty?(!detach?)
       if resource_exists?(builder.find)
         warn "wip: starting existing container '#{container}'"
-        execute(builder.start(detach: options[:detach]), interactive: interactive)
+        execute(builder.start(detach: detach?), interactive: interactive)
       else
         warn "wip: container '#{container}' not found, creating it"
-        execute(builder.up(detach: options[:detach]), interactive: interactive)
+        execute(builder.up(detach: detach?), interactive: interactive)
       end
+    end
+
+    # --watch polls in a loop after boot, which can't share this one thread with an attached
+    # (`-it`) primary container — force the same effective behavior `-d` gives ensure_container.
+    def detach? = options[:detach] || options[:watch]
+
+    # Approximates Docker Compose's `restart:` policy via a foreground poll loop — not a
+    # background daemon/service (see README "Roadmap"); the same opt-in, keep-a-terminal-open
+    # shape as `wip sync --watch`.
+    def watch_restarts
+      names = load_config.dependencies.keys
+      interval = restart_interval
+      warn "wip: watching #{names.join(', ')} for exited restart: containers every #{interval}s " \
+           '(running detached; Ctrl-C to stop)'
+      loop do
+        names.each { |name| restart_if_exited(name) }
+        sleep interval
+      end
+    rescue Interrupt
+      warn "\nwip: watch stopped"
+    end
+
+    def restart_interval
+      raise ConfigError, '--interval must be a positive number' unless options[:interval].positive?
+
+      options[:interval]
+    end
+
+    # Status-based, not transition-based: each tick checks current state, not whether it *just*
+    # exited. Can't distinguish "crashed on its own" from "you ran `wip stop`/`wip down` in
+    # another terminal" — Ctrl-C this loop first if you're about to do either (see README).
+    def restart_if_exited(name)
+      policy = load_config.dependency(name)['restart']
+      return unless auto_restart?(policy)
+
+      status = container_status(name)
+      return unless %w[exited dead].include?(status)
+
+      warn "wip: '#{name}' is #{status}, restarting it (restart: #{policy})"
+      execute(builder.dependency_start(name), exit_on_failure: false)
+    end
+
+    def auto_restart?(policy) = AUTO_RESTART_POLICIES.any? { |value| policy.to_s.start_with?(value) }
+
+    # ASSUMPTION, unverified against a real wslc install (no test fixture/sample output exists
+    # anywhere in this repo today): `wslc list --all --format json` is presumed to emit a
+    # lowercase `State` field matching `docker ps --format json`'s own shape (created/running/
+    # paused/restarting/exited/removing/dead). Isolated to this one method so correcting a wrong
+    # guess is a one-line change. Logs the raw entry under --debug specifically so a wrong guess
+    # is immediately visible instead of silently no-op'ing forever.
+    def container_status(name)
+      code, output = probe(builder.dependency_find(name))
+      return nil unless code.zero?
+
+      entry = JSON.parse(output).first
+      warn "wip: [debug] '#{name}': #{entry.inspect}" if debug?
+      entry&.fetch('State', nil)
+    rescue JSON::ParserError
+      nil
     end
   end
 end

--- a/lib/wip/compose_file.rb
+++ b/lib/wip/compose_file.rb
@@ -15,15 +15,17 @@ module Wip
   # "Compose mode (native)") — once wslc ships that support, or a
   # compose-for-wslc tool reliably supports `run`.
   class ComposeFile
-    Service = Struct.new(:image, :build, :command, :env, :ports, :volumes, :workdir, :user, :depends_on, :profiles,
-                         keyword_init: true)
+    Service = Struct.new(:image, :build, :command, :env, :ports, :volumes, :workdir, :user, :restart, :depends_on,
+                         :profiles, keyword_init: true)
 
-    SERVICE_KEYS = %w[image build command environment ports volumes working_dir user depends_on profiles].freeze
+    SERVICE_KEYS = %w[image build command environment ports volumes working_dir user restart depends_on
+                      profiles].freeze
     # Real Compose keys that read as meaningful here but have nothing to map onto: TTY/stdin
     # allocation is decided per invocation (CommandBuilder#tty?), not per service; every
     # service already shares one project network (config.rb); and `wslc run`/`exec` has no
-    # restart-policy or capability flag to forward `restart:`/`cap_add:` to.
-    IGNORED_SERVICE_KEYS = %w[tty stdin_open networks restart cap_add].freeze
+    # capability flag to forward `cap_add:` to. (`restart:` used to be here too, silently
+    # ignored — it's parsed below now and approximated by `wip up --watch`, see cli.rb.)
+    IGNORED_SERVICE_KEYS = %w[tty stdin_open networks cap_add].freeze
     BUILD_KEYS = %w[context dockerfile args shadow_context].freeze
     SUPPORTED_CONDITIONS = %w[service_started].freeze
     LIST_HINT = 'only supports short syntax ("host:container"), not long-syntax mappings'
@@ -65,14 +67,14 @@ module Wip
       end.to_h
     end
 
-    # Shaped like Config::DEPENDENCY_DEFAULTS expects: image/command/env/ports/volumes/workdir,
+    # Shaped like Config::DEPENDENCY_DEFAULTS expects: image/command/env/ports/volumes/workdir/restart,
     # in dependency order so callers iterating sidecars start them before their dependents.
     def to_dependencies_hash
       startable_order.to_h do |name|
         service = @services.fetch(name)
         [name, { 'image' => service.build ? image_tag(name, service) : service.image, 'command' => service.command,
                  'env' => service.env, 'ports' => service.ports, 'volumes' => service.volumes,
-                 'workdir' => service.workdir, 'user' => service.user }]
+                 'workdir' => service.workdir, 'user' => service.user, 'restart' => service.restart }]
       end
     end
 
@@ -97,6 +99,7 @@ module Wip
       Service.new(image: image, build: build, command: normalize_command(entry['command']),
                   env: normalize_env(name, entry['environment']), **normalize_service_lists(name, entry),
                   workdir: presence(entry['working_dir']), user: presence(entry['user']),
+                  restart: normalize_restart(entry['restart']),
                   depends_on: normalize_depends_on(name, entry['depends_on']))
     end
 
@@ -248,6 +251,20 @@ module Wip
       visiting.delete(name)
       visited[name] = true
       order << name
+    end
+
+    # Compose's own default (`no`) applies whether restart: is absent or explicitly falsy —
+    # including the very common unquoted `restart: no`, which YAML resolves to the boolean
+    # `false`, not the string "no" (confirmed against this repo's own Psych: `YAML.safe_load
+    # ("restart: no")` => {"restart"=>false}). Every other value is accepted as-is, even ones
+    # outside always/unless-stopped/on-failure[:N]: this parser's job is to read what's in
+    # compose.yml, not police it — `wip up --watch` (cli.rb) decides which values it acts on.
+    # Rejecting a real, valid Compose value here would break projects that already work today
+    # (compose.yml predates wip, unlike wip.yml itself).
+    def normalize_restart(value)
+      return 'no' if value == false
+
+      presence(value) || 'no'
     end
 
     def presence(value) = value.to_s.empty? ? nil : value.to_s

--- a/lib/wip/config.rb
+++ b/lib/wip/config.rb
@@ -209,9 +209,16 @@ module Wip
       raise ConfigError, "dependencies.#{name} must set image" if entry['image'].to_s.empty?
 
       entry['env']&.transform_values!(&:to_s)
-      # See ComposeFile#normalize_restart — same YAML gotcha applies here: an unquoted
-      # `restart: no` parses as the boolean false, not the string "no".
-      entry['restart'] = 'no' if entry['restart'] == false
+      normalize_dependency_restart!(entry)
+    end
+
+    # Mirrors ComposeFile#normalize_restart: an unquoted `restart: no` parses as the boolean
+    # false rather than the string "no", and an explicit nil/"" should default the same way an
+    # absent key does (DEPENDENCY_DEFAULTS only fills in a genuinely *missing* key).
+    def normalize_dependency_restart!(entry)
+      return unless entry.key?('restart')
+
+      entry['restart'] = 'no' if entry['restart'] == false || entry['restart'].to_s.empty?
     end
 
     def stringify(object)

--- a/lib/wip/config.rb
+++ b/lib/wip/config.rb
@@ -8,7 +8,7 @@ module Wip
     # Applied to every dependencies: entry, primary container included — there
     # is no separate, differently-shaped bucket for "the one you exec into."
     DEPENDENCY_DEFAULTS = { 'workdir' => nil, 'user' => nil, 'interactive' => false, 'remove' => true,
-                            'env' => {}, 'ports' => [], 'volumes' => [] }.freeze
+                            'env' => {}, 'ports' => [], 'volumes' => [], 'restart' => 'no' }.freeze
     SECRET_PATTERN = /token|password|secret|credential|auth/i
     # Which orchestration path `up`/`down`/`sync`/etc. take. Explicit rather than
     # inferred from a `compose:` block's presence, so a config reader doesn't have
@@ -209,6 +209,9 @@ module Wip
       raise ConfigError, "dependencies.#{name} must set image" if entry['image'].to_s.empty?
 
       entry['env']&.transform_values!(&:to_s)
+      # See ComposeFile#normalize_restart — same YAML gotcha applies here: an unquoted
+      # `restart: no` parses as the boolean false, not the string "no".
+      entry['restart'] = 'no' if entry['restart'] == false
     end
 
     def stringify(object)

--- a/lib/wip/initializer.rb
+++ b/lib/wip/initializer.rb
@@ -159,6 +159,10 @@ module Wip
             # optional; remove the container after each run
             remove: true
 
+            # optional; restart policy `wip up --watch` polls for — always/unless-stopped/on-failure
+            # restart an exited container; "no" (the default) never does — see README
+            restart: "no"
+
             # optional; environment variables passed to the container, e.g. {FOO: bar}
             env: {}
 

--- a/spec/wip/cli_spec.rb
+++ b/spec/wip/cli_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe Wip::CLI do
         def run(command, **_kwargs)
           self.class.calls << command
           if command.include?('list')
-            @stdout&.write('[{"Name":"app","State":"running"}]')
+            @stdout&.write('[{"Name":"app","State":2}]') # 2 == WslcContainerState running
             raise Interrupt if self.class.calls.count { |c| c.include?('list') } == 2
           end
           0
@@ -230,8 +230,9 @@ RSpec.describe Wip::CLI do
         end
         self.calls = []
         self.responses = {
-          app_list => '[{"Name":"app","State":"exited"}]',
-          db_list => '[{"Name":"db","State":"exited"}]'
+          # 3 == WslcContainerState exited (see cli.rb's WSLC_CONTAINER_STATE_EXITED)
+          app_list => '[{"Name":"app","State":3}]',
+          db_list => '[{"Name":"db","State":3}]'
         }
 
         def initialize(stdout: nil, **_kwargs)
@@ -261,18 +262,75 @@ RSpec.describe Wip::CLI do
       expect(fake_runner.calls.count { |c| c == %w[wslc.exe start db] }).to eq(2)
     end
 
-    it 'rejects a non-positive --interval for up --watch' do
-      runner = instance_double(Wip::CommandRunner)
-      allow(Wip::CommandRunner).to receive(:new) do |**kwargs|
-        kwargs[:stdout]&.write('[{"Name":"app","State":"running"}]')
-        runner
-      end
+    it 'never restarts a dependency whose restart: is an unrecognized value, even while exited' do
+      File.write('wip.yml', <<~YAML)
+        version: 1
+        container: app
+        dependencies:
+          app:
+            image: example:dev
+            restart: always-invalid
+      YAML
       allow(Wip::CommandResolver).to receive(:new).and_return(instance_double(Wip::CommandResolver,
                                                                               resolve: 'wslc.exe'))
-      allow(runner).to receive(:run).and_return(0)
+      fake_runner = Class.new do
+        class << self
+          attr_accessor :calls
+        end
+        self.calls = []
+
+        def initialize(stdout: nil, **_kwargs)
+          @stdout = stdout
+        end
+
+        def run(command, **_kwargs)
+          self.class.calls << command
+          @stdout&.write('[{"Name":"app","State":3}]') if command.include?('list')
+          0
+        end
+      end
+      stub_const('Wip::CommandRunner', fake_runner)
+      # An unrecognized restart: means restart_if_exited returns before ever probing status, so
+      # no wslc command runs on any tick to hook an Interrupt into — stub `sleep` (still called
+      # once per tick either way) to end the loop instead.
+      ticks = 0
+      allow_any_instance_of(described_class).to receive(:sleep) do |*_args|
+        ticks += 1
+        raise Interrupt if ticks == 2
+      end
+
+      described_class.start(%w[up -d --watch --interval 0.01])
+
+      expect(ticks).to eq(2)
+      # Only the bring-up list/start ever ran; the loop itself never issued another wslc command.
+      expect(fake_runner.calls).to eq([%w[wslc.exe list --all --filter name=app --format json],
+                                       %w[wslc.exe start app]])
+    end
+
+    it 'rejects a non-positive --interval before any startup side effect runs' do
+      fake_runner = Class.new do
+        class << self
+          attr_accessor :calls
+        end
+        self.calls = []
+
+        def initialize(stdout: nil, **_kwargs)
+          @stdout = stdout
+        end
+
+        def run(command, **_kwargs)
+          self.class.calls << command
+          @stdout&.write('[]')
+          0
+        end
+      end
+      stub_const('Wip::CommandRunner', fake_runner)
+      allow(Wip::CommandResolver).to receive(:new).and_return(instance_double(Wip::CommandResolver,
+                                                                              resolve: 'wslc.exe'))
 
       expect { described_class.start(%w[up --watch --interval -1]) }
         .to raise_error(Wip::ConfigError, /--interval must be a positive number/)
+      expect(fake_runner.calls).to be_empty
     end
 
     it 'logs the raw wslc list entry under --debug, to make a wrong State-field guess visible' do
@@ -299,7 +357,7 @@ RSpec.describe Wip::CLI do
         def run(command, **_kwargs)
           self.class.calls << command
           if command.include?('list')
-            @stdout&.write('[{"Name":"app","State":"exited"}]')
+            @stdout&.write('[{"Name":"app","State":3}]')
             # Raise on the 3rd `list` call (bring-up + tick 1), not the 2nd (tick 1 itself) —
             # container_status must run to completion at least once so its debug line has a
             # chance to print before the loop is interrupted.
@@ -311,7 +369,7 @@ RSpec.describe Wip::CLI do
       stub_const('Wip::CommandRunner', fake_runner)
 
       expect { described_class.start(%w[up --watch --interval 0.01 --debug]) }
-        .to output(/\[debug\] 'app': .*State.*exited/).to_stderr
+        .to output(/\[debug\] 'app': .*State.*3/).to_stderr
     end
   end
 

--- a/spec/wip/cli_spec.rb
+++ b/spec/wip/cli_spec.rb
@@ -167,6 +167,154 @@ RSpec.describe Wip::CLI do
     described_class.start(%w[up])
   end
 
+  describe '--watch' do
+    it '--watch implies -d for the primary container' do
+      File.write('wip.yml', <<~YAML)
+        version: 1
+        container: app
+        dependencies:
+          app:
+            image: example:dev
+            restart: always
+      YAML
+      allow(Wip::CommandResolver).to receive(:new).and_return(instance_double(Wip::CommandResolver,
+                                                                              resolve: 'wslc.exe'))
+      fake_runner = Class.new do
+        class << self
+          attr_accessor :calls
+        end
+        self.calls = []
+
+        def initialize(stdout: nil, **_kwargs)
+          @stdout = stdout
+        end
+
+        def run(command, **_kwargs)
+          self.class.calls << command
+          if command.include?('list')
+            @stdout&.write('[{"Name":"app","State":"running"}]')
+            raise Interrupt if self.class.calls.count { |c| c.include?('list') } == 2
+          end
+          0
+        end
+      end
+      stub_const('Wip::CommandRunner', fake_runner)
+
+      described_class.start(%w[up --watch --interval 0.01]) # deliberately no -d
+
+      expect(fake_runner.calls).to eq([
+                                        %w[wslc.exe list --all --filter name=app --format json],
+                                        %w[wslc.exe start app], # no -a/-i here proves detach: true
+                                        %w[wslc.exe list --all --filter name=app --format json]
+                                      ])
+    end
+
+    it 'restarts an exited dependency whose restart: allows it, leaving one without a policy alone' do
+      File.write('wip.yml', <<~YAML)
+        version: 1
+        container: app
+        dependencies:
+          app:
+            image: example:dev
+          db:
+            image: mysql:8
+            restart: always
+      YAML
+      allow(Wip::CommandResolver).to receive(:new).and_return(instance_double(Wip::CommandResolver,
+                                                                              resolve: 'wslc.exe'))
+      app_list = %w[wslc.exe list --all --filter name=app --format json]
+      db_list = %w[wslc.exe list --all --filter name=db --format json]
+      fake_runner = Class.new do
+        class << self
+          attr_accessor :calls, :responses
+        end
+        self.calls = []
+        self.responses = {
+          app_list => '[{"Name":"app","State":"exited"}]',
+          db_list => '[{"Name":"db","State":"exited"}]'
+        }
+
+        def initialize(stdout: nil, **_kwargs)
+          @stdout = stdout
+        end
+
+        def run(command, **_kwargs)
+          self.class.calls << command
+          @stdout&.write(self.class.responses.fetch(command, ''))
+          raise Interrupt if command == self.class.responses.keys.last &&
+                             self.class.calls.count { |c| c == command } == 3
+
+          0
+        end
+      end
+      stub_const('Wip::CommandRunner', fake_runner)
+
+      described_class.start(%w[up -d --watch --interval 0.01])
+
+      # app has no restart: (defaults to "no"), so it's never polled past bring-up, and never
+      # restarted even though the stub reports it as exited too.
+      expect(fake_runner.calls.count { |c| c == app_list }).to eq(1)
+      expect(fake_runner.calls.count { |c| c == %w[wslc.exe start app] }).to eq(1)
+      # db has restart: always, so it's polled and restarted every tick until the 3rd db-list
+      # call (bring-up + 2 ticks) raises Interrupt to stop the loop.
+      expect(fake_runner.calls.count { |c| c == db_list }).to eq(3)
+      expect(fake_runner.calls.count { |c| c == %w[wslc.exe start db] }).to eq(2)
+    end
+
+    it 'rejects a non-positive --interval for up --watch' do
+      runner = instance_double(Wip::CommandRunner)
+      allow(Wip::CommandRunner).to receive(:new) do |**kwargs|
+        kwargs[:stdout]&.write('[{"Name":"app","State":"running"}]')
+        runner
+      end
+      allow(Wip::CommandResolver).to receive(:new).and_return(instance_double(Wip::CommandResolver,
+                                                                              resolve: 'wslc.exe'))
+      allow(runner).to receive(:run).and_return(0)
+
+      expect { described_class.start(%w[up --watch --interval -1]) }
+        .to raise_error(Wip::ConfigError, /--interval must be a positive number/)
+    end
+
+    it 'logs the raw wslc list entry under --debug, to make a wrong State-field guess visible' do
+      File.write('wip.yml', <<~YAML)
+        version: 1
+        container: app
+        dependencies:
+          app:
+            image: example:dev
+            restart: always
+      YAML
+      allow(Wip::CommandResolver).to receive(:new).and_return(instance_double(Wip::CommandResolver,
+                                                                              resolve: 'wslc.exe'))
+      fake_runner = Class.new do
+        class << self
+          attr_accessor :calls
+        end
+        self.calls = []
+
+        def initialize(stdout: nil, **_kwargs)
+          @stdout = stdout
+        end
+
+        def run(command, **_kwargs)
+          self.class.calls << command
+          if command.include?('list')
+            @stdout&.write('[{"Name":"app","State":"exited"}]')
+            # Raise on the 3rd `list` call (bring-up + tick 1), not the 2nd (tick 1 itself) —
+            # container_status must run to completion at least once so its debug line has a
+            # chance to print before the loop is interrupted.
+            raise Interrupt if self.class.calls.count { |c| c.include?('list') } == 3
+          end
+          0
+        end
+      end
+      stub_const('Wip::CommandRunner', fake_runner)
+
+      expect { described_class.start(%w[up --watch --interval 0.01 --debug]) }
+        .to output(/\[debug\] 'app': .*State.*exited/).to_stderr
+    end
+  end
+
   describe 'sync mode' do
     let(:source) { File.expand_path('.') }
 
@@ -457,6 +605,11 @@ RSpec.describe Wip::CLI do
                                            interactive: false).and_return(0)
 
       described_class.start(%w[up -d])
+    end
+
+    it 'rejects --watch under mode: compose, since there is no parsed service list to poll' do
+      expect { described_class.start(%w[up --watch]) }
+        .to raise_error(Wip::ConfigError, /--watch.*not supported under mode: compose/)
     end
 
     it 'mirrors into the volume before compose starts the container when sync is enabled' do

--- a/spec/wip/compose_file_spec.rb
+++ b/spec/wip/compose_file_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe Wip::ComposeFile do
     deps = described_class.load(path).to_dependencies_hash
     expect(deps['app']).to eq('image' => 'example:dev', 'command' => 'bin/rails s',
                               'env' => { 'RAILS_ENV' => 'development' }, 'ports' => ['3000:3000'],
-                              'volumes' => ['app-src:/app'], 'workdir' => '/app', 'user' => nil)
+                              'volumes' => ['app-src:/app'], 'workdir' => '/app', 'user' => nil,
+                              'restart' => 'no')
   end
 
   it 'normalizes environment given as a KEY=VALUE array' do
@@ -216,6 +217,36 @@ RSpec.describe Wip::ComposeFile do
 
     deps = described_class.load(path).to_dependencies_hash
     expect(deps['app']['user']).to eq('1000:1000')
+  end
+
+  it 'defaults restart to "no" when not set' do
+    path = write_compose("services:\n  app:\n    image: example:dev\n")
+    expect(described_class.load(path).to_dependencies_hash['app']['restart']).to eq('no')
+  end
+
+  it 'reads restart: always/unless-stopped/on-failure[:N] as-is' do
+    path = write_compose(<<~YAML)
+      services:
+        a:
+          image: example:dev
+          restart: always
+        b:
+          image: example:dev
+          restart: unless-stopped
+        c:
+          image: example:dev
+          restart: "on-failure:3"
+    YAML
+
+    deps = described_class.load(path).to_dependencies_hash
+    expect(deps['a']['restart']).to eq('always')
+    expect(deps['b']['restart']).to eq('unless-stopped')
+    expect(deps['c']['restart']).to eq('on-failure:3')
+  end
+
+  it 'normalizes an unquoted restart: no (parsed by YAML as false) back to the string "no"' do
+    path = write_compose("services:\n  app:\n    image: example:dev\n    restart: no\n")
+    expect(described_class.load(path).to_dependencies_hash['app']['restart']).to eq('no')
   end
 
   it 'excludes services with a profiles: entry from to_dependencies_hash, like an inactive `docker compose` profile' do

--- a/spec/wip/config_spec.rb
+++ b/spec/wip/config_spec.rb
@@ -100,6 +100,16 @@ RSpec.describe Wip::Config do
     expect(config.dependency('app')['restart']).to eq('no')
   end
 
+  it 'normalizes an explicit nil or empty-string dependencies.<name>.restart: to "no"' do
+    nil_config = described_class.new('container' => 'app',
+                                     'dependencies' => { 'app' => { 'image' => 'example:dev', 'restart' => nil } })
+    blank_config = described_class.new('container' => 'app',
+                                       'dependencies' => { 'app' => { 'image' => 'example:dev', 'restart' => '' } })
+
+    expect(nil_config.dependency('app')['restart']).to eq('no')
+    expect(blank_config.dependency('app')['restart']).to eq('no')
+  end
+
   it 'exposes network, defaulting to nil' do
     expect(described_class.new({}).network).to be_nil
     expect(described_class.new('network' => 'app-tier').network).to eq('app-tier')

--- a/spec/wip/config_spec.rb
+++ b/spec/wip/config_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Wip::Config do
 
     expect(config.dependency('redis')).to include('image' => 'redis:latest', 'workdir' => nil,
                                                   'interactive' => false, 'remove' => true,
-                                                  'env' => {}, 'ports' => [], 'volumes' => [])
+                                                  'env' => {}, 'ports' => [], 'volumes' => [], 'restart' => 'no')
     expect(config.dependency('unknown')).to be_nil
   end
 
@@ -92,6 +92,12 @@ RSpec.describe Wip::Config do
     expect do
       described_class.new('container' => 'redis', 'dependencies' => { 'redis' => { 'command' => 'redis-server' } })
     end.to raise_error(Wip::ConfigError, /dependencies\.redis must set image/)
+  end
+
+  it 'normalizes an unquoted dependencies.<name>.restart: no (parsed by YAML as false) to "no"' do
+    config = described_class.new('container' => 'app',
+                                 'dependencies' => { 'app' => { 'image' => 'example:dev', 'restart' => false } })
+    expect(config.dependency('app')['restart']).to eq('no')
   end
 
   it 'exposes network, defaulting to nil' do

--- a/spec/wip/initializer_spec.rb
+++ b/spec/wip/initializer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Wip::Initializer do
       expect(initializer.compose?).to be(false)
       parsed = YAML.safe_load(initializer.call)
       expect(parsed).to include('version' => 1, 'mode' => 'container')
-      expect(parsed['dependencies']['app']).to include('image', 'workdir')
+      expect(parsed['dependencies']['app']).to include('image', 'workdir', 'restart')
       expect(parsed).to have_key('sync')
     end
   end


### PR DESCRIPTION
## Summary

- `restart:` in `compose.yml` was silently dropped by `mode: compose-native` — `wslc run`/`exec` has no restart-policy flag. A crashed sidecar (e.g. a MySQL dependency) just stayed down until someone manually reran `wip up`.
- Investigated whether `wslc` itself (now open-sourced in `microsoft/WSL`) could support this some other way: it can't, today. No `RestartPolicy` concept anywhere in its engine, and no public `wslc events` CLI command (only an unmerged, SDK/COM-level PR — microsoft/WSL#40971 — not consumable from wip's shell-out-to-CLI architecture even once merged). The only viable mechanism is polling `wslc list --all --format json`, which wip already calls.
- `wip up --watch` adds that polling as a **foreground, opt-in loop** — the same shape as the already-shipped `wip sync --watch` — not a background daemon (which the README explicitly rules out as a non-goal; see the updated Roadmap section for how this stays inside that boundary).
- `restart:` is now parsed (compose-native) and accepted (`mode: container`) instead of ignored, defaulting to `"no"`. Handles a real gotcha: YAML coerces an unquoted `restart: no` to the boolean `false`, not the string `"no"` — both parsing paths correct this back.
- Deliberately conservative scope, consistent with how this codebase already treats compose-native mode ("a deliberately minimal subset"): `always`/`unless-stopped`/`on-failure` are all treated identically (restart on exited/dead, no exit-code gating for `on-failure`), and the loop is status-based rather than transition-based, so it can race with a concurrent manual `wip stop`/`down` in another terminal — documented as a known limitation, not solved.

## Known unverified assumption (flagged prominently in code + README)

The exited/dead detection assumes `wslc list --all --format json` reports a lowercase `State` field matching `docker ps --format json`'s own shape. No fixture or sample output exists anywhere in this repo to confirm the exact field name against a real `wslc` install — isolated to one method (`container_status` in `cli.rb`) and logged under `--debug` so a wrong guess is immediately visible rather than silently inert. Needs a follow-up check against a real WSLC install (see README's new "Restarting exited dependencies" section for exactly what to check).

## Test plan

- [x] `bundle exec rspec` (278 examples, 0 failures)
- [x] `bundle exec rubocop` (46 files, no offenses)
- [x] Manual smoke test: `Config#dependency` merges `restart: "no"` default correctly for both `mode: container` and `mode: compose-native`; unquoted `restart: no` normalizes correctly in both; `wip init`'s scaffolded template parses with the new key.
- [ ] Cannot be verified from this environment (no real wslc/WSL2/Windows access) — needs manual verification on a real machine:
  - Confirm `wslc list --all --format json`'s actual field name/values for container status.
  - Run `wip up --watch --debug` against a real stack with a `restart: always` sidecar, kill it externally, confirm it gets restarted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `wip up --watch` to automatically restart exited dependency services based on configured restart policies.
  * Added configurable polling intervals with `--interval`.
  * Watch mode runs detached and continues until interrupted.

* **Bug Fixes**
  * Restart settings are now preserved and normalized consistently across dependency configurations.
  * Added validation and clear handling for unsupported watch mode in Compose workflows.

* **Documentation**
  * Documented watch mode, polling, restart policies, detached execution, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->