### PR TITLE
fix(ci): don't let release-drafter's draft satisfy the release-exists check

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -95,7 +95,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.version.outputs.tag }}
         run: |
-          if gh release view "$TAG" >/dev/null 2>&1; then
+          # release-drafter (Changelog workflow) keeps a draft release updated on every
+          # push to main, and `gh release view` matches drafts too. Only a published
+          # (non-draft) release means notes for this tag have actually gone out.
+          is_draft=$(gh release view "$TAG" --json isDraft --jq .isDraft 2>/dev/null || echo "")
+          if [ "$is_draft" = "false" ]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- The `Changelog` workflow runs release-drafter with `publish: false` on every push to `main`, keeping a **draft** release up to date under the target tag name.
- `gem-push.yml`'s "Check GitHub release" step used `gh release view "$TAG"`, which matches drafts too — so it always saw the tag as "existing" and skipped "Publish release notes", leaving the draft unpublished indefinitely (confirmed: v1.1.3's release sat as a draft until it was published manually).
- Now checks `isDraft` explicitly; only an already-published release counts as "exists", so the draft correctly gets converted to a real published release on the next gem-push run.

## Test plan
- [x] `ruby -ryaml -e "YAML.load_file(...)"` — valid YAML
- [x] `actionlint` — no new findings on the changed step
- [ ] Next `gem-push` run on `main` should show "Publish release notes" actually running (not skipped) when only a release-drafter draft exists for the tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release notes can now be published correctly when a draft release exists.
  * Draft releases no longer prevent publication of release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->