### PR TITLE
docs(wiki): expand outlines into one page per feature

### DIFF
--- a/wiki/Architecture-Mismatch.md
+++ b/wiki/Architecture-Mismatch.md
@@ -1,0 +1,99 @@
+# Architecture Mismatch
+
+```
+no matching manifest for linux/arm64 in the manifest list entries
+```
+
+The image has no variant for your CPU architecture.
+
+## The hint wip prints
+
+```
+The image does not contain a manifest for the current CPU architecture.
+
+Current architecture:
+  linux/arm64
+
+Inspect the image with:
+
+  docker buildx imagetools inspect <image>
+
+Rebuild and push a multi-platform image with:
+
+  docker buildx build \
+    --platform linux/amd64,linux/arm64 \
+    -t <image> \
+    --push .
+```
+
+Triggered by output matching `no matching manifest for linux/amd64` or `.../arm64`.
+
+## Confirm your architecture
+
+```console
+$ wip doctor
+[OK] Architecture: linux/arm64
+```
+
+| Host CPU | Reported |
+|---|---|
+| `x86_64`, `x64` | `linux/amd64` |
+| `aarch64`, `arm64` | `linux/arm64` |
+| anything else | `linux/<host_cpu>` |
+
+## Confirm the image's
+
+```bash
+docker buildx imagetools inspect ghcr.io/example/myapp:dev
+```
+
+```
+Manifests:
+  Platform:  linux/amd64
+```
+
+One platform, and it isn't yours → confirmed.
+
+## Fixes
+
+### Your own image → publish multi-arch
+
+```bash
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  -t ghcr.io/example/myapp:dev \
+  --push .
+```
+
+Full walkthrough, including a CI recipe: [Multi Arch Images](Multi-Arch-Images).
+
+### Third-party image → find a multi-arch tag
+
+Most popular images publish both architectures. Check before assuming:
+
+```bash
+docker buildx imagetools inspect postgres:16
+```
+
+Some vendor images publish arch-specific tags (`-amd64`, `-arm64`) instead of a manifest list —
+pinning one works, at the cost of a `wip.yml` that only runs on one kind of machine.
+
+### After the image is fixed
+
+```bash
+wip down
+wip up -d      # pulls fresh
+```
+
+## Also seen as
+
+Not every architecture problem surfaces as this message. A container that starts and then
+immediately dies with `exec format error` is the same underlying issue: a binary built for the
+wrong architecture, either in the image or copied in during the build.
+
+Check the base image's platform in your Dockerfile, and any binaries you `COPY` in.
+
+## Related
+
+- [Multi Arch Images](Multi-Arch-Images) — the full guide
+- [wip doctor](wip-doctor)

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -1,0 +1,126 @@
+# Architecture
+
+How the codebase is laid out, for contributors. User-facing behavior lives elsewhere in this wiki;
+this page is about the code.
+
+## The flow of a command
+
+```
+exe/wip
+  └─ Wip::CLI (Thor)
+       ├─ ConfigLoader ──► Config ──► SyncSettings
+       │                      └────► ComposeFile ──► VariableInterpolation
+       ├─ CommandResolver ──► the wslc binary
+       ├─ CommandBuilder ──► an argument array
+       │      └─ DotenvLoader supplies -e defaults
+       ├─ BuildContext ──► DockerIgnore, StagingProgress   (build paths only)
+       └─ CommandRunner ──► spawns it
+              ├─ DebugReporter ──► ResourceMonitor
+              ├─ CommandDisplay  (masks -e values)
+              └─ ErrorInterpreter (hints on failure)
+```
+
+## Modules
+
+### Configuration
+
+| File | Responsibility |
+|---|---|
+| `config_loader.rb` | Finds `wip.yml` (walking up from the cwd, or `--config`), parses it safely (no aliases, no custom classes) |
+| `config.rb` | Validated, defaulted access to the parsed document. Every `ConfigError` for `wip.yml` originates here |
+| `sync_settings.rb` | The `sync:` block: defaults, path validation, mode rules, and the rsync invocation |
+| `compose_file.rb` | Parses `compose.yml` into the shape `Config#dependencies` expects; owns the supported-subset rules and topological ordering |
+| `variable_interpolation.rb` | `${VAR}` substitution over an already-parsed YAML tree |
+| `dotenv_loader.rb` | `.env` parsing |
+
+`Config` is the single source of truth for "what does this project want?" Under compose-native it
+delegates to `ComposeFile` and presents the result through the same accessors, which is why the
+rest of the codebase barely knows which mode it's in.
+
+### Command construction
+
+| File | Responsibility |
+|---|---|
+| `command_builder.rb` | Builds `wslc` argument arrays for exec/run/up/start/stop/remove/build/logs/network/sync |
+| `compose_bridge.rb` | Builds argument arrays for an external compose-for-`wslc` binary, and resolves the compose file path |
+| `command_resolver.rb` | Locates an executable from a candidate list; raises `CommandNotFoundError` listing what it tried |
+| `command_display.rb` | Renders a command array for logs, masking `-e KEY=value` |
+
+Nothing here executes anything. That separation is what makes the suite runnable without WSLC.
+
+### Execution
+
+| File | Responsibility |
+|---|---|
+| `command_runner.rb` | Spawns a command and returns its exit status. Piped (`Open3.popen3`) or behind a pty (`PTY.spawn`), with a `Process.spawn` fallback on Windows |
+| `environment.rb` | Host facts: WSL2, Windows interop, architecture, whether stdio is a TTY |
+| `error_interpreter.rb` | Pattern-matches known failure output into a friendlier hint |
+
+`CommandRunner` is the fiddliest file in the repo. Its complexity is all in service of one goal:
+give the child a *real* terminal (job control, `Ctrl-C`, `isatty`) while still routing output
+through wip so hints can be generated. Hence the pty rather than inherited fds, raw-mode stdin,
+and `SIGWINCH` re-syncing.
+
+### Build context
+
+| File | Responsibility |
+|---|---|
+| `build_context.rb` | Stages a context: `.dockerignore` filtering, temp staging, and the persistent Windows-side shadow with its manifest, locking, and atomic copies |
+| `docker_ignore.rb` | gitignore-style pattern matching, including negation and prune-safety |
+| `staging_progress.rb` | The self-overwriting "copying N/total" line, on its own thread |
+
+### Diagnostics
+
+| File | Responsibility |
+|---|---|
+| `doctor.rb` | Runs the checks and returns `Result(level, message)` values |
+| `debug_reporter.rb` | `--debug` step narration, timings, and where snapshots go |
+| `resource_monitor.rb` | Periodic load/memory/disk-IO/top-process snapshots on a background thread |
+
+### Everything else
+
+| File | Responsibility |
+|---|---|
+| `cli.rb` | Thor command definitions, orchestration, and the global-switch reordering that lets `wip --config X up` work |
+| `initializer.rb` | Generates `wip.yml` (mode detection + templates) |
+| `errors.rb` | `Error` → `ConfigError`, `CommandNotFoundError` |
+| `version.rb` | `Wip::VERSION` |
+
+## Conventions that hold across the codebase
+
+**Argument arrays, never shell strings.** Values from config reach the process spawner as discrete
+arguments. The only intentional splitting is a configured `command:`, split with shell-word rules.
+
+**Validate at load time, name the key.** Every `ConfigError` says which key is wrong, and is raised
+before any container side effect. The one deliberate exception is compose.yml's top-level sections,
+which are ignored rather than rejected.
+
+**Explicit over inferred.** `mode:` is declared, `container:` has no default, `sync.mode` is
+configured rather than probed, `compose.command` has no default.
+
+**Isolate assumptions about `wslc`'s output.** Anything that depends on wslc's JSON shape lives in
+one method, so a future wslc change is a one-line fix. `CLI#container_status` is the model: it
+parses `State` in one place and logs the raw entry under `--debug`.
+
+**Comments carry the *why*.** The codebase leans heavily on comments that record non-obvious
+constraints — why an absolute build context crashes `wslc`, why `restart: no` is a YAML boolean,
+why the shadow root can't be inside the context, why a pty rather than inherited fds. Preserve them
+when you touch the code.
+
+## Deliberately temporary code
+
+`compose_file.rb` carries a note saying so: it exists only because `wslc` has no native Compose
+support ([microsoft/WSL#40948](https://github.com/microsoft/WSL/issues/40948)). When that lands, it
+and its hooks in `config.rb`, `cli.rb`, `doctor.rb`, and `initializer.rb` come out together.
+
+## RuboCop exemptions
+
+`.rubocop.yml` raises `Metrics/ClassLength` for `cli.rb`, `compose_file.rb`, and `config.rb`. Those
+are acknowledged as large; treat the exemption as a debt marker, not a licence to grow them
+further. `Layout/LineLength` is 120.
+
+## Related
+
+- [Development](Development)
+- [Testing and Linting](Testing-and-Linting)
+- [Concepts](Concepts)

--- a/wiki/Auto-Restarting-Containers.md
+++ b/wiki/Auto-Restarting-Containers.md
@@ -1,0 +1,146 @@
+# Auto Restarting Containers
+
+Real Compose restarts a container tagged `restart: always` when it exits. `wslc` has no such
+policy, and no push-based "container exited" notification for wip to hook into — so the closest
+approximation is polling: `wip up --watch`.
+
+Reference for the values and their limits: [Restart Policies](Restart-Policies).
+
+## Setup
+
+Tag the containers you want supervised:
+
+```yaml
+# wip.yml — mode: container
+container: app
+network: app-tier
+dependencies:
+  app:
+    image: myapp:dev
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+  worker:
+    image: myapp:dev
+    command: bundle exec sidekiq
+    restart: on-failure:5
+  postgres:
+    image: postgres:16
+    restart: always
+    env:
+      POSTGRES_PASSWORD: password
+  mailcatcher:
+    image: sj26/mailcatcher
+    # no restart: → never auto-restarted
+```
+
+Or in `compose.yml` under [compose-native mode](Compose-Native-Mode):
+
+```yaml
+services:
+  worker:
+    image: myapp:dev
+    command: bundle exec sidekiq
+    restart: unless-stopped
+```
+
+## Running the supervisor
+
+```console
+$ wip up --watch
+wip: creating network 'app-tier'
+wip: dependency 'postgres' not found, creating it
+wip: dependency 'worker' not found, creating it
+wip: container 'app' not found, creating it
+wip: watching app, worker, postgres, mailcatcher for exited restart: containers every 5s (running detached; Ctrl-C to stop)
+```
+
+Every 5 seconds it checks each dependency's state and restarts the exited ones whose `restart:`
+allows it:
+
+```console
+wip: 'worker' has exited, restarting it (restart: on-failure:5)
+```
+
+`--interval N` changes the period:
+
+```bash
+wip up --watch --interval 10
+```
+
+## Things that will surprise you
+
+### `--watch` implies `-d`
+
+The primary container can't hold an attached TTY while the loop polls on the same thread, so it
+always runs detached under `--watch`. To see its output:
+
+```bash
+# terminal 2 — compose modes only
+wip logs -f
+# or, any mode
+wslc logs -f app
+```
+
+### Exit codes are not read
+
+All three restarting values behave identically: an exited container is restarted regardless of exit
+status. Real `on-failure` skips a clean (zero) exit; this loop doesn't, because reading the code
+would need a heavier call per tick. `on-failure:5`'s retry count is likewise not enforced.
+
+If your worker exits `0` on purpose when it's done, `--watch` will restart it forever. Use
+`restart: no` (or omit it) for anything that's meant to finish.
+
+### It races with manual stops
+
+The loop asks "is this container exited right now?", not "did it just exit?" It cannot tell a crash
+from a `wip stop` you ran in another terminal — so it may restart what you deliberately stopped.
+
+**Ctrl-C the watch loop first**, then `wip stop` / `wip down`.
+
+### Removed containers are not recreated
+
+A removed container reports state `deleted`, not `exited`, and `--watch` only ever runs `start`.
+Recovering from a `wip down` needs a fresh `wip up`.
+
+### Not available under `mode: compose`
+
+```
+`wip up --watch` is not supported under mode: compose (wip never parses a compose.yml
+service list in that mode, so there is nothing to poll)
+```
+
+Use your compose tool's own restart handling. See [Compose Mode](Compose-Mode).
+
+## When it isn't restarting anything
+
+Run the loop with `--debug` — wip logs the raw `wslc list` entry it read for each dependency:
+
+```console
+$ wip up --watch --debug
+wip: [debug] 'worker': {"Name"=>"worker", "State"=>3, …}
+```
+
+Compare `State` against the enum: `0` invalid, `1` created, `2` running, `3` exited, `4` deleted.
+Only `3` triggers a restart.
+
+Checklist:
+
+1. Is `restart:` an exact match for `always` / `unless-stopped` / `on-failure[:N]`? Typos are
+   silently inert.
+2. Did you quote `restart: "no"` when you meant something else? Unquoted `no` is a YAML boolean.
+3. Is the container actually `exited` (`3`), or `deleted` (`4`)?
+4. Is the loop still running? It's a foreground process.
+
+## Should you use this?
+
+It's a development convenience for the case where a sidecar occasionally dies and you'd rather not
+notice. It is not a production supervisor: there's no daemon, no backoff, no exit-code awareness,
+and no logging beyond your terminal. For anything that must stay up unattended, use a real process
+supervisor on the host.
+
+## Related
+
+- [Restart Policies](Restart-Policies)
+- [wip up](wip-up)
+- [Dependencies](Dependencies)

--- a/wiki/CLI-Command-Reference.md
+++ b/wiki/CLI-Command-Reference.md
@@ -1,0 +1,63 @@
+# CLI Command Reference
+
+Index of every `wip` command. Each has its own page with flags, behavior per mode, and examples.
+
+## Commands
+
+| Command | Description | Page |
+|---|---|---|
+| `wip init [--force] [--template NAME]` | Write a starter `wip.yml` | [wip init](wip-init) |
+| `wip version` | wip's version, plus WSLC's if detectable | [wip version](wip-version) |
+| `wip doctor` | Diagnose WSL2, interop, WSLC, config, architecture, Git | [wip doctor](wip-doctor) |
+| `wip config` | Print the effective configuration (secrets masked) | [wip config](wip-config) |
+| `wip build [--no-cache] [-- OPTIONS]` | Build the configured image | [wip build](wip-build) |
+| `wip up [-d] [--no-sync] [--no-cache] [--watch] [--interval N]` | Start the stack | [wip up](wip-up) |
+| `wip stop` | Stop containers without removing them | [wip stop](wip-stop) |
+| `wip down` | Stop and remove containers | [wip down](wip-down) |
+| `wip exec [--no-interactive] COMMAND...` | Run a command in the running container | [wip exec](wip-exec) |
+| `wip run [--no-interactive] COMMAND...` | Run a command in a fresh container | [wip run](wip-run) |
+| `wip shell` | Open a shell, falling back `bash` → `sh` | [wip shell](wip-shell) |
+| `wip logs [-f] [SERVICE...]` | Follow logs (compose modes only) | [wip logs](wip-logs) |
+| `wip sync [-w] [--interval N]` | Mirror the source into the sync volume | [wip sync](wip-sync) |
+| `wip dispatch NAME [ARGS...]` | Run an interaction explicitly | [wip dispatch](wip-dispatch) |
+| `wip NAME ARGS...` | Run `interaction.NAME` | [Interactions](Interactions) |
+
+## Cross-cutting
+
+- [Global Options](Global-Options) — `--config`, `--env-file`, `--debug`, `--debug-log`, and where they may appear
+- [Debug Output](Debug-Output) — reading `--debug`, resource snapshots, telling wip overhead from container time
+- [TTY Allocation](TTY-Allocation) — how `interactive:`, `--no-interactive`, and real-TTY detection combine
+
+## Availability by mode
+
+| Command | `container` | `compose-native` | `compose` |
+|---|---|---|---|
+| `init` `version` `doctor` `config` | ✔ | ✔ | ✔ |
+| `build` | ✔ | ✔ | ✔ (interaction must be `type: exec`) |
+| `up` | ✔ | ✔ | ✔ (no `--watch`) |
+| `stop` `down` | ✔ | ✔ | ✔ (bridged) |
+| `exec` `shell` | ✔ | ✔ | ✔ (bridged) |
+| `run` | ✔ real `--rm` | ✔ real `--rm` | falls back to `exec` |
+| `logs` | ✘ | ✔ (one service) | ✔ (multi-service) |
+| `sync` | ✔ | ✔ | ✔ (`mode: run` only) |
+| `dispatch` | ✔ | ✔ | ✔ (`type: exec` only) |
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | success |
+| `1` | a wip-level failure (`ConfigError`, `wip doctor` found a `[FAIL]`) |
+| `127` | the resolved binary couldn't be executed |
+| `130` | interrupted (`Ctrl-C`) |
+| `128 + N` | the child was killed by signal `N` |
+| anything else | passed through from `wslc` / the child process |
+
+`wip` exits with the child's exit code for the command-running paths, so `wip rspec` fails your CI
+step exactly when `rspec` does.
+
+## Command name resolution
+
+An unrecognized first argument is routed to `dispatch`, which is what makes `wip rspec` work
+without a `dispatch` prefix. Built-in names always win over an interaction of the same name — see
+[wip dispatch](wip-dispatch).

--- a/wiki/Choosing-a-Mode.md
+++ b/wiki/Choosing-a-Mode.md
@@ -1,0 +1,76 @@
+# Choosing a Mode
+
+`mode:` is the first line of `wip.yml` that actually changes behavior. Everything else — which
+keys are legal, what `wip up` does, whether `wip run` gets a real ephemeral container — follows
+from it.
+
+## Decision table
+
+| Situation | Use |
+|---|---|
+| No `compose.yml`; you want containers declared in `wip.yml` itself | [`mode: container`](Container-Mode) (default) |
+| You have a `compose.yml` and don't want to install anything extra | [`mode: compose-native`](Compose-Native-Mode) |
+| You have a `compose.yml` and already use a third-party compose-for-`wslc` tool | [`mode: compose`](Compose-Mode) |
+
+## Decision flow
+
+```
+Do you already have a compose.yml?
+│
+├─ No ──────────────────► mode: container
+│                         Declare containers in wip.yml's dependencies:
+│
+└─ Yes
+   │
+   ├─ Do you already run a compose-for-wslc binary you trust?
+   │  │
+   │  ├─ Yes ───────────► mode: compose
+   │  │                   wip bridges to it (up/down/exec/logs)
+   │  │
+   │  └─ No ────────────► mode: compose-native
+   │                      wip parses compose.yml itself, no extra binary
+   │
+   └─ Does your compose.yml use features outside the supported subset
+      (health-check conditions, long-syntax volumes, scaling, ...)?
+      │
+      ├─ Yes ───────────► mode: compose (let the external tool handle it)
+      └─ No ────────────► mode: compose-native
+```
+
+## What changes between the modes
+
+| | `container` | `compose-native` | `compose` |
+|---|---|---|---|
+| Where containers are declared | `dependencies:` in `wip.yml` | `services:` in `compose.yml` | `services:` in `compose.yml` |
+| Who drives `wslc` | wip | wip | the external compose binary |
+| External binary required | no | no | yes (`compose.command`) |
+| Names the app | `container:` | `compose.service` | `compose.service` |
+| `wip run` | real `wslc run --rm` | real `wslc run --rm` | falls back to `exec` |
+| `wip logs` | not available | one service at a time | full compose `logs` |
+| `wip up --watch` | yes | yes | no |
+| `interaction.type: run` / `build` | yes | yes | no (exec only) |
+| `sync.mode` default | `exec` | `exec` | `run` (and `exec` is rejected) |
+| `sync.image` / `sync.build` | optional | optional | one is required |
+
+## `wip init` picks for you
+
+`wip init` writes `mode: compose-native` when it finds a compose file next to the `wip.yml` it's
+creating, and `mode: container` otherwise. It never writes `mode: compose` on its own, because
+that mode needs a `compose.command` only you can name. See [wip init](wip-init).
+
+## Rules the loader enforces
+
+- `mode:` must be one of `container`, `compose`, `compose-native` — anything else is a `ConfigError`.
+- `mode: compose` and `mode: compose-native` both require a `compose:` block.
+- A `compose:` block without one of those two modes is an error.
+- `compose:` is mutually exclusive with `dependencies:` and with `network:`.
+- `compose.command` is **required** under `mode: compose` and **rejected** under `mode: compose-native`.
+
+The full list, with the exact messages, is on [Configuration Errors](Configuration-Errors).
+
+## Can I switch later?
+
+Yes, and the shape of `wip.yml` is intended to stay stable across the switch: `mode:` plus a
+`compose:` block is the whole surface. Going from `compose` to `compose-native` usually means
+deleting `compose.command`; going the other way means adding it back. Your `interaction:` entries,
+`.env` handling, and `sync:` block carry over unchanged.

--- a/wiki/Comparison.md
+++ b/wiki/Comparison.md
@@ -1,0 +1,63 @@
+# Comparison
+
+Why `wip`, and how it relates to the tools next to it.
+
+## The short answer
+
+`wip` is to WSLC roughly what `dip` is to Docker Compose: a project-local workflow CLI that turns
+long, flag-heavy runtime invocations into `wip rspec`. It doesn't replace `wslc`; every command
+ends in one.
+
+## Pages
+
+- [wip vs dip](wip-vs-dip) — shared ground, differences, what isn't covered yet
+- [wip vs docker compose](wip-vs-docker-compose) — what consolidating into `wip.yml` buys you over driving `wslc` by hand
+- [Third Party Compose Tools](Third-Party-Compose-Tools) — the compose-for-`wslc` ecosystem, and why wip doesn't pick a winner
+
+## At a glance
+
+| | `wip` | `dip` | `docker compose` | plain `wslc` |
+|---|---|---|---|---|
+| Runtime | WSLC | Docker | Docker | WSLC |
+| Named project commands | ✔ `interaction:` | ✔ `interaction:` | ✘ | ✘ |
+| Declares services | ✔ `dependencies:` / reuses `compose.yml` | delegates to Compose | ✔ | ✘ |
+| Reuses an existing `compose.yml` | ✔ (two modes) | ✔ | ✔ (it *is* it) | ✘ |
+| `.env` support | ✔ | ✔ | ✔ | ✘ |
+| `.dockerignore` honored on build | ✔ | via Docker | via Docker | ✘ |
+| Source-sync for slow mounts | ✔ `sync:` | ✘ | ✘ | ✘ |
+| Restart policies | approximated by polling | via Compose | ✔ native | ✘ |
+| Health checks | ✘ | via Compose | ✔ | ✘ |
+| Background daemon | ✘ by design | ✘ | ✔ (the engine) | — |
+
+## The three ways to run a compose.yml under WSLC
+
+| | wip `compose-native` | wip `compose` | a compose-for-wslc tool directly |
+|---|---|---|---|
+| External binary | none | required | required |
+| Named project commands | ✔ | ✔ | ✘ |
+| Compose coverage | a [documented subset](Compose-File-Support) | the tool's | the tool's |
+| `run` (ephemeral) | ✔ real `wslc run --rm` | falls back to `exec` | the tool's |
+| `logs` | one service | the tool's | the tool's |
+| `--watch` restarts | ✔ | ✘ | the tool's |
+
+## Related upstream work
+
+`wslc` has no native Compose support yet — tracked in
+[microsoft/WSL#40948](https://github.com/microsoft/WSL/issues/40948). Both of wip's compose modes
+exist because of that gap:
+
+- `compose-native` is the stopgap wip maintains itself
+- `compose` is the bridge to whatever the ecosystem produces in the meantime
+
+`wslc` is new and still evolving, so expect this landscape to change. wip's stated intent is that
+`wip.yml`'s shape stays stable across it.
+
+## When not to use wip
+
+Being honest about the boundaries:
+
+- **You're on Docker, not WSLC.** Use `dip` and `docker compose`. wip has no Docker backend.
+- **You need production orchestration.** wip is a development workflow tool: no daemon, no backoff,
+  no health checks, no scaling.
+- **Your `compose.yml` needs the full spec and you don't want an extra binary.** `compose-native`'s
+  subset may not reach far enough; `mode: compose` plus a real tool will.

--- a/wiki/Compose-Build.md
+++ b/wiki/Compose-Build.md
@@ -1,0 +1,149 @@
+# Compose Build
+
+How [`mode: compose-native`](Compose-Native-Mode) handles services that declare `build:` instead of
+(or alongside) `image:`.
+
+## Accepted forms
+
+Short form — just a context:
+
+```yaml
+services:
+  app:
+    build: .
+```
+
+Long form:
+
+```yaml
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+      args:
+        RUBY_VERSION: "3.4"
+      shadow_context: /mnt/c/Users/me/AppData/Local/wip/build-contexts
+```
+
+Only those four keys are supported. Anything else:
+
+```
+compose.yml: services.app.build has unsupported key(s): target, cache_from
+```
+
+`build:` must be a string or a mapping — a list is an error.
+
+## Path resolution
+
+- **`context`** is resolved relative to `compose.yml`'s own directory (Compose's rule), **not**
+  wherever `wip` was invoked from. It defaults to `.`.
+- **`dockerfile`** stays relative to `context`, and is passed through as `-f`. It is deliberately
+  *not* resolved against the context, so `-f` still finds it after wip changes into a staged or
+  shadowed copy of that context.
+
+## Tagging
+
+| Service declares | Resulting tag |
+|---|---|
+| `build:` only | `wip-compose-<service>:latest` (auto-generated) |
+| `build:` **and** `image:` | the `image:` value |
+| `image:` only | the `image:` value; nothing is built |
+
+The `build:` + `image:` combination follows real Compose's own rule: build via the former, tag the
+result with the latter.
+
+```yaml
+services:
+  app:
+    build: .
+    image: myapp:dev     # → wslc build -t myapp:dev .
+```
+
+## When images are built
+
+At the start of `wip up`, **before** the network is created and any container is started:
+
+```console
+$ wip up -d
+wip: building service 'app' (tag: myapp:dev) from /home/me/app
+wip: staging build context (/home/me/app)
+wip: copying build context files: 812/812
+```
+
+Every service with a `build:` is built, once per `wip up` invocation, in `depends_on` order.
+Profile-gated services are skipped entirely — see [Compose Profiles](Compose-Profiles).
+
+`wip up --no-cache` adds `--no-cache` to each of those builds.
+
+There is no separate "build only these services" command; `wip build` runs the `build` *interaction*
+from `wip.yml`, which is a different thing — see [wip build](wip-build).
+
+## Build args
+
+```yaml
+build:
+  args:
+    RUBY_VERSION: "3.4"
+    BUNDLER_VERSION: "2.5.6"
+```
+
+Each becomes `--build-arg KEY=VALUE`. Both mapping and `KEY=VALUE` array forms are accepted, with
+the same rules as `environment:`: a null value or a bare key is an error, since host pass-through
+isn't supported.
+
+## Context staging
+
+Each service's build context goes through the same staging path `wip build` uses:
+
+- its own `.dockerignore`, read from the context root — see [Dockerignore](Dockerignore)
+- an optional persistent Windows-side shadow copy via `shadow_context:` — see
+  [Shadow Build Context](Shadow-Build-Context)
+- progress reporting while files are copied
+
+The build then runs from **inside** the staged directory with `.` as the context, because
+`wslc build` crashes when handed an absolute context path.
+
+## Full example
+
+```yaml
+# compose.yml
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+      args:
+        RUBY_VERSION: "3.4"
+      shadow_context: /mnt/c/Users/me/AppData/Local/wip/build-contexts
+    image: myapp:dev
+    working_dir: /app
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_PASSWORD: password
+```
+
+```yaml
+# wip.yml
+version: 1
+mode: compose-native
+compose:
+  service: app
+  project: myapp
+```
+
+```bash
+wip up -d      # builds myapp:dev, creates network myapp, starts db, then app
+```
+
+## Related
+
+- [Compose File Support](Compose-File-Support)
+- [Dockerignore](Dockerignore)
+- [Shadow Build Context](Shadow-Build-Context)
+- [wip up](wip-up)

--- a/wiki/Compose-Depends-On.md
+++ b/wiki/Compose-Depends-On.md
@@ -1,0 +1,118 @@
+# Compose Depends On
+
+`depends_on:` controls **start ordering** under [`mode: compose-native`](Compose-Native-Mode).
+That's all it controls — there is no health-check support, so it cannot mean "wait until ready".
+
+## Accepted forms
+
+Array form:
+
+```yaml
+services:
+  app:
+    image: myapp:dev
+    depends_on:
+      - db
+      - redis
+```
+
+Mapping form, with an explicit condition:
+
+```yaml
+services:
+  app:
+    image: myapp:dev
+    depends_on:
+      db:
+        condition: service_started
+```
+
+Anything else (a string, a number) is an error:
+
+```
+compose.yml: services.app.depends_on must be an array or a mapping
+```
+
+## Supported conditions
+
+| Condition | Support |
+|---|---|
+| `service_started` | ✔ (and the default when no condition is given) |
+| `service_healthy` | ✘ |
+| `service_completed_successfully` | ✘ |
+
+```
+compose.yml: services.app.depends_on.db: condition 'service_healthy' is not supported
+(only service_started — no health checks)
+```
+
+Why: `healthcheck:` is not in the [supported subset](Compose-File-Support), so there is no health
+state for wip to wait on. If your stack genuinely needs readiness gating, either use
+[`mode: compose`](Compose-Mode) with a tool that implements it, or handle it in the app (retry the
+DB connection on boot — which most frameworks do already, and which is more robust anyway).
+
+## What ordering actually means
+
+Services are sorted into a topological order and started in that order. "Started" means the
+container process has been launched — not that the service inside it is accepting connections.
+
+```yaml
+services:
+  app:
+    depends_on: [db]
+  db:
+    image: postgres:16
+```
+
+```console
+$ wip up -d
+wip: dependency 'db' not found, creating it
+wip: container 'app' not found, creating it
+```
+
+The primary service (`compose.service`) is always started **last**, after every sidecar, regardless
+of what `depends_on` says — same as [Container Mode](Container-Mode)'s primary/sidecar split. See
+[Dependencies](Dependencies).
+
+The same order is used when building `build:` services at the start of `wip up` — see
+[Compose Build](Compose-Build).
+
+## Validation
+
+**Unknown target:**
+
+```
+compose.yml: services.app depends_on unknown service 'databse'
+```
+
+**Cycles** are detected and rejected rather than looping forever:
+
+```
+compose.yml: services.app is part of a depends_on cycle
+```
+
+**Depending on a profile-gated service** is rejected, because wip has no way to activate a profile,
+so that dependency would silently never start:
+
+```
+compose.yml: services.app depends_on 'debug-tools', gated behind profiles: (debug) wip never
+activates (no --profile flag)
+```
+
+A profile-gated service is allowed to depend on another profile-gated service — neither is started
+anyway. See [Compose Profiles](Compose-Profiles).
+
+## Checking the resolved order
+
+```bash
+wip config
+```
+
+prints the services as `dependencies:` entries in dependency order, so you can read off exactly
+what `wip up` will do.
+
+## Related
+
+- [Compose File Support](Compose-File-Support)
+- [Compose Profiles](Compose-Profiles)
+- [wip up](wip-up)

--- a/wiki/Compose-File-Support.md
+++ b/wiki/Compose-File-Support.md
@@ -1,0 +1,173 @@
+# Compose File Support
+
+What [`mode: compose-native`](Compose-Native-Mode) understands when it parses your `compose.yml`.
+
+The subset is deliberately small — it exists to close the gap until `wslc` ships Compose support
+of its own ([microsoft/WSL#40948](https://github.com/microsoft/WSL/issues/40948)) — but it's
+actively extended, not a frozen ceiling. If your file needs more than this, use
+[`mode: compose`](Compose-Mode) and let a dedicated tool handle it.
+
+## Which file is read
+
+`compose.file` if set (resolved relative to `wip.yml`), otherwise the first of these found next to
+`wip.yml`:
+
+```
+compose.yml → compose.yaml → docker-compose.yml → docker-compose.yaml
+```
+
+Parsed with YAML **aliases enabled**, so merge keys and anchors work:
+
+```yaml
+x-common: &common
+  image: myapp:dev
+  working_dir: /app
+
+services:
+  app:
+    <<: *common
+  worker:
+    <<: *common
+    command: bundle exec sidekiq
+```
+
+(`wip.yml` itself is parsed with aliases *disabled* — see
+[Config File Discovery](Config-File-Discovery).)
+
+`${VAR}` references are substituted before anything else — see
+[Compose Variable Interpolation](Compose-Variable-Interpolation).
+
+## Supported per-service keys
+
+| Key | Support |
+|---|---|
+| `image` | full |
+| `build` | string, or `{context, dockerfile, args, shadow_context}` — see [Compose Build](Compose-Build) |
+| `command` | shell form (`"bin/rails s"`) or exec form (`["bin/rails", "s"]`) |
+| `environment` | mapping, or `KEY=VALUE` array. No host pass-through (a null value / bare `KEY` is an error) |
+| `ports` | **short syntax only** (`"3000:3000"`) |
+| `volumes` | **short syntax only** (`".:/app"`, `"app-src:/app"`) |
+| `working_dir` | full → `-w` |
+| `user` | full → `-u` |
+| `restart` | stored as-is; acted on by [`wip up --watch`](Restart-Policies) |
+| `depends_on` | ordering only — see [Compose Depends On](Compose-Depends-On) |
+| `profiles` | parsed; profile-gated services are skipped — see [Compose Profiles](Compose-Profiles) |
+
+Either `image` or `build` is required per service:
+
+```
+services.app must set image or build
+```
+
+## Accepted but ignored
+
+| Key | Why it's ignored |
+|---|---|
+| `tty` | TTY allocation is decided per invocation, not per service — see [TTY Allocation](TTY-Allocation) |
+| `stdin_open` | same |
+| `networks` | every service already shares the one project network — see [Networking](Networking) |
+| `cap_add` | `wslc run`/`exec` has no capability flag to forward it to |
+
+These don't fail; they simply have no effect.
+
+## Ignored top-level sections
+
+Everything outside `services:` — `networks:`, `volumes:`, `configs:`, `secrets:`, `x-*` extensions,
+and so on — is read by real Compose tools, not by wip, so it's silently ignored rather than
+rejected. This is the one place wip deliberately doesn't complain about what it can't handle:
+failing here would reject an otherwise perfectly valid `compose.yml` over sections wip never needs
+to look at.
+
+`services:` itself must be a mapping:
+
+```
+compose.yml: services: must be a mapping
+```
+
+## Anything else in a service is an error
+
+Inside `services.<name>:`, an unrecognized key fails at load time and names itself:
+
+```
+compose.yml: services.app has unsupported key(s): healthcheck, deploy
+```
+
+That's intentional: silently dropping `healthcheck:` would mean the file says one thing and wip
+does another.
+
+Commonly-hit unsupported keys, and what to do:
+
+| Key | Alternative |
+|---|---|
+| `healthcheck` | none — `depends_on` conditions other than `service_started` are rejected; use `mode: compose` |
+| `deploy` (incl. `replicas`) | no scaling support; use `mode: compose` |
+| `env_file` | move values into `.env` next to `wip.yml` ([Env Files](Env-Files)) or `environment:` |
+| `extends` | inline it, or use YAML anchors (aliases are enabled) |
+| `entrypoint` | fold it into `command:`, or bake it into the image |
+| `labels` | no equivalent |
+
+Long-syntax `ports:` / `volumes:` fail with a specific hint:
+
+```
+compose.yml: services.app.volumes only supports short syntax ("host:container"), not long-syntax mappings
+```
+
+## `environment` rules
+
+```yaml
+environment:
+  RAILS_ENV: development     # ok
+  PORT: 3000                 # ok — stringified
+```
+
+```yaml
+environment:
+  - RAILS_ENV=development    # ok
+  - PORT=3000                # ok
+```
+
+Not supported:
+
+```yaml
+environment:
+  RAILS_ENV:                 # null → error
+  - RAILS_ENV                # bare KEY → error
+```
+
+```
+compose.yml: services.app.environment.RAILS_ENV must have a value (host environment pass-through is not supported)
+compose.yml: services.app.environment entries must be KEY=VALUE
+```
+
+Pass the value through `.env` instead — see [Env Files](Env-Files).
+
+## Validating your file
+
+```bash
+wip doctor
+```
+
+reports whether the compose file was found, whether it parsed, and whether `compose.service` names
+a service it actually defines:
+
+```console
+[OK] Found compose file /home/me/app/compose.yml
+[OK] Parsed compose file
+```
+
+Then check what wip made of it:
+
+```bash
+wip config
+```
+
+which prints each service as a resolved `dependencies:` entry.
+
+## Related
+
+- [Compose Native Mode](Compose-Native-Mode)
+- [Compose Build](Compose-Build)
+- [Compose Depends On](Compose-Depends-On)
+- [Compose Profiles](Compose-Profiles)
+- [Compose Variable Interpolation](Compose-Variable-Interpolation)
+- [Reusing an Existing compose.yml](Reusing-an-Existing-compose-yml)

--- a/wiki/Compose-Mode.md
+++ b/wiki/Compose-Mode.md
@@ -1,0 +1,99 @@
+# Compose Mode
+
+`mode: compose` makes wip a thin bridge to a third-party compose-for-`wslc` binary that you
+install and name yourself. wip builds `<command> -f FILE [-p PROJECT] up|down|stop|exec|logs`
+argument arrays; the external tool does the orchestration.
+
+Prefer this when you already run such a tool, or when your `compose.yml` uses features outside
+[what compose-native supports](Compose-File-Support). Otherwise see
+[Compose Native Mode](Compose-Native-Mode).
+
+## Config
+
+```yaml
+version: 1
+mode: compose              # required; a compose: block without it is an error
+compose:
+  service: app             # required: which service wip run/exec/NAME target
+  command: wslc-compose    # required: the compose-for-wslc binary or path you installed
+  file: compose.yml        # optional; auto-detected next to wip.yml otherwise
+  project: myapp           # optional; omitted lets the compose tool pick its default
+```
+
+### Key reference
+
+| Key | Required | Default | Notes |
+|---|---|---|---|
+| `compose.service` | yes | — | must not be empty |
+| `compose.command` | yes | — | no default: wip doesn't favor any implementation |
+| `compose.file` | no | auto-detected | relative paths resolve against `wip.yml`, not the cwd |
+| `compose.project` | no | unset | passed as `-p` only when set |
+
+Auto-detection looks for, in order: `compose.yml`, `compose.yaml`, `docker-compose.yml`,
+`docker-compose.yaml`, next to `wip.yml`. None found is a `ConfigError`.
+
+`compose:` is mutually exclusive with `dependencies:` and `network:`.
+
+## Why `compose.command` has no default
+
+`wslc` has no native Compose support yet (tracked upstream in
+[microsoft/WSL#40948](https://github.com/microsoft/WSL/issues/40948)), and independent third-party
+tools fill the gap. wip deliberately doesn't pick a winner — unlike `wslc.command`, which defaults
+to `auto` and searches. Set `compose.command` to whichever binary name or absolute path you have.
+Candidates: [Third Party Compose Tools](Third-Party-Compose-Tools).
+
+Whatever you point it at must understand `-f FILE [-p PROJECT] up|down|stop|exec|logs` — the
+subset of the Compose CLI vocabulary wip drives.
+
+## Command surface
+
+| Command | Bridged to | Notes |
+|---|---|---|
+| [`wip up`](wip-up) | `<cmd> up [-d]` | `--watch` is rejected in this mode |
+| [`wip stop`](wip-stop) | `<cmd> stop` | |
+| [`wip down`](wip-down) | `<cmd> down` | |
+| [`wip exec`](wip-exec) | `<cmd> exec [-T] <service> …` | `-T` when non-interactive |
+| [`wip run`](wip-run) | `<cmd> exec …` | **falls back** to exec; wip warns |
+| [`wip shell`](wip-shell) | `<cmd> exec <service> bash`, then `sh` | |
+| [`wip logs`](wip-logs) | `<cmd> logs [-f] [SERVICE…]` | multi-service, unlike compose-native |
+| [`wip NAME`](wip-dispatch) | `<cmd> exec <service> …` | only `type: exec` is supported |
+
+### Limitations specific to this mode
+
+- **No ephemeral `run`.** The exec-only vocabulary has no equivalent, so `wip run` execs into the
+  already-running `compose.service` and warns that it did.
+- **No `type: run` / `type: build` interactions.** Both raise a `ConfigError` pointing you at your
+  compose tool's own `build` / `up --build`. Compose owns builds for its own services.
+- **No `wip up --watch`.** wip never parses a service list in this mode, so there's nothing to
+  poll. Use whatever restart support your compose tool offers.
+- **`sync:` behaves differently.** `sync.mode` defaults to `run` and cannot be `exec`, and one of
+  `sync.image` / `sync.build` is required. See [Sync Modes](Sync-Modes).
+
+## Source sync under this mode
+
+Compose owns the volume layout, so wip does **not** rewrite any mounts for you. Your compose
+service must itself declare a named volume matching `sync.volume` (default `<service>-src`):
+
+```yaml
+# compose.yml
+services:
+  app:
+    volumes:
+      - app-src:/app
+volumes:
+  app-src:
+```
+
+wip's mirror writes into that volume from a separate, disposable container; it never touches the
+compose service directly. `wip up`'s pre-boot mirror (and `--no-sync`) work the same as elsewhere.
+Full explanation: [Sync Modes](Sync-Modes).
+
+## Diagnostics
+
+`wip doctor` in this mode additionally reports:
+
+- whether `compose.command` resolves to an executable (and its `version` output)
+- which compose file wip resolved, and whether it exists
+
+It does **not** parse the compose file here — that's the external tool's job. See
+[wip doctor](wip-doctor).

--- a/wiki/Compose-Native-Mode.md
+++ b/wiki/Compose-Native-Mode.md
@@ -1,0 +1,96 @@
+# Compose Native Mode
+
+`mode: compose-native` reuses your existing `compose.yml` without installing anything: wip parses
+it and drives `wslc` directly, the same way [Container Mode](Container-Mode) drives
+`dependencies:`.
+
+This is explicitly a stopgap for as long as `wslc` itself has no native Compose support (tracked
+upstream in [microsoft/WSL#40948](https://github.com/microsoft/WSL/issues/40948)) and third-party
+compose-for-`wslc` tools stay incomplete. Its Compose coverage is maintained in this repo and
+actively extended — it isn't frozen at whatever it handles today.
+
+## Config
+
+```yaml
+version: 1
+mode: compose-native
+
+compose:
+  service: app      # required: which compose service wip run/exec/NAME target
+  file: compose.yml # optional; auto-detected next to wip.yml otherwise
+  project: myapp    # optional; also names wip's project network
+                    # (defaults to the wip.yml directory's name)
+```
+
+There is no `compose.command` here — naming one is a `ConfigError`, since there's no external
+binary involved. There is also no top-level `container:`; `compose.service` already names it.
+`compose:` stays mutually exclusive with `dependencies:` and `network:`.
+
+### `compose.project` and the network
+
+wip creates its own project network so services can reach each other by name, the same guarantee
+real Compose's per-project network gives. The network name is `compose.project`, falling back to
+the `wip.yml` directory's basename. See [Networking](Networking).
+
+## What it understands
+
+The supported `compose.yml` subset — per-service keys, accepted-but-ignored keys, and what happens
+when you use something outside it — has its own page:
+**[Compose File Support](Compose-File-Support)**.
+
+Sub-features with their own pages:
+
+- [Compose Build](Compose-Build) — `build:` services, auto-tagging, and when they're built
+- [Compose Depends On](Compose-Depends-On) — start ordering, cycles, supported conditions
+- [Compose Profiles](Compose-Profiles) — profile-gated services and why wip skips them
+- [Compose Variable Interpolation](Compose-Variable-Interpolation) — `${VAR}` handling
+
+## Command surface
+
+| Command | Behavior |
+|---|---|
+| [`wip up`](wip-up) | build `build:` services → create network → start services in `depends_on` order → mirror source → start `compose.service` |
+| [`wip stop`](wip-stop) / [`wip down`](wip-down) | `wslc stop` / `wslc remove -f` across every service |
+| [`wip exec`](wip-exec) | `wslc exec` into `compose.service` |
+| [`wip run`](wip-run) | real `wslc run --rm` — unlike `mode: compose`'s exec fallback |
+| [`wip logs`](wip-logs) | at most **one** service (defaults to `compose.service`) |
+| [`wip up --watch`](Restart-Policies) | available; reads each service's `restart:` |
+| [`wip sync`](wip-sync) | defaults to `sync.mode: exec`, same as container mode |
+
+## How compose.yml maps onto wip's model
+
+wip converts each service into the same internal shape `dependencies:` produces:
+
+| compose.yml | wip |
+|---|---|
+| `services.<name>` | a `dependencies:` entry named `<name>` |
+| `compose.service` | `container:` (the primary container) |
+| `image:` | the entry's `image` |
+| `build:` | built first, then used as the entry's image |
+| `command:` | the entry's `command` (shell or exec form both accepted) |
+| `environment:` | the entry's `env` |
+| `ports:` / `volumes:` | the entry's `ports` / `volumes` (short syntax only) |
+| `working_dir:` / `user:` | `-w` / `-u` |
+| `restart:` | polled by `wip up --watch` |
+| `depends_on:` | start order |
+
+That's why everything on [Dependencies](Dependencies) about primary vs. sidecar applies here too —
+`compose.service` is simply the primary entry.
+
+## Source sync
+
+Behaves exactly like [Container Mode](Container-Mode)'s: `sync.mode` defaults to `exec`, and
+`sync.image` / `sync.build` fall back to the primary service's own image. None of
+[`mode: compose`](Compose-Mode)'s extra requirements apply, because wip itself boots every
+container here. See [Source Sync](Source-Sync).
+
+## Diagnostics
+
+`wip doctor` additionally checks that the compose file exists **and parses**, and that
+`compose.service` names a service the file actually defines. See [wip doctor](wip-doctor).
+
+## When `wslc` ships Compose support
+
+`compose-native` exists to close that gap. `wip.yml`'s shape (`mode:`, `compose:`) isn't planned
+to change for existing setups, so whatever happens once `wslc` catches up won't require rewriting
+your config.

--- a/wiki/Compose-Profiles.md
+++ b/wiki/Compose-Profiles.md
@@ -1,0 +1,95 @@
+# Compose Profiles
+
+`profiles:` in a `compose.yml` service marks it as opt-in — real Compose only starts it when you
+activate the profile with `--profile`. wip has **no `--profile` flag**, so profile-gated services
+are parsed, validated, and then skipped.
+
+## Behavior
+
+```yaml
+services:
+  app:
+    image: myapp:dev
+  db:
+    image: postgres:16
+  mailcatcher:
+    image: sj26/mailcatcher
+    profiles: [dev-tools]
+  seed:
+    image: myapp:dev
+    command: bundle exec rails db:seed
+    profiles: [tools]
+```
+
+```bash
+wip up -d     # starts db and app. mailcatcher and seed are ignored.
+```
+
+Profile-gated services are:
+
+- **parsed and validated** like any other — an unsupported key in one is still an error
+- **included in `depends_on` validation and cycle detection**
+- **excluded** from `wip up`, `wip stop`, `wip down`, and `wip up --watch`
+- **excluded** from image builds (a profile-gated service with `build:` is never built)
+- **absent** from `wip config`'s `dependencies:` output
+
+This matches what real Compose does with an unactivated profile: the service exists in the model
+but isn't part of the run.
+
+`profiles:` must be an array of strings:
+
+```
+compose.yml: services.mailcatcher.profiles must be an array of strings
+```
+
+## `compose.service` may not be profile-gated
+
+The primary service is the one thing wip always starts, so pointing `compose.service` at a
+profile-gated service is rejected up front rather than failing later with a confusing "no matching
+service" message:
+
+```
+compose.service 'seed' is gated behind profiles: in compose.yml, but wip has no --profile flag
+to activate one — pick a service with no profiles: or remove profiles: from it
+```
+
+## A startable service may not depend on a gated one
+
+```yaml
+services:
+  app:
+    depends_on: [mailcatcher]
+  mailcatcher:
+    profiles: [dev-tools]
+```
+
+```
+compose.yml: services.app depends_on 'mailcatcher', gated behind profiles: (dev-tools) wip
+never activates (no --profile flag)
+```
+
+Real Compose treats this as an invalid model too, since the dependency would never start. A gated
+service depending on another gated service is fine — neither runs.
+
+## Working with a profiled compose.yml
+
+If your compose file uses profiles heavily, you have three options:
+
+1. **Leave them.** Gated services are simply skipped, which is usually what you want in a dev
+   container workflow — they exist for CI, seeding, or one-off tooling.
+2. **Run the gated thing yourself.** Since it isn't managed by wip, use `wslc run` directly, or add
+   an [interaction](Interactions) with `type: run`:
+   ```yaml
+   interaction:
+     seed:
+       type: run
+       command: bundle exec rails db:seed
+   ```
+3. **Use [`mode: compose`](Compose-Mode).** The external tool has its own `--profile` support, and
+   wip just bridges to it.
+
+## Related
+
+- [Compose File Support](Compose-File-Support)
+- [Compose Depends On](Compose-Depends-On)
+- [Compose Native Mode](Compose-Native-Mode)

--- a/wiki/Compose-Variable-Interpolation.md
+++ b/wiki/Compose-Variable-Interpolation.md
@@ -1,0 +1,108 @@
+# Compose Variable Interpolation
+
+`${VAR}` references inside `compose.yml` are substituted the way `docker compose` does, before wip
+looks at the file at all. This is what lets `user: ${USER_ID}:${GROUP_ID}` reach `wslc` already
+resolved instead of literally.
+
+Applies to [`mode: compose-native`](Compose-Native-Mode) only — under
+[`mode: compose`](Compose-Mode) the external tool does its own interpolation.
+
+## Supported syntax
+
+| Form | Behavior |
+|---|---|
+| `${VAR}` | the value, or an empty string if unset |
+| `$VAR` | same as `${VAR}` |
+| `${VAR:-default}` | `default` if `VAR` is unset **or empty** |
+| `${VAR-default}` | `default` only if `VAR` is unset (an empty value stays empty) |
+| `$$` | an escaped literal `$` |
+
+```yaml
+services:
+  app:
+    image: myapp:${TAG:-dev}
+    user: "${USER_ID}:${GROUP_ID}"
+    environment:
+      RAILS_ENV: ${RAILS_ENV:-development}
+      PROMPT: "cost: $$5"        # → cost: $5
+```
+
+## Not supported — passed through unchanged
+
+`${VAR:?error}` and `${VAR:+alternate}` aren't recognized. Unlike an unset `${VAR}` (which becomes
+an empty string), these pass through **completely untouched**, braces and all:
+
+```yaml
+environment:
+  MODE: ${MODE:+production}     # the container literally sees ${MODE:+production}
+```
+
+If you were relying on `:?` to enforce a required variable, that check won't happen — use
+[`wip doctor`](wip-doctor) plus a sane `:-` default instead.
+
+## Where values come from
+
+Two sources, merged, with the **host shell winning**:
+
+```
+.env (next to wip.yml, or --env-file)  <  the process environment
+```
+
+That's Compose's own precedence rule. Using the same `.env` file wip passes to containers means
+interpolation and container env never see two different files. See [Env Files](Env-Files).
+
+```dotenv
+# .env
+TAG=dev
+```
+
+```bash
+wip up -d              # image: myapp:dev
+TAG=ci wip up -d       # image: myapp:ci  (shell wins)
+```
+
+Note this is the opposite direction from container env, where `wip.yml`'s `env:` beats `.env` and
+the host shell isn't consulted at all.
+
+## What gets interpolated
+
+**Values only, never mapping keys** — Compose documents the same restriction. And substitution
+happens *after* YAML parsing, on the already-parsed structure, which means a substituted value can
+never introduce YAML syntax:
+
+```dotenv
+NOTE=hello # not a comment
+```
+
+```yaml
+environment:
+  NOTE: ${NOTE}     # the whole string survives, "#" included
+```
+
+Strings inside nested mappings and arrays are all covered.
+
+## YAML aliases
+
+`compose.yml` is parsed with aliases enabled, so anchors and merge keys work. A **self-referential**
+alias is rejected rather than recursing until the stack blows:
+
+```
+compose.yml contains a self-referential YAML alias
+```
+
+Re-using the same anchor from several places is fine — that's a shared node, not a cycle.
+
+## Debugging what was substituted
+
+```bash
+wip config
+```
+
+prints the resolved services, post-interpolation. If a value came out empty, the variable was unset
+in both the shell and `.env`.
+
+## Related
+
+- [Env Files](Env-Files)
+- [Compose File Support](Compose-File-Support)
+- [wip config](wip-config)

--- a/wiki/Concepts.md
+++ b/wiki/Concepts.md
@@ -1,0 +1,99 @@
+# Concepts
+
+What `wip` is, what it deliberately isn't, and the ideas the rest of the wiki assumes you know.
+
+## What `wip` is
+
+`wip` is a project-local workflow CLI for Microsoft WSLC, in the spirit of
+[`dip`](https://github.com/bibendi/dip) for Docker. It collects a project's container, image,
+environment variables, mounts, and everyday commands into a single `wip.yml`, and forwards them to
+`wslc.exe` / `wslc`.
+
+The point is that `wip rails console` should work on a freshly cloned machine without anyone
+remembering the twelve-flag `wslc exec` line behind it.
+
+## What `wip` is not
+
+- **Not a container runtime.** Every operation ends in a `wslc` invocation.
+- **Not a Compose implementation.** `mode: compose-native` implements a deliberately small subset,
+  as a stopgap until `wslc` ships Compose support of its own
+  ([microsoft/WSL#40948](https://github.com/microsoft/WSL/issues/40948)). See
+  [Compose File Support](Compose-File-Support).
+- **Not a daemon.** There is no background service. Every `--watch` variant is a foreground poll
+  loop tied to an open terminal (see [Design stance](#design-stance) below).
+
+## The three modes
+
+`mode:` is the central concept. See [Choosing a Mode](Choosing-a-Mode) for the decision, and:
+
+- [Container Mode](Container-Mode) — wip declares containers itself in `dependencies:`
+- [Compose Native Mode](Compose-Native-Mode) — wip parses `compose.yml` and drives `wslc`
+- [Compose Mode](Compose-Mode) — wip bridges to an external compose-for-`wslc` binary
+
+```
+mode: container
+  wip ──► wslc ──► containers declared in wip.yml
+
+mode: compose-native
+  wip ──► compose.yml parser ──► wslc ──► containers declared in compose.yml
+
+mode: compose
+  wip ──► external compose-for-wslc binary ──► wslc ──► containers
+```
+
+## Design stance
+
+### Arguments are arrays, never shell strings
+
+Every command wip runs is built as an argument array and handed to the process spawner directly —
+there is no intermediate shell, so a value containing spaces, quotes, `;`, or `$(...)` is passed
+through as one literal argument instead of being re-interpreted. This is why `env` values, ports,
+and volume specs from `wip.yml` are safe even when they come from a `.env` file you didn't write.
+
+The one place a string *is* split is a command definition (`command: bundle exec rspec`), which is
+split with shell-word rules so the familiar spelling keeps working.
+
+### No resident daemon
+
+`wip up --watch` and `wip sync --watch` are foreground loops. They print what they're watching,
+poll on an interval, and stop on `Ctrl-C`. Nothing survives closing the terminal. This is a
+deliberate choice, not a missing feature: a background supervisor would need its own lifecycle,
+logs, and failure modes, and `wslc` offers no event stream to build one on top of.
+
+The consequences show up in [Restart Policies](Restart-Policies) (status-based, not event-based)
+and [Continuous Sync](Continuous-Sync) (keep a second terminal open).
+
+### Explicit over inferred
+
+- `mode:` is declared, not guessed from whether a `compose:` block exists.
+- `container:` has no default — a project with `dependencies:` must say which entry is primary.
+- `sync.mode` is fixed by config, not probed from whether a container happens to be running.
+- `compose.command` has no default, because picking a third-party implementation isn't wip's call.
+
+### Fail at load time, with the offending key named
+
+Configuration problems raise a `ConfigError` when `wip.yml` (and, under compose-native,
+`compose.yml`) is loaded — before any container is created — and the message names the key. The
+one deliberate exception is compose.yml's top-level sections (`networks:`, `volumes:`, `configs:`,
+`secrets:`), which belong to real Compose tools and are ignored rather than rejected. See
+[Configuration Errors](Configuration-Errors).
+
+## Layers inside wip
+
+Roughly, a command flows through:
+
+```
+ConfigLoader ──► Config ──► CommandBuilder ──► CommandRunner ──► wslc
+   finds &        validated    builds the        spawns it,
+   parses         accessors    argument array    pumps I/O
+   wip.yml
+```
+
+with `CommandResolver` picking the `wslc` binary, `DebugReporter`/`ResourceMonitor` narrating it
+under `--debug`, and `ErrorInterpreter` translating known failure output into hints. Contributor
+detail: [Architecture](Architecture).
+
+## Glossary
+
+Terms used throughout this wiki are defined once on [Glossary](Glossary) — primary container,
+sidecar, interaction, sync volume, shadow context, and WSLC's container states.

--- a/wiki/Config-File-Discovery.md
+++ b/wiki/Config-File-Discovery.md
@@ -1,0 +1,110 @@
+# Config File Discovery
+
+How wip finds `wip.yml`, what `version:` means, and how the `wslc:` block resolves the binary.
+
+## Finding wip.yml
+
+With no `--config`, wip starts in the current directory and walks **up** to the filesystem root,
+taking the first `wip.yml` it finds. That's what makes this work:
+
+```bash
+cd my-project/app/models
+wip rspec            # still uses my-project/wip.yml
+```
+
+If nothing is found:
+
+```
+wip.yml was not found (searched from /path/to/cwd to the filesystem root)
+```
+
+### Pointing at one explicitly
+
+```bash
+wip --config /path/to/wip.yml up
+wip up --config /path/to/wip.yml
+```
+
+Both spellings work — wip pulls leading global switches off the front of `ARGV` and reinserts them
+after the command name. See [Global Options](Global-Options).
+
+The path is expanded against the current directory. `wip init --config PATH` writes there too.
+
+### Paths are relative to wip.yml, not the cwd
+
+Everything wip resolves from config is anchored to the directory holding `wip.yml`:
+
+- `compose.file`
+- `sync.source`
+- a build command's `context`
+- the `.env` file (unless `--env-file` overrides it)
+- compose-native's default network name (the directory's basename)
+
+This is what keeps behavior identical from any subdirectory.
+
+## `version:`
+
+```yaml
+version: 1
+```
+
+Only `1` is supported. Omitting it is the same as `1`. Any other value:
+
+```
+Unsupported configuration version: 2
+```
+
+## YAML parsing rules
+
+`wip.yml` is parsed with a safe loader: **no** custom Ruby classes and **no** YAML aliases. An
+anchor/alias in `wip.yml` (`<<: *defaults`) is a parse error:
+
+```
+Could not parse /path/wip.yml: Unknown alias: defaults
+```
+
+`compose.yml`, by contrast, *is* parsed with aliases enabled, because merge keys are common and
+long-standing in real compose files. See [Compose File Support](Compose-File-Support).
+
+Mapping keys are stringified throughout, so `env: {PORT: 3000}` and `env: {"PORT": "3000"}` are
+equivalent — and every `env` value is converted to a string.
+
+## The `wslc:` block
+
+```yaml
+wslc:
+  command: auto
+```
+
+| Value | Behavior |
+|---|---|
+| `auto` (default) | try `wslc.exe`, then `wslc`, then `/mnt/c/Windows/System32/wslc.exe` |
+| any other name | must be executable on `PATH` |
+| an absolute path | must be executable at that path |
+
+A name containing a path separator is checked directly with `File.executable?`; a bare name is
+looked up across `PATH`. Failure raises `CommandNotFoundError` listing everything it checked:
+
+```
+WSLC was not found.
+
+Checked:
+  wslc.exe
+  wslc
+  /mnt/c/Windows/System32/wslc.exe
+
+Install or update the WSL container tooling, then run:
+
+  wip doctor
+```
+
+See [WSLC Not Found](WSLC-Not-Found).
+
+Note that `wip version` swallows this error — it still prints wip's own version when `wslc` is
+missing. Every other command fails.
+
+## Related
+
+- [Global Options](Global-Options) — `--config`, `--env-file`
+- [wip config](wip-config) — print the effective, resolved configuration
+- [wip init](wip-init) — generate a starter file

--- a/wiki/Configuration-Errors.md
+++ b/wiki/Configuration-Errors.md
@@ -1,0 +1,139 @@
+# Configuration Errors
+
+Every configuration problem raises a `ConfigError` **at load time**, before any container is
+created, and names the offending key. This page catalogs them.
+
+Reproduce any of these quickly with:
+
+```bash
+wip config      # or wip doctor, which reports them as [FAIL]
+```
+
+## File and version
+
+| Message | Cause |
+|---|---|
+| `wip.yml was not found (searched from … to the filesystem root)` | No `wip.yml` in the current directory or any ancestor. Use `--config PATH`. See [Config File Discovery](Config-File-Discovery). |
+| `Could not parse /path/wip.yml: …` | Invalid YAML. Note aliases are **disabled** in `wip.yml` — an anchor/merge key fails here. |
+| `Unsupported configuration version: 2` | Only `version: 1` exists. |
+
+## Mode
+
+| Message | Cause |
+|---|---|
+| `mode must be one of container, compose, compose-native` | Typo in `mode:`. |
+| `mode: compose requires a compose: block` | The mode is set but `compose:` is missing. |
+| `a compose: block requires mode: compose or compose-native` | `compose:` present with `mode: container` (or no `mode:`). |
+
+## Dependencies
+
+| Message | Cause |
+|---|---|
+| `dependencies must be a mapping` | `dependencies:` is a list or scalar. |
+| `container: must be set when dependencies: has entries` | No default exists — name the primary entry. See [Dependencies](Dependencies). |
+| `dependencies.app must be a mapping` | An entry is a scalar or list. |
+| `dependencies.app must set image` | Every entry needs a non-empty `image`. |
+| `No dependencies.app entry (check container: in wip.yml)` | `container:` names an entry that doesn't exist. |
+| `Configured container must not be empty` / `container: must be set in wip.yml` | Reached a command needing the primary container with none set. |
+| `Unknown dependency: redis` | An internal lookup for a name not in `dependencies:`. |
+| `Configured network must not be empty` | A network operation with `network:` empty. |
+
+## Commands / interactions
+
+| Message | Cause |
+|---|---|
+| `commands is mutually exclusive with interaction — pick one` | Both keys declared. See [Interactions](Interactions). |
+| `commands must be a mapping` | The block is a list or scalar. |
+| `commands.rspec must be a mapping` | An entry is a scalar. |
+| `Invalid command type for migrate: exectue` | `type:` must be `exec`, `run`, or `build`. |
+| `commands.build.shadow_context must be a non-empty path for a build command` | `shadow_context` on a non-build command, or empty. See [Shadow Build Context](Shadow-Build-Context). |
+| `Unknown command: nope` | `wip nope` with no matching interaction. See [wip dispatch](wip-dispatch). |
+| `Build image/tag must not be empty` | A build command with neither `tag` nor an inherited `image`. |
+| `commands.migrate: type 'run' is not supported in compose mode (use \`wslc-compose build\`/\`up --build\` directly)` | Only `type: exec` works under `mode: compose`. |
+
+## Compose block
+
+| Message | Cause |
+|---|---|
+| `compose must be a mapping` | `compose:` is a scalar or list. |
+| `compose.service must not be empty` | Required in both compose modes. |
+| `compose is mutually exclusive with dependencies` | Pick one orchestration path. |
+| `compose is mutually exclusive with network` | Under compose-native, the network comes from `compose.project`. See [Networking](Networking). |
+| `compose.command must not be empty` | Required under `mode: compose`. |
+| `compose.command is not used under mode: compose-native (wip drives wslc directly — there's no external compose binary to name)` | Remove it. |
+| `compose mode: no compose file found next to /path/wip.yml (looked for compose.yml, compose.yaml, docker-compose.yml, docker-compose.yaml)` | Set `compose.file`, or put a compose file next to `wip.yml`. |
+| `compose.service 'seed' is gated behind profiles: … but wip has no --profile flag to activate one` | See [Compose Profiles](Compose-Profiles). |
+
+## compose.yml parsing (compose-native only)
+
+| Message | Cause |
+|---|---|
+| `Compose file not found: /path/compose.yml` | `compose.file` points at a missing file. |
+| `Could not parse /path/compose.yml: …` | Invalid YAML. Aliases **are** enabled here. |
+| `compose.yml: services: must be a mapping` | Missing or malformed `services:`. |
+| `compose.yml: services.app must be a mapping` | A service is a scalar. |
+| `compose.yml: services.app has unsupported key(s): healthcheck, deploy` | Outside the supported subset. See [Compose File Support](Compose-File-Support). |
+| `compose.yml: services.app must set image or build` | One is required. |
+| `compose.yml: services.app.build must be a string or mapping` | `build:` is a list. |
+| `compose.yml: services.app.build has unsupported key(s): target` | Only `context`, `dockerfile`, `args`, `shadow_context`. See [Compose Build](Compose-Build). |
+| `compose.yml: services.app.ports must be an array` | Scalar `ports:`. |
+| `compose.yml: services.app.volumes only supports short syntax ("host:container"), not long-syntax mappings` | Rewrite as strings. |
+| `compose.yml: services.app.profiles must be an array of strings` | Malformed `profiles:`. |
+| `compose.yml: services.app.environment must be a mapping or an array of KEY=VALUE` | Wrong shape. |
+| `compose.yml: services.app.environment.FOO must have a value (host environment pass-through is not supported)` | A null mapping value. See [Env Files](Env-Files). |
+| `compose.yml: services.app.environment entries must be KEY=VALUE` | A bare key in the array form. |
+| `compose.yml: services.app.build.args …` | Same rules as `environment:`. |
+| `compose.yml: services.app.depends_on must be an array or a mapping` | Wrong shape. |
+| `compose.yml: services.app depends_on unknown service 'databse'` | Typo, or the service isn't defined. |
+| `compose.yml: services.app.depends_on.db: condition 'service_healthy' is not supported (only service_started — no health checks)` | See [Compose Depends On](Compose-Depends-On). |
+| `compose.yml: services.app depends_on 'x', gated behind profiles: (…) wip never activates (no --profile flag)` | See [Compose Profiles](Compose-Profiles). |
+| `compose.yml: services.app is part of a depends_on cycle` | Circular dependency. |
+| `compose.yml contains a self-referential YAML alias` | An anchor that refers to itself. See [Compose Variable Interpolation](Compose-Variable-Interpolation). |
+
+## Sync
+
+| Message | Cause |
+|---|---|
+| `sync must be a mapping` | `sync:` is a scalar or list. (`sync: {}` is valid.) |
+| `sync.target must be an absolute path` | Must start with `/`. |
+| `sync.mount must be an absolute path` | Must start with `/`. |
+| `sync.mount must differ from sync.target` | They'd shadow each other. |
+| `sync.interval must be a positive number` | Non-numeric or ≤ 0. |
+| `sync.mode must be one of exec, run` | Typo. See [Sync Modes](Sync-Modes). |
+| `sync.mode: exec needs mode: container (compose owns its services' mounts …)` | Under `mode: compose`, only `run` works. |
+| `sync.image or sync.build is required under mode: compose (there's no dependencies: entry to borrow the mirror container's image from)` | Name an image. |
+| `sync.build must be a mapping` | Wrong shape. |
+| `sync.build.dockerfile must not be empty` | Required when `sync.build` is present. |
+| `No sync: block configured in wip.yml` / `` `wip sync` needs a sync: block in wip.yml `` | Running a sync operation without configuring it. |
+| `No sync.build configured in wip.yml` | An internal build request with no `sync.build`. |
+
+## Build context
+
+| Message | Cause |
+|---|---|
+| `shadow_context (/path) must not be inside the build context (/path)` | The shadow would copy itself recursively. See [Shadow Build Context](Shadow-Build-Context). |
+
+## Runtime restrictions
+
+| Message | Cause |
+|---|---|
+| `` `wip logs` is only available in compose mode `` | Not available under `mode: container`. See [wip logs](wip-logs). |
+| `` `wip logs` under mode: compose-native takes at most one SERVICE … `` | Pass one, or none. |
+| `` `wip up --watch` is not supported under mode: compose … `` | See [Restart Policies](Restart-Policies). |
+| `--interval must be a positive number` | On `wip up --watch` or `wip sync --watch`. |
+
+## Not a ConfigError
+
+These use the plain `Error` class instead, but read the same way:
+
+| Message | Cause |
+|---|---|
+| `/path/wip.yml already exists (use --force to overwrite)` | [wip init](wip-init) protecting your file. |
+| `unknown --template "python" (valid: rails, node, rust, csharp)` | [wip init](wip-init). |
+| `WSLC was not found. Checked: …` | `CommandNotFoundError` — see [WSLC Not Found](WSLC-Not-Found). |
+
+## Related
+
+- [Configuration Reference](Configuration-Reference)
+- [wip doctor](wip-doctor)
+- [Troubleshooting & FAQ](Troubleshooting-and-FAQ)

--- a/wiki/Configuration-Reference.md
+++ b/wiki/Configuration-Reference.md
@@ -1,0 +1,78 @@
+# Configuration Reference
+
+Index of every `wip.yml` key. Each feature has its own page; this page is the map plus the
+top-level keys that don't warrant one.
+
+## Top-level keys
+
+| Key | Modes | Default | Meaning |
+|---|---|---|---|
+| `version:` | all | `1` | Config schema version. Only `1` is supported; anything else is a `ConfigError`. |
+| `mode:` | all | `container` | `container` / `compose` / `compose-native`. See [Choosing a Mode](Choosing-a-Mode). |
+| `wslc:` | all | `{command: auto}` | Which `wslc` binary to shell out to. See [Config File Discovery](Config-File-Discovery). |
+| `container:` | container | *(none)* | Which `dependencies:` entry is primary. Required once `dependencies:` has entries. See [Dependencies](Dependencies). |
+| `network:` | container | *(unset)* | Container network shared by every dependency. See [Networking](Networking). |
+| `dependencies:` | container | `{}` | Every container wip manages. See [Dependencies](Dependencies). |
+| `compose:` | compose, compose-native | — | Which compose file/service to use. See [Compose Mode](Compose-Mode) / [Compose Native Mode](Compose-Native-Mode). |
+| `interaction:` / `commands:` | all | `{}` | Project commands run as `wip NAME`. See [Interactions](Interactions). |
+| `sync:` | all | *(unset)* | Mirror the source into a named volume. See [Source Sync](Source-Sync). |
+
+## By feature
+
+### File and binary resolution
+- [Config File Discovery](Config-File-Discovery) — where `wip.yml` is found, `--config`, `version:`, the `wslc:` block
+
+### Containers
+- [Dependencies](Dependencies) — `dependencies:` entries, `container:`, primary vs. sidecar
+- [Networking](Networking) — `network:`, when it's created, name resolution
+- [Restart Policies](Restart-Policies) — `restart:` values and `wip up --watch`
+
+### Commands
+- [Interactions](Interactions) — `interaction:` / `commands:`, `type: exec|run|build`, name collisions
+
+### Environment
+- [Env Files](Env-Files) — `.env` loading rules, `--env-file`, precedence
+- [Secret Masking](Secret-Masking) — what `wip config` redacts, and what that does and doesn't protect
+
+### Builds
+- [Dockerignore](Dockerignore) — how `.dockerignore` filters the build context
+- [Shadow Build Context](Shadow-Build-Context) — `shadow_context:`, when it applies, how it stays incremental
+
+### Source sync
+- [Source Sync](Source-Sync) — the `sync:` block, every parameter, mount rewriting
+- [Sync Modes](Sync-Modes) — `exec` vs. `run`, `sync.image` / `sync.build`, per-mode defaults
+
+### compose.yml
+- [Compose File Support](Compose-File-Support) — the supported subset
+- [Compose Build](Compose-Build) — `build:` services
+- [Compose Depends On](Compose-Depends-On) — ordering
+- [Compose Profiles](Compose-Profiles) — profile-gated services
+- [Compose Variable Interpolation](Compose-Variable-Interpolation) — `${VAR}`
+
+## Which keys are legal in which mode
+
+| Key | `container` | `compose-native` | `compose` |
+|---|---|---|---|
+| `container:` | required with deps | rejected (implied) | rejected (implied) |
+| `dependencies:` | yes | rejected | rejected |
+| `network:` | yes | derived from `compose.project` | rejected |
+| `compose.service` | — | required | required |
+| `compose.file` | — | optional | optional |
+| `compose.project` | — | optional | optional |
+| `compose.command` | — | rejected | required |
+| `interaction.type: run` | yes | yes | rejected |
+| `interaction.type: build` | yes | yes | rejected |
+| `sync.mode: exec` | yes (default) | yes (default) | rejected |
+| `sync.image` / `sync.build` | optional | optional | one required |
+
+Every rejection above is a load-time `ConfigError` — see [Configuration Errors](Configuration-Errors)
+for the exact messages.
+
+## Seeing the effective config
+
+```bash
+wip config
+```
+
+prints the fully defaulted, secret-masked configuration as YAML — the fastest way to check what
+wip actually resolved. See [wip config](wip-config).

--- a/wiki/Container-Mode.md
+++ b/wiki/Container-Mode.md
@@ -1,0 +1,123 @@
+# Container Mode
+
+`mode: container` is the default. wip declares every container itself in `wip.yml` and drives
+`wslc` directly — no `compose.yml`, no external binary.
+
+Use it when your project has no `compose.yml` (or when you'd rather not have one). If you already
+have a compose file, see [Compose Native Mode](Compose-Native-Mode) or
+[Compose Mode](Compose-Mode).
+
+## Minimal config
+
+```yaml
+version: 1
+mode: container
+container: app
+dependencies:
+  app:
+    image: your/image:tag
+    workdir: /app
+```
+
+## Full example
+
+```yaml
+version: 1
+mode: container            # default; may be omitted
+wslc:
+  command: auto            # wslc.exe → wslc → /mnt/c/Windows/System32/wslc.exe
+container: app             # required once dependencies: has entries
+network: app-tier          # optional; shared by every dependencies: entry
+dependencies:
+  app:                     # the primary container — container: points here
+    image: slidict/slidict:development
+    workdir: /app
+    interactive: false
+    remove: true
+    command: server        # extra args appended when `wip up` creates it
+    env:
+      RAILS_ENV: development
+      PORT: "3000"
+    ports:
+      - "3000:3000"
+    volumes:
+      - ".:/app"
+  redis:
+    image: redis:latest
+  development.mysql:
+    image: mysql:8.0
+    command: --default-authentication-plugin=mysql_native_password
+    restart: unless-stopped
+    env:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: development
+interaction:
+  rails:
+    type: exec
+    command: bin/rails
+    interactive: true
+  rspec:
+    command: bundle exec rspec
+  migrate:
+    type: run
+    command: bundle exec rails db:migrate
+    remove: true
+  build:
+    type: build
+    context: .
+    tag: slidict/slidict:development
+sync:
+  exclude:
+    - .git
+    - tmp/
+    - node_modules/
+```
+
+## Keys available in this mode
+
+| Key | Page |
+|---|---|
+| `version:`, `mode:`, `wslc:` | [Config File Discovery](Config-File-Discovery) |
+| `container:`, `dependencies:` | [Dependencies](Dependencies) |
+| `network:` | [Networking](Networking) |
+| `interaction:` / `commands:` | [Interactions](Interactions) |
+| `dependencies.*.restart:` | [Restart Policies](Restart-Policies) |
+| `sync:` | [Source Sync](Source-Sync) |
+
+`compose:` is **not** available here — a `compose:` block requires `mode: compose` or
+`mode: compose-native`.
+
+## What each command does in this mode
+
+| Command | Behavior |
+|---|---|
+| [`wip up`](wip-up) | create network → start sidecars → mirror source → start primary |
+| [`wip stop`](wip-stop) | `wslc stop` on the primary, then each sidecar |
+| [`wip down`](wip-down) | `wslc remove -f` on the primary, then each sidecar; network is left in place |
+| [`wip exec`](wip-exec) | `wslc exec` into the primary container |
+| [`wip run`](wip-run) | real `wslc run --rm` — a fresh, ephemeral container |
+| [`wip build`](wip-build) | builds from the `build` interaction's `context`/`tag` |
+| [`wip logs`](wip-logs) | **not available** (compose modes only) |
+| [`wip sync`](wip-sync) | defaults to `sync.mode: exec` |
+| [`wip up --watch`](Restart-Policies) | available |
+
+## Primary vs. sidecar
+
+`dependencies:` holds every container uniformly — there is no separate, differently-shaped block
+for "the one you exec into." What sets the primary entry apart is purely operational:
+
+- `wip up` starts every **other** entry first (by name), then the primary one, so the app can
+  resolve `redis` / `development.mysql` by their dependency names.
+- `exec`, `run`, `build`, `shell`, and interactions only ever target the primary entry.
+- Sidecars are only started and stopped.
+
+Details and the per-key reference: [Dependencies](Dependencies).
+
+## Generating this shape
+
+```bash
+wip init            # writes mode: container when no compose.yml is found
+wip init --template rails
+```
+
+See [wip init](wip-init).

--- a/wiki/Continuous-Sync.md
+++ b/wiki/Continuous-Sync.md
@@ -1,0 +1,155 @@
+# Continuous Sync
+
+Keeping the container's copy of your source current while you edit, with `wip sync --watch`.
+
+Prerequisite: a `sync:` block. See [Source Sync](Source-Sync) and, for *why*,
+[Fixing a Slow Boot](Fixing-a-Slow-Boot).
+
+## The two-terminal workflow
+
+```bash
+# terminal 1 — the stack
+wip up -d
+
+# terminal 2 — the watcher
+wip sync --watch
+```
+
+```console
+$ wip sync --watch
+wip: syncing /home/me/app -> app-src:/app every 2s (Ctrl-C to stop)
+```
+
+Edit on the host as usual; changes land in the container within one interval.
+
+This is a **foreground loop, not a daemon** — wip has no background service by design. Keep the
+terminal open; closing it stops the watcher. See [Concepts](Concepts#design-stance).
+
+## Tuning the interval
+
+```bash
+wip sync --watch --interval 5
+```
+
+or permanently:
+
+```yaml
+sync:
+  interval: 5
+```
+
+Default is `2` seconds. Considerations:
+
+- Each tick is a full `rsync` pass. With good `exclude` patterns, that's a quick metadata scan; on
+  a huge unexcluded tree it isn't.
+- Shorter intervals mean shorter edit-to-container latency but more constant scanning.
+- `2`–`5` seconds suits most projects. If a pass takes longer than the interval, raise it.
+
+Must be positive:
+
+```
+--interval must be a positive number
+```
+
+## Failures don't stop the loop
+
+Unlike a one-shot `wip sync`, a failed mirror inside the watch loop prints the error and retries on
+the next tick. Restarting the app container mid-loop won't kill your watcher.
+
+Stop with `Ctrl-C`:
+
+```console
+^C
+wip: sync stopped
+```
+
+## The one-way gotcha
+
+The mirror is host → volume, with `--delete` on by default. **Anything the app writes under the
+target is removed on the next pass.** With a 2-second watcher, that means "almost immediately."
+
+Concretely, these get wiped unless handled:
+
+| Written by the container | Fix |
+|---|---|
+| `tmp/`, `log/` | add to `exclude` |
+| `node_modules/` (installed inside the container) | add to `exclude` |
+| Installed gems under `vendor/bundle` | `exclude`, or give it its own volume |
+| Compiled assets (`public/assets`) | add to `exclude` |
+| Generated files you want on the host (scaffolds, migrations) | copy them out, or see below |
+
+```yaml
+sync:
+  exclude:
+    - .git
+    - log/
+    - tmp/
+    - node_modules/
+    - vendor/bundle/
+    - public/assets/
+```
+
+Or, if excluding isn't practical:
+
+```yaml
+sync:
+  delete: false      # never remove anything from the volume
+```
+
+The cost of `delete: false` is drift: files you delete on the host stay in the volume forever,
+which for a Ruby or JS project means deleted classes and modules can still be autoloaded. Prefer
+`exclude` where you can.
+
+### Recovering generated files
+
+`wip sync` only goes one way. To get a generator's output back onto the host, copy it out of the
+container:
+
+```bash
+wip exec cat db/migrate/20260810120000_add_index.rb > db/migrate/20260810120000_add_index.rb
+```
+
+Or run generators through [`wip run`](wip-run) with a normal bind mount for that path.
+
+## Which container runs the mirror
+
+| `sync.mode` | Where the watcher's rsync runs | Requires |
+|---|---|---|
+| `exec` (default, container / compose-native) | inside the running primary container | that container up, with rsync in its image |
+| `run` (default and only option under `mode: compose`) | a throwaway container per tick | `sync.image` or `sync.build` |
+
+Under `exec`, start the stack **before** the watcher. Under `run`, order doesn't matter. See
+[Sync Modes](Sync-Modes).
+
+`sync.build`'s image is built **once** before the loop starts, not on every tick.
+
+## Do I need the watcher at all?
+
+No. `wip sync` on demand is often enough:
+
+```bash
+# edit files…
+wip sync && wip rspec
+```
+
+Or wire it into an interaction so you can't forget:
+
+```yaml
+interaction:
+  test:
+    command: bundle exec rspec
+```
+
+```bash
+wip sync && wip test
+```
+
+The watcher is worth it when you're iterating quickly, or when a file-watching dev server inside
+the container needs to see changes without you thinking about it.
+
+## Related
+
+- [wip sync](wip-sync)
+- [Source Sync](Source-Sync)
+- [Sync Modes](Sync-Modes)
+- [Fixing a Slow Boot](Fixing-a-Slow-Boot)

--- a/wiki/Debug-Output.md
+++ b/wiki/Debug-Output.md
@@ -1,0 +1,127 @@
+# Debug Output
+
+`--debug` (or `WIP_DEBUG=1`) makes wip narrate what it's doing and how long each step took. It's
+the main tool for answering "why is this slow?" — particularly for telling wip's own overhead apart
+from time spent inside the container.
+
+## Turning it on
+
+```bash
+wip rails c --debug
+WIP_DEBUG=1 wip rails c
+```
+
+## What it prints
+
+```console
+$ wip rails c --debug
+wip: [debug] running: wslc.exe exec -it -w /app -e RAILS_ENV=*** app bin/rails c
++ wslc.exe exec -it -w /app -e RAILS_ENV=*** app bin/rails c
+...
+wip: [debug] done in 4.32s: running: wslc.exe exec -it -w /app -e RAILS_ENV=*** app bin/rails c
+```
+
+| Line | Meaning |
+|---|---|
+| `wip: [debug] checking: …` | an existence probe (network, container, dependency) |
+| `wip: [debug] running: …` | the command wip is about to run |
+| `+ …` | the runner echoing the command as it spawns it |
+| `wip: [debug] still running (…): …` | a periodic host resource snapshot |
+| `wip: [debug] done in N.NNs: …` | that step finished |
+
+Environment values are masked (`-e KEY=***`) so a debug paste doesn't leak credentials. Other flags
+are printed verbatim — see [Secret Masking](Secret-Masking).
+
+## Reading the timings
+
+For long-running interactive commands (`rails console`), the `done in …` line only prints after you
+**exit**. So it doesn't tell you how long startup took. What does: the timestamp of the `+ …` line.
+Everything before it is wip's own setup; everything after is `wslc` and the container.
+
+```
+[wip parses config, probes containers]  ← wip overhead
++ wslc.exe exec …                       ← handoff
+[image pull, container boot, app boot]  ← wslc + your app
+```
+
+If the `+` line appears instantly and you still wait two minutes, the time is not wip's.
+
+## Resource snapshots
+
+While a step is still running, wip prints a host snapshot every 5 seconds:
+
+```console
+wip: [debug] still running (load 3.42 2.10 1.05 | mem 6.1G/15.6G | io read 12000KB/s write 400KB/s | top: wslc.exe(8842) cpu 61.0%/mem 3.2%, ruby(9001) cpu 4.0%/mem 1.1%): running: wslc.exe exec …
+```
+
+| Field | Source | What it tells you |
+|---|---|---|
+| `load` | `/proc/loadavg` | 1/5/15-minute load average |
+| `mem` | `/proc/meminfo` | used / total, derived from `MemAvailable` |
+| `io` | `/proc/diskstats` | read/write KB/s since the previous snapshot |
+| `top` | `ps -eo pid,pcpu,pmem,comm` | the three highest-CPU processes |
+
+Unavailable fields degrade to `n/a` rather than failing the command.
+
+### The diagnostic pattern that matters
+
+**Low CPU, low memory, low-ish IO, and nothing happening for minutes** is the signature of
+bind-mount overhead: a framework doing many small `stat`/`open` calls across virtiofs, each one a
+round trip. Almost no data moves, so nothing looks busy — but the process is blocked the whole
+time.
+
+That's not a broken app. It's [Fixing a Slow Boot](Fixing-a-Slow-Boot).
+
+Contrast:
+
+| Snapshot pattern | Likely cause |
+|---|---|
+| low CPU, low IO, long duration | bind-mount round trips → add `sync:` |
+| high `io read` sustained | pulling an image, or a genuinely large copy |
+| high CPU on `wslc.exe` | the VM is doing real work — probably fine |
+| high memory near total | the host is swapping |
+
+## Where snapshots go
+
+By default, wip decides based on whether the command owns your terminal:
+
+| Command | Destination |
+|---|---|
+| Interactive (`-it`) | a temp log file; the path is printed once |
+| Non-interactive | inline on stderr |
+
+```console
+wip: [debug] command owns the terminal; streaming resource snapshots to /tmp/wip-debug-20260810.log
+```
+
+Interactive children control the terminal in raw mode; writing snapshots into it would garble both
+outputs. Override with `--debug-log`:
+
+```bash
+wip rails c --debug --debug-log=-                     # force inline
+wip rspec --debug --debug-log=/tmp/wip-debug.log      # force to a file
+```
+
+The file is opened in append mode, so repeated runs accumulate. See
+[Global Options](Global-Options).
+
+## Error hints
+
+Independently of `--debug`, when a command fails wip inspects its output and prints a hint if it
+recognizes the failure:
+
+| Detected | Hint page |
+|---|---|
+| `pull access denied`, `insufficient_scope`, `authorization failed` | [Registry Authentication](Registry-Authentication) |
+| `no matching manifest for linux/amd64\|arm64` | [Architecture Mismatch](Architecture-Mismatch) |
+| `0x8007000e`, "too many mounted volumes" | [Volume Limit Reached](Volume-Limit-Reached) |
+| `rsync: not found` and variants | [rsync Not Found](rsync-Not-Found) |
+
+Note: hints require wip to be able to see the output. On native Windows, interactive commands
+inherit the real stdio directly, so wip can't observe them and no hint is generated on that path.
+
+## Related
+
+- [Global Options](Global-Options)
+- [Fixing a Slow Boot](Fixing-a-Slow-Boot)
+- [Reporting Issues](Reporting-Issues) — `WIP_DEBUG=1` output is the single most useful attachment

--- a/wiki/Dependencies.md
+++ b/wiki/Dependencies.md
@@ -1,0 +1,132 @@
+# Dependencies
+
+`dependencies:` declares every container wip manages under [Container Mode](Container-Mode) — the
+app itself and every sidecar, in one uniformly-shaped block. `container:` names which one is
+primary.
+
+Under [Compose Native Mode](Compose-Native-Mode) this block is synthesized from `compose.yml`'s
+`services:` instead, and `compose.service` plays the role of `container:` — everything below about
+primary vs. sidecar behavior still applies.
+
+## Shape
+
+```yaml
+container: app
+dependencies:
+  app:
+    image: slidict/slidict:development
+    workdir: /app
+    user: "1000:1000"
+    interactive: false
+    remove: true
+    command: server
+    restart: "no"
+    env:
+      RAILS_ENV: development
+    ports:
+      - "3000:3000"
+    volumes:
+      - ".:/app"
+  redis:
+    image: redis:latest
+```
+
+## Entry keys
+
+| Key | Required | Default | Maps to | Notes |
+|---|---|---|---|---|
+| `image` | **yes** | — | the image argument | empty/missing is a `ConfigError` |
+| `command` | no | *(image default)* | trailing args | split with shell-word rules |
+| `workdir` | no | `nil` | `-w` | |
+| `user` | no | `nil` | `-u` | e.g. `"1000:1000"` |
+| `env` | no | `{}` | `-e KEY=VALUE` | values stringified; wins over `.env` |
+| `ports` | no | `[]` | `-p` | not applied on `exec` |
+| `volumes` | no | `[]` | `-v` | rewritten when `sync:` is set |
+| `restart` | no | `"no"` | polled by `--watch` | see [Restart Policies](Restart-Policies) |
+| `interactive` | no | `false` | `-it` | combined with real-TTY detection |
+| `remove` | no | `true` | `--rm` on `wip run` | |
+
+`interactive` and `remove` only affect the primary entry's `run`/`exec` paths; sidecars are always
+started detached.
+
+## `container:` has no default
+
+Once `dependencies:` has any entries, `container:` must be set:
+
+```
+container: must be set when dependencies: has entries
+```
+
+There used to be an implicit `app` default. Guessing a name either matches by luck or fails later
+in a way that points at the wrong thing (`No dependencies.app entry`) instead of at the real
+problem — a differently-named entry. So it's explicit.
+
+If `container:` names an entry that doesn't exist, `wip doctor` reports:
+
+```
+[FAIL] No dependencies.app entry
+```
+
+and any command that needs the primary container fails with:
+
+```
+No dependencies.app entry (check container: in wip.yml)
+```
+
+## Primary vs. sidecar
+
+The distinction is operational, not structural — same keys, same shape.
+
+| | primary | sidecar |
+|---|---|---|
+| `wip up` | started **last** | started **first**, by name |
+| `wip stop` / `wip down` | yes | yes |
+| `wip exec` / `wip shell` | yes | no |
+| `wip run` | yes | no |
+| `wip build` | yes | no |
+| `interaction:` entries | yes | no |
+| `wip up --watch` restarts it | yes | yes |
+
+This mirrors Compose's own split: services are things you bring up; one of them is the thing you
+exec into.
+
+### Why sidecars start first
+
+So the app can reach them. `wip up` creates `network:` if it's set and missing, starts each
+sidecar by its dependency name, then boots the primary container — at which point `bin/rails c`
+can connect to `development.mysql` or `redis` by name, the way Compose service names resolve. See
+[Networking](Networking).
+
+## Startup semantics
+
+For each sidecar, `wip up` first probes whether it exists:
+
+```
+wip: starting existing dependency 'redis'      # found → wslc start redis
+wip: dependency 'redis' not found, creating it # not found → wslc run --name redis …
+```
+
+The same existence check runs for the primary container. Re-running `wip up` against a running
+stack is safe: starting an already-running container is a no-op.
+
+`wip down` removes the primary container and all sidecars. **The network itself is left in place.**
+
+## `restart: no` and YAML
+
+An unquoted `restart: no` parses as the boolean `false` in YAML, not the string `"no"`. wip
+normalizes `false`, `nil`, and `""` to `"no"`, so both spellings behave identically. Quoting it
+(`restart: "no"`) is still clearer. See [Restart Policies](Restart-Policies).
+
+## Interaction with `sync:`
+
+When `sync:` is configured, any `volumes` entry on the **primary** container that mounts the sync
+target (the usual `.:/app`) is replaced by the read-only source mount plus the named volume. Other
+volumes pass through untouched, and sidecar volumes are never rewritten. See
+[Source Sync](Source-Sync).
+
+## Related
+
+- [Networking](Networking)
+- [Restart Policies](Restart-Policies)
+- [Interactions](Interactions)
+- [wip up](wip-up)

--- a/wiki/Development.md
+++ b/wiki/Development.md
@@ -1,0 +1,121 @@
+# Development
+
+Contributor-facing detail.
+[CONTRIBUTING.md](https://github.com/slidict/wip/blob/main/CONTRIBUTING.md) is the summary; this is
+where the depth lives.
+
+## Setting up
+
+```bash
+git clone https://github.com/slidict/wip.git
+cd wip
+bundle install
+bundle exec exe/wip version
+```
+
+Requires Ruby 3.2+. Runtime dependencies are just `thor`; development adds `rake`, `rspec`, and
+`rubocop`.
+
+### You don't need WSLC to develop wip
+
+The test suite doesn't require it. The resolution, build, and execution layers are all swappable —
+`CommandResolver` takes an injectable executable check, `CommandBuilder` produces argument arrays
+without running them, and `CommandRunner` takes injectable IO. So specs assert on the *arrays wip
+would run*, not on real containers, and you can develop on any platform.
+
+That design constraint is worth preserving: a change that makes a layer un-injectable makes it
+untestable. See [Architecture](Architecture).
+
+## Running the checks
+
+```bash
+bundle exec rspec     # unit tests
+bundle exec rubocop   # style/lint
+bundle exec rake      # both (the default task)
+```
+
+Both must pass before a PR merges. Details, including how to write specs that match the existing
+style: [Testing and Linting](Testing-and-Linting).
+
+## CI
+
+`.github/workflows/test.yml` runs on every pull request and every push to `main`:
+
+- **Ruby matrix:** 3.2, 3.3, 3.4, 4.0 (`fail-fast: false`, so you see every failing version)
+- `bundle exec rake spec`
+- `bundle exec rake rubocop`
+- a CLI smoke test: `bundle exec exe/wip help | grep -q '^Commands:'`
+
+## Commit conventions
+
+[Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>[optional scope]: <description>
+```
+
+Types in use: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `ci`, `build`, `perf`.
+
+```
+feat(cli): add doctor command
+fix(config): accept positional path argument
+ci: add push trigger for main
+```
+
+The type matters beyond tidiness: **PR labels drive the generated release notes** —
+`feat` → 🚀 Features, `fix` → 🐛 Fixes, and `chore`/`ci`/`docs`/`build`/`perf`/`test` →
+🧰 Maintenance. See [Release Process](Release-Process).
+
+## Versioning
+
+[SemVer](https://semver.org/):
+
+| Bump | For |
+|---|---|
+| patch | bug fixes (`fix`) |
+| minor | new commands or features (`feat`) |
+| major | breaking changes |
+
+**Maintainers bump the version**, via the "Bump Version" GitHub Actions workflow — you don't touch
+`lib/wip/version.rb` in a PR.
+
+## Making a pull request
+
+1. Fork and branch from `main`.
+2. Make the change, with tests for new behavior.
+3. `bundle exec rake` — clean.
+4. Open a PR describing what changed, why, and how you verified it.
+
+Small, focused PRs are much easier to review. If a change grows a second unrelated concern, split
+it.
+
+### What reviewers look for
+
+- **Tests for new behavior**, at the layer that owns it — a config rule belongs in
+  `spec/wip/config_spec.rb`, not an end-to-end CLI test.
+- **Errors that name the offending key.** Every `ConfigError` in this codebase says which key is
+  wrong; keep that up. See [Configuration Errors](Configuration-Errors).
+- **Load-time validation** over runtime surprises — fail before creating containers.
+- **Comments that explain *why*.** This codebase leans on them heavily for non-obvious constraints
+  (why an absolute build context crashes `wslc`, why `restart: no` needs normalizing, why the
+  shadow root can't live inside the context). Preserve that reasoning when you touch the code.
+- **Documentation.** A user-visible change means updating the README *and* the relevant wiki page.
+
+## Where things live
+
+```
+exe/wip              # the executable
+lib/wip.rb           # requires everything
+lib/wip/             # one class per concern
+spec/wip/            # one spec file per class
+docs/                # README assets (logo, demo gif/tape)
+```
+
+Per-module detail: [Architecture](Architecture).
+
+## Related
+
+- [Architecture](Architecture)
+- [Testing and Linting](Testing-and-Linting)
+- [Release Process](Release-Process)
+- [Reporting Issues](Reporting-Issues)

--- a/wiki/Dockerignore.md
+++ b/wiki/Dockerignore.md
@@ -1,0 +1,104 @@
+# Dockerignore
+
+`wslc build` sends the build context as-is, with no `.dockerignore` support of its own. `wip build`
+fills that gap: it reads `.dockerignore` from the build context, stages only the files that survive
+it, and hands `wslc` the filtered copy.
+
+For a large project this is the difference between shipping a few megabytes and shipping
+`node_modules/` plus `.git/`.
+
+## Where the file is read from
+
+The `.dockerignore` at the **root of the build context** — that is, next to whatever `context:`
+resolves to, not necessarily next to `wip.yml`:
+
+```yaml
+interaction:
+  build:
+    type: build
+    context: .          # relative to wip.yml's directory
+    tag: myapp:dev
+```
+
+Under [Compose Native Mode](Compose-Native-Mode), each service's `build.context` gets its own
+`.dockerignore` treatment when `wip up` builds it. See [Compose Build](Compose-Build).
+
+## Pattern rules
+
+The same gitignore-style rules the Docker CLI uses:
+
+| Pattern | Matches |
+|---|---|
+| `node_modules` | any path component named `node_modules`, at any depth |
+| `/node_modules` | only at the context root (leading `/` anchors) |
+| `tmp/` | same as `tmp` — a trailing slash is stripped |
+| `*.log` | any `.log` file at any depth |
+| `build/**/*.o` | globs with `/` are matched against the full relative path |
+| `!keep.log` | negation — re-includes something an earlier rule excluded |
+| `# …`, blank lines | ignored |
+
+Details that matter in practice:
+
+- **Later rules win.** Rules are applied in order; the last one that matches decides.
+- **A pattern with no `/` is implicitly `**/pattern`** — it matches at any depth.
+- **Matching a directory excludes everything under it.** Every prefix of a path is tested, so
+  `node_modules` excludes `node_modules/pkg/index.js` without needing a `/**` suffix.
+- **Dotfiles are matched.** `*` matches `.env`.
+
+## Staging behavior
+
+```console
+$ wip build
+wip: staging build context (/home/me/my-project)
+wip: copying build context files: 1240/1240
+```
+
+- If `.dockerignore` is missing or has no effective rules, the context is passed through **in
+  place** — no copy at all.
+- Otherwise wip copies the included files into a temporary directory, runs the build from there,
+  and removes it afterward.
+- The walk **prunes** ignored directories instead of descending into them. A 3 GB `node_modules/`
+  is never walked, let alone copied — unless a later negated rule (`!node_modules/pkg`) could match
+  something beneath it, in which case pruning is skipped for correctness.
+- **Symlinks are copied as symlinks**, never dereferenced. Following them could pull arbitrary host
+  files (`~/.ssh/id_rsa`) into the context.
+
+Progress is reported on its own thread, so one very large file doesn't make the copy look hung.
+
+## Interaction with the shadow context
+
+If `shadow_context:` is configured and applicable, the same `.dockerignore` filtering feeds the
+persistent Windows-side shadow directory instead of a throwaway temp dir — so only added/changed
+files are copied on later builds. See [Shadow Build Context](Shadow-Build-Context).
+
+## Why the build runs from inside the context
+
+`wslc build` crashes with `ERROR_UNHANDLED_EXCEPTION` when handed an absolute context path, so wip
+changes into the staged directory and passes `.` instead. You'll see this reflected in `--debug`
+output:
+
+```console
+wip: [debug] running: wslc.exe build -t myapp:dev .
+```
+
+## A good starting `.dockerignore`
+
+```gitignore
+.git
+.dockerignore
+node_modules
+tmp
+log
+coverage
+*.log
+.env
+```
+
+Note this is separate from `sync.exclude`, which controls the rsync mirror rather than the build
+context — they often overlap but serve different steps. See [Source Sync](Source-Sync).
+
+## Related
+
+- [wip build](wip-build)
+- [Shadow Build Context](Shadow-Build-Context)
+- [Compose Build](Compose-Build)

--- a/wiki/Env-Files.md
+++ b/wiki/Env-Files.md
@@ -1,0 +1,104 @@
+# Env Files
+
+wip loads a `.env` file the way `docker compose` does, so values don't have to be duplicated into
+`wip.yml` just to reach the container.
+
+## Where it looks
+
+By default: `.env` next to `wip.yml` — **not** next to your current directory. Override it:
+
+```bash
+wip --env-file config/dev.env up
+wip up --env-file config/dev.env
+```
+
+The path is expanded against the current directory. A missing file is not an error; it simply
+contributes nothing.
+
+## Syntax
+
+```dotenv
+# comments and blank lines are ignored
+DATABASE_URL=postgres://db/app
+export RAILS_ENV=development
+QUOTED="value with spaces"
+SINGLE='also fine'
+TRAILING=value   # this comment is stripped
+```
+
+| Rule | Behavior |
+|---|---|
+| `KEY=VALUE` | keys must start with a letter or `_`, then letters/digits/`_` |
+| `export KEY=VALUE` | the `export ` prefix is accepted and stripped |
+| `# …` | full-line comments ignored |
+| blank lines | ignored |
+| `"…"` / `'…'` | surrounding quotes stripped; contents kept verbatim |
+| unquoted values | trailing ` #comment` is stripped, then whitespace trimmed |
+| anything else | silently skipped (no error) |
+
+Note the asymmetry: an inline `#` comment is only stripped from **unquoted** values. If your value
+legitimately contains ` #`, quote it.
+
+## Precedence
+
+`.env` supplies **defaults only**. Anything set in `wip.yml` wins:
+
+```
+.env  <  dependencies.<name>.env  <  interaction.<name>.env
+```
+
+```yaml
+# .env
+RAILS_ENV=development
+```
+
+```yaml
+# wip.yml
+dependencies:
+  app:
+    env:
+      RAILS_ENV: test      # wins → container sees test
+```
+
+Every value reaches the container as an explicit `-e KEY=VALUE` flag, so what you see in
+`wip config` is what the container gets.
+
+## Which commands load it
+
+All of them that create or enter a container: `build`, `up`, `run`, `exec`, `shell`, and every
+interaction.
+
+## Also used for compose.yml interpolation
+
+Under [Compose Native Mode](Compose-Native-Mode), the same file resolves `${VAR}` references inside
+`compose.yml` — with the **shell environment winning** over `.env`, matching Compose's own rule.
+Using one file for both means compose interpolation and the env actually passed to containers
+never disagree. See [Compose Variable Interpolation](Compose-Variable-Interpolation).
+
+Note the difference in precedence between the two uses:
+
+| Use | Precedence |
+|---|---|
+| Env passed to containers | `wip.yml` `env:` beats `.env`; the host shell is not consulted |
+| compose.yml `${VAR}` | host shell env beats `.env` |
+
+Host environment pass-through (a bare `KEY` with no value) is **not** supported for container env —
+see [Compose File Support](Compose-File-Support).
+
+## Secrets
+
+`.env` is the right place for real secrets, but only if it's actually untracked:
+
+```bash
+echo '.env' >> .gitignore
+git check-ignore .env      # should print .env
+```
+
+`wip config` masks secret-looking keys when printing, and `--debug` masks `-e` values, but neither
+encrypts anything. See [Secret Masking](Secret-Masking).
+
+## Related
+
+- [Secret Masking](Secret-Masking)
+- [Global Options](Global-Options)
+- [Compose Variable Interpolation](Compose-Variable-Interpolation)

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -1,0 +1,159 @@
+# FAQ
+
+Questions rather than errors. For errors, start at
+[Troubleshooting & FAQ](Troubleshooting-and-FAQ).
+
+## Modes
+
+**Which mode should I start with?**
+No `compose.yml` → [`mode: container`](Container-Mode). Have one → try
+[`mode: compose-native`](Compose-Native-Mode) first, and fall back to
+[`mode: compose`](Compose-Mode) if your file needs more than the
+[supported subset](Compose-File-Support). Full breakdown:
+[Choosing a Mode](Choosing-a-Mode).
+
+**Can I use `dependencies:` and `compose:` together?**
+No. They're mutually exclusive — one orchestration path per project. `network:` is likewise
+rejected alongside `compose:`. See [Configuration Errors](Configuration-Errors).
+
+**What's the difference between `mode: compose` and `mode: compose-native`?**
+`compose` delegates to a third-party compose-for-`wslc` binary you install yourself
+(`compose.command`). `compose-native` parses `compose.yml` itself and drives `wslc` directly, with
+no external tool — and gets a real `wslc run --rm` for `wip run` instead of the exec fallback.
+`compose`'s coverage is whatever your tool supports; `compose-native`'s is maintained in this repo
+and actively extended.
+
+**`dependencies:` already gives me sidecars — why would I need `compose-native`?**
+They're for different starting points, not alternatives. No `compose.yml`? Declare containers in
+`wip.yml`'s own shape with `dependencies:`. Already have one? Reusing it is what `compose-native`
+and `mode: compose` are both for — so the real comparison is between *those two*, not against
+`dependencies:`.
+
+**What happens to `compose-native` once `wslc` gets official Compose support?**
+It exists to close that gap (tracked in
+[microsoft/WSL#40948](https://github.com/microsoft/WSL/issues/40948)), and its coverage keeps
+growing until that lands. `wip.yml`'s shape (`mode:`, `compose:`) isn't planned to change for
+existing setups, so whatever happens next won't require rewriting your config.
+
+**Can I switch modes later?**
+Yes. Going `compose` → `compose-native` usually just means deleting `compose.command`; the reverse
+means adding it. `interaction:`, `.env`, and `sync:` carry over unchanged.
+
+## Configuration
+
+**Do I have to set `container:`?**
+Only under `mode: container`, and only once `dependencies:` has entries — but then it's required.
+There's deliberately no default. Under compose modes, `compose.service` plays that role instead.
+See [Dependencies](Dependencies).
+
+**Do I need to rename `interaction:` when migrating from dip?**
+No. `interaction:` is wip's primary spelling too. `commands:` is an accepted alias, but declaring
+both in one file is a `ConfigError`. See [Migrating from dip](Migrating-from-dip).
+
+**Why does `wip config` print `commands:` when I wrote `interaction:`?**
+They're two names for one feature, and the effective-config output normalizes to `commands:`.
+Nothing changed about your file.
+
+**Can I use YAML anchors?**
+In `compose.yml`, yes — aliases are enabled, so merge keys work. In `wip.yml`, no — it's parsed
+with aliases disabled, and an anchor is a parse error. See
+[Config File Discovery](Config-File-Discovery).
+
+**Where do relative paths resolve from?**
+The directory holding `wip.yml`, never your current directory. That's what makes wip behave
+identically from any subdirectory. (`compose.yml`'s `build.context` resolves against `compose.yml`
+instead — Compose's own rule.)
+
+## Environment and secrets
+
+**Is `.env` loaded automatically?**
+Yes, from next to `wip.yml`, like `docker compose`. `--env-file PATH` overrides it. `env:` in
+`wip.yml` always wins over `.env`. See [Env Files](Env-Files).
+
+**Is it safe to put passwords in `wip.yml`?**
+`wip config` masks keys matching token/password/secret/credential/auth, but the file itself is
+plain text and the masking is a key-name heuristic — `API_KEY` and `DATABASE_URL` aren't caught.
+Keep real secrets in `.env` (gitignored — verify with `git check-ignore .env`) or your runtime
+environment. See [Secret Masking](Secret-Masking).
+
+**Can I pass a host environment variable through without naming its value?**
+Not in `compose.yml` — a bare `KEY` or a null value is rejected. Put it in `.env` instead. Note
+that compose.yml's `${VAR}` interpolation *does* read your shell environment, so
+`FOO: ${FOO}` achieves it. See [Compose Variable Interpolation](Compose-Variable-Interpolation).
+
+## Sync
+
+**Is `sync:` required?**
+No, entirely optional. Add it when boot times feel slow with a bind-mounted app directory. See
+[Fixing a Slow Boot](Fixing-a-Slow-Boot).
+
+**How does `sync:` actually fix the slow boot?**
+The slowness is `.:/app`-style bind mounts crossing virtiofs, where a framework that stats/opens
+thousands of files at startup pays a round trip per file. `sync:` moves the app off that path: the
+host source is mounted read-only, the app runs off a named volume (fast native storage inside the
+VM), and wip mirrors one into the other with `rsync`. The trade-off is a one-way, slightly-delayed
+mirror instead of a live view.
+
+**Do I need `rsync` in my image?**
+Under the default `sync.mode: exec`, yes. Avoid it with `sync.mode: run` plus `sync.build`. See
+[rsync Not Found](rsync-Not-Found).
+
+**Why do files my app writes keep disappearing?**
+The mirror is one-way with `--delete`. Exclude the path, give it its own volume, or set
+`delete: false`. See [Continuous Sync](Continuous-Sync).
+
+**Do I have to run `wip sync --watch`?**
+No — `wip sync` on demand is often enough. The watcher is for fast iteration or for a dev server
+inside the container that needs to see changes on its own.
+
+## Commands
+
+**Why does `wip <name>` run a built-in instead of my command?**
+Built-ins always win. Use `wip dispatch <name>`, or rename your entry. See
+[wip dispatch](wip-dispatch).
+
+**Why doesn't `wip logs` work?**
+It's compose-modes-only. Under `mode: container`, use `wslc logs -f <name>` directly. See
+[wip logs](wip-logs).
+
+**Why did `wip run` say it's exec'ing instead?**
+`mode: compose`'s vocabulary is exec-only, so `run` falls back. `compose-native` and `container`
+both get a real `wslc run --rm`. See [wip run](wip-run).
+
+**My new `ports:` entry isn't listening. Why?**
+Ports apply at container **creation**. An existing container predates the change:
+`wip down && wip up -d`.
+
+**Does `wip down` delete my database volume?**
+No. `wip down` removes containers only — named volumes and the network survive. Remove volumes
+explicitly with `wslc volume remove`. See [wip down](wip-down).
+
+**Why does `rails console` exit immediately?**
+No TTY was allocated. Set `interactive: true` on the interaction, and check you're in a real
+terminal — wip requires both stdin and stdout to be TTYs. See [TTY Allocation](TTY-Allocation).
+
+## Operations
+
+**Can wip restart containers automatically?**
+Approximately, via `wip up --watch` — a foreground poll loop, not a daemon, that restarts exited
+containers whose `restart:` allows it. It doesn't read exit codes and can race with manual stops.
+See [Restart Policies](Restart-Policies).
+
+**Is there a background daemon?**
+No, deliberately. Every `--watch` variant is a foreground loop tied to an open terminal. See
+[Concepts](Concepts#design-stance).
+
+**Can I run wip in CI?**
+Yes, if the runner has WSL2 and WSLC. TTY handling degrades automatically and exit codes
+propagate. See [Using wip in CI](Using-wip-in-CI).
+
+**`wslc.exe` isn't found — what do I do?**
+See [WSLC Not Found](WSLC-Not-Found).
+
+## Project
+
+**How do I report a bug?**
+See [Reporting Issues](Reporting-Issues).
+
+**How do I contribute?**
+See [Development](Development).

--- a/wiki/Fixing-a-Slow-Boot.md
+++ b/wiki/Fixing-a-Slow-Boot.md
@@ -1,0 +1,168 @@
+# Fixing a Slow Boot
+
+The single most common performance complaint with WSLC: a container that takes minutes to boot and
+looks completely hung, while the host shows almost no activity.
+
+## Recognizing the symptom
+
+Run the slow command with `--debug`:
+
+```console
+$ wip rails c --debug
+wip: [debug] running: wslc.exe exec -it -w /app app bin/rails c
++ wslc.exe exec -it -w /app app bin/rails c
+wip: [debug] still running (load 0.31 0.22 0.18 | mem 3.1G/15.6G | io read 40KB/s write 0KB/s | top: wslc.exe(8842) cpu 2.1%/mem 0.9%): running: …
+wip: [debug] still running (load 0.29 0.24 0.19 | mem 3.1G/15.6G | io read 36KB/s write 0KB/s | top: …): running: …
+```
+
+The tell: **low CPU, low memory, low IO, and nothing happening for minutes.** Almost no data is
+moving, so nothing looks busy — but the process is blocked the entire time.
+
+If instead you see sustained high `io read` or high CPU, this isn't your problem — something is
+genuinely doing work.
+
+## The cause
+
+WSLC containers run in their own VM. A bind-mounted host directory (`.:/app`) is always shared in
+over virtiofs — **even when the host path is already on WSL's native filesystem**. Every file
+operation is a round trip across that boundary.
+
+Frameworks that scan large directory trees at startup make an enormous number of tiny
+`stat`/`open` calls:
+
+- Ruby's Zeitwerk autoloader walking `app/`
+- Bundler resolving a large `Gemfile.lock`
+- Node resolving through `node_modules/`
+- .NET probing assemblies
+
+Each call is cheap in isolation and ruinous at ten thousand round trips. CPU on the Windows side
+can look busy while essentially no data is transferred, and the process appears hung.
+
+## The fix: stop bind-mounting the source
+
+Mirror it into a named volume instead. The app then reads from fast native storage inside the VM,
+and the bind mount is only touched in bulk by `rsync`:
+
+```
+before:  host ./ ──(virtiofs, every stat/open)──► /app   ← the app reads here
+after:   host ./ ──(virtiofs, bulk rsync only)──► /host-src
+                                    │
+                                    ▼
+         named volume app-src ─────────────────► /app     ← the app reads here
+```
+
+### Minimal configuration
+
+Add a `sync:` block to `wip.yml`:
+
+```yaml
+sync:
+  exclude:
+    - .git
+    - tmp/
+    - node_modules/
+```
+
+That's genuinely all of it — every other key has a default. wip then:
+
+- rewrites the primary container's `.:/app` into `<source>:/host-src:ro` + `app-src:/app`
+- mirrors before the container boots on `wip up`
+- re-mirrors on demand with `wip sync`
+
+```bash
+wip down       # existing containers keep their old mounts
+wip up -d      # recreated with the new ones
+```
+
+### Getting the excludes right
+
+Exclude anything large, regenerated inside the container, or irrelevant:
+
+```yaml
+sync:
+  exclude:
+    - .git
+    - log/
+    - tmp/
+    - storage/
+    - public/assets/
+    - .bundle/
+    - vendor/bundle/
+    - coverage/
+    - node_modules/
+```
+
+`wip init --template rails|node|rust|csharp` writes a stack-appropriate list for you. See
+[Source Sync](Source-Sync).
+
+Two reasons to exclude generously:
+
+1. Less to mirror = faster syncs.
+2. Excluded paths survive `--delete`, so container-generated content (installed gems, compiled
+   assets) isn't wiped on the next pass.
+
+### rsync has to exist
+
+Under the default `sync.mode: exec`, the mirror runs *inside* your app image:
+
+```dockerfile
+RUN apt-get update && apt-get install -y rsync
+```
+
+Don't want it in your app image? Use `sync.mode: run` with a dedicated image:
+
+```yaml
+sync:
+  mode: run
+  build:
+    dockerfile: |
+      FROM alpine:latest
+      RUN apk add --no-cache rsync
+```
+
+See [Sync Modes](Sync-Modes) and [rsync Not Found](rsync-Not-Found).
+
+## Keeping it current while you work
+
+The mirror is a snapshot, not a live view. Run a watcher in a second terminal:
+
+```bash
+# terminal 1
+wip up -d
+
+# terminal 2
+wip sync --watch
+```
+
+See [Continuous Sync](Continuous-Sync).
+
+## Verify it worked
+
+```bash
+wip doctor                 # [OK] Sync source … mirrors into volume app-src at /app
+wip config                 # confirm the resolved source/volume/target
+wip rails c --debug        # compare the time before the prompt appears
+```
+
+## The trade-off
+
+You give up an always-live view of host edits. The mirror is one-way (host → volume) and slightly
+delayed, and `--delete` removes anything the app wrote under the target unless you exclude it, give
+it its own volume, or set `delete: false`.
+
+For an edit-run-edit loop with a 2-second watcher, that's usually invisible. For a workflow that
+depends on generated files landing back on the host (scaffold generators, migration files), you'll
+copy them out manually — see [Source Sync](Source-Sync).
+
+## Also worth checking
+
+If **builds** are slow rather than boots, that's a different problem with a different fix — the
+build context crossing the same boundary. See [Shadow Build Context](Shadow-Build-Context) and
+[Dockerignore](Dockerignore).
+
+## Related
+
+- [Source Sync](Source-Sync)
+- [Sync Modes](Sync-Modes)
+- [Continuous Sync](Continuous-Sync)
+- [Debug Output](Debug-Output)

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -1,0 +1,115 @@
+# Getting Started
+
+From nothing to your first `wip up`. If you already know which mode you want, jump straight to
+[Container Mode](Container-Mode), [Compose Native Mode](Compose-Native-Mode), or
+[Compose Mode](Compose-Mode).
+
+## Prerequisites
+
+| Requirement | Why |
+|---|---|
+| Ruby 3.2+ | `wip` is a Ruby gem (`required_ruby_version >= 3.2`) |
+| WSL2 | WSLC containers run in a WSL2-backed VM |
+| Microsoft WSLC | `wip` shells out to `wslc.exe` / `wslc` for everything |
+
+Confirm `wslc` itself is reachable before installing anything:
+
+```bash
+wslc.exe version || wslc version
+```
+
+`wip` looks for the binary in this order when `wslc.command` is left at `auto`:
+
+1. `wslc.exe` (on `PATH`)
+2. `wslc` (on `PATH`)
+3. `/mnt/c/Windows/System32/wslc.exe`
+
+If none of those exist, see [WSLC Not Found](WSLC-Not-Found).
+
+## Installation
+
+```bash
+gem install wslc-wip
+```
+
+The gem is named `wslc-wip`; the command it installs is `wip`.
+
+From source, when you want to run an unreleased revision or hack on it:
+
+```bash
+git clone https://github.com/slidict/wip.git
+cd wip
+bundle install
+bundle exec exe/wip version
+```
+
+Check what you got:
+
+```bash
+wip version
+```
+
+That prints wip's own version and then asks `wslc` for its version — see [wip version](wip-version).
+
+## Generate a wip.yml
+
+```bash
+cd my-project
+wip init
+```
+
+`wip init` looks for `compose.yml` / `compose.yaml` / `docker-compose.yml` / `docker-compose.yaml`
+next to the file it's about to write:
+
+- **found** → writes `mode: compose-native`, pointing at that file
+- **not found** → writes `mode: container`, with a `dependencies:` skeleton
+
+It refuses to overwrite an existing `wip.yml` unless you pass `--force`, and `--template
+rails|node|rust|csharp` picks a stack-appropriate default `sync.exclude` list. Full details:
+[wip init](wip-init).
+
+The generated file is deliberately full of comments and `TODO:` markers. At minimum you need to
+fill in:
+
+- **container mode** — `dependencies.app.image` (and rename `app` / `container:` if you like)
+- **compose-native mode** — `compose.service`, so wip knows which service is "the app"
+
+## Verify it works
+
+```bash
+wip doctor
+```
+
+Every check prints `[OK]`, `[WARN]`, or `[FAIL]`. Warnings alone still exit `0`; a WSL2, interop,
+WSLC, config, or sync failure exits `1`. See [wip doctor](wip-doctor) for what each line means.
+
+## First boot
+
+```bash
+wip build     # only if you have a build: / interaction.build definition
+wip up -d
+wip shell
+```
+
+`wip up` creates the network (if `network:` is set), starts every sidecar, mirrors the source if
+you configured [Source Sync](Source-Sync), then starts the primary container. See [wip up](wip-up).
+
+Then run your project's own commands through the interactions you declared:
+
+```bash
+wip rails console
+wip rspec
+```
+
+Those come from the `interaction:` block — see [Interactions](Interactions).
+
+## Where to go next
+
+| Question | Page |
+|---|---|
+| Which mode should I use? | [Choosing a Mode](Choosing-a-Mode) |
+| What does every `wip.yml` key do? | [Configuration Reference](Configuration-Reference) |
+| What commands exist? | [CLI Command Reference](CLI-Command-Reference) |
+| Boot feels unbearably slow | [Fixing a Slow Boot](Fixing-a-Slow-Boot) |
+| I'm coming from `dip` | [Migrating from dip](Migrating-from-dip) |
+| Something failed | [Troubleshooting & FAQ](Troubleshooting-and-FAQ) |

--- a/wiki/Global-Options.md
+++ b/wiki/Global-Options.md
@@ -1,0 +1,97 @@
+# Global Options
+
+Four options apply to every command.
+
+| Option | Meaning |
+|---|---|
+| `--config PATH` | Use this `wip.yml` instead of searching |
+| `--env-file PATH` | Load this dotenv file instead of `.env` next to `wip.yml` |
+| `--debug` | Print each step wip takes, with timings |
+| `--debug-log PATH` \| `-` | Where `--debug` resource snapshots go |
+
+## They may appear before or after the command
+
+```bash
+wip up --config other/wip.yml
+wip --config other/wip.yml up
+```
+
+Both work. wip pulls a leading run of global switches off the front of the arguments and reinserts
+them after the command name, since the underlying CLI framework only recognizes them there. Both
+`--config PATH` and `--config=PATH` spellings are handled.
+
+This matters most for interactions, where trailing arguments belong to *your* command:
+
+```bash
+wip --debug rails console        # --debug is wip's
+wip rails console --debug        # also wip's — it's a known global switch
+wip rails console -- --debug     # after --, it belongs to bin/rails
+```
+
+## `--config PATH`
+
+```bash
+wip --config /path/to/wip.yml up
+```
+
+Skips the upward directory search. The path is expanded against your current directory. Also
+respected by `wip init`, which writes there (and detects a compose file next to *that* path).
+
+See [Config File Discovery](Config-File-Discovery).
+
+## `--env-file PATH`
+
+```bash
+wip --env-file config/dev.env up
+```
+
+Replaces the default `.env` next to `wip.yml`. Missing files are not an error.
+
+The same file is used for compose.yml `${VAR}` interpolation under
+[compose-native mode](Compose-Native-Mode), so both uses always agree. See [Env Files](Env-Files).
+
+## `--debug`
+
+```bash
+wip rails c --debug
+WIP_DEBUG=1 wip rails c      # equivalent
+```
+
+Prints every step — existence probes, the resolved `wslc` invocation, elapsed time — plus periodic
+host resource snapshots. Environment values in logged commands are masked as `KEY=***`.
+
+Full explanation of the output: [Debug Output](Debug-Output).
+
+## `--debug-log`
+
+Controls where the periodic resource snapshots go. By default wip decides:
+
+| Command type | Default destination |
+|---|---|
+| Interactive (`-it`, e.g. `rails console`) | a temp log file, whose path is printed once |
+| Non-interactive | inline on stderr |
+
+Overrides:
+
+| Value | Effect |
+|---|---|
+| `--debug-log=-` | always inline, even for interactive commands |
+| `--debug-log=PATH` | always to `PATH` (appended), even for non-interactive commands |
+
+```bash
+wip rails c --debug --debug-log=/tmp/wip-debug.log
+```
+
+Only the snapshots are redirected — step start/finish lines always go to stderr.
+
+## Environment variables
+
+| Variable | Effect |
+|---|---|
+| `WIP_DEBUG` | any non-empty value enables `--debug` |
+
+## Related
+
+- [Debug Output](Debug-Output)
+- [Config File Discovery](Config-File-Discovery)
+- [Env Files](Env-Files)

--- a/wiki/Glossary.md
+++ b/wiki/Glossary.md
@@ -1,0 +1,80 @@
+# Glossary
+
+### primary container
+
+The one container `wip` treats as "the app": the target of `exec`, `run`, `build`, `shell`, and
+every [interaction](Interactions). Named by `container:` under [Container Mode](Container-Mode),
+and by `compose.service` under [Compose Mode](Compose-Mode) /
+[Compose Native Mode](Compose-Native-Mode). It has no default — see [Dependencies](Dependencies).
+
+### sidecar / dependency
+
+Every other entry under `dependencies:` (or every other `compose.yml` service): a database, Redis,
+a queue worker. wip only ever starts and stops these; it never execs into them. See
+[Dependencies](Dependencies).
+
+### interaction
+
+A named project command declared in `wip.yml`, run as `wip <name> [args...]` — `wip rspec`,
+`wip rails console`. Spelled `interaction:` (the primary key, same as `dip`) or `commands:` (an
+alias). Declaring both is an error. See [Interactions](Interactions).
+
+### dispatch
+
+The built-in that runs an interaction explicitly: `wip dispatch NAME`. Needed only when an
+interaction's name collides with a built-in command, since the built-in wins. See
+[wip dispatch](wip-dispatch).
+
+### bind mount
+
+A host directory shared into the container (`.:/app`). Under WSLC this always crosses a virtiofs
+boundary, which is what makes framework boot slow. See [Fixing a Slow Boot](Fixing-a-Slow-Boot).
+
+### sync volume
+
+The named volume that holds a mirror of your source, so the running app reads from fast storage
+inside the VM instead of a bind mount. Defaults to `<container>-src`. See
+[Source Sync](Source-Sync).
+
+### mirror
+
+One `rsync` pass from the read-only source mount into the sync volume. Run before boot by
+`wip up`, on demand by `wip sync`, and repeatedly by `wip sync --watch`. One-way, host → volume.
+
+### shadow context
+
+A persistent copy of the build context kept on the Windows filesystem so `wslc build` doesn't have
+to read a WSL-side tree over the VM boundary on every build. Enabled per build command via
+`shadow_context:`. See [Shadow Build Context](Shadow-Build-Context).
+
+### staged context
+
+The temporary directory `wip build` assembles by applying `.dockerignore` to the build context
+before handing it to `wslc build`. Distinct from a shadow context, which is persistent and
+Windows-side. See [Dockerignore](Dockerignore).
+
+### `WslcContainerState`
+
+The integer `wslc list --format json` reports in each entry's `State` field:
+
+| Value | State | Meaning for wip |
+|---|---|---|
+| `0` | invalid | not a usable container |
+| `1` | created | exists, never started |
+| `2` | running | up |
+| `3` | exited | the only state `wip up --watch` restarts |
+| `4` | deleted | gone; needs `wip up` to recreate, not `start` |
+
+Unlike Docker there is no separate `dead` state. Reference:
+[wsl.dev](https://wsl.dev/api-reference/c/enumerations/wslccontainerstate/). See
+[Restart Policies](Restart-Policies).
+
+### compose-for-wslc tool
+
+A third-party binary that speaks Compose vocabulary against `wslc`. `mode: compose` bridges to one
+of these; wip doesn't bundle or favor any. See [Third Party Compose Tools](Third-Party-Compose-Tools).
+
+### `ConfigError`
+
+The error class raised for every configuration problem, at load time, naming the offending key.
+Catalog: [Configuration Errors](Configuration-Errors).

--- a/wiki/Guides.md
+++ b/wiki/Guides.md
@@ -1,0 +1,35 @@
+# Guides
+
+Task-oriented how-tos. Reference material lives under
+[Configuration Reference](Configuration-Reference) and
+[CLI Command Reference](CLI-Command-Reference); these pages are about getting a specific job done.
+
+## Getting set up
+
+| I want to… | Guide |
+|---|---|
+| Install wip and boot a project for the first time | [Getting Started](Getting-Started) |
+| Decide which `mode:` to use | [Choosing a Mode](Choosing-a-Mode) |
+| Move a project from `dip` to `wip` | [Migrating from dip](Migrating-from-dip) |
+| Reuse a `compose.yml` I already have | [Reusing an Existing compose.yml](Reusing-an-Existing-compose-yml) |
+
+## Performance
+
+| I want to… | Guide |
+|---|---|
+| Fix a boot that takes minutes and looks hung | [Fixing a Slow Boot](Fixing-a-Slow-Boot) |
+| Keep the container's copy of my source current while I edit | [Continuous Sync](Continuous-Sync) |
+| Stop re-sending the whole build context on every build | [Shadow Build Context](Shadow-Build-Context) |
+
+## Operations
+
+| I want to… | Guide |
+|---|---|
+| Restart containers automatically when they exit | [Auto Restarting Containers](Auto-Restarting-Containers) |
+| Fix "no matching manifest for linux/arm64" | [Multi Arch Images](Multi-Arch-Images) |
+| Run wip in CI or another non-interactive environment | [Using wip in CI](Using-wip-in-CI) |
+
+## Troubleshooting
+
+Errors and diagnostics have their own section — start at
+[Troubleshooting & FAQ](Troubleshooting-and-FAQ).

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,50 @@
+# wip Wiki
+
+`wip` is a Ruby-built CLI that brings a [`dip`](https://github.com/bibendi/dip)-like workflow to
+Microsoft WSLC. This wiki is where the deeper explanations, guides, and reference material that
+don't fit in the [README](https://github.com/slidict/wip#quick-start) live.
+
+> Rule of thumb: the README is the fastest path to "get it running"; the wiki is for daily use,
+> troubleshooting, and contributing. Every page here covers exactly one feature, so you can link
+> a teammate straight at the thing they asked about.
+
+## Start here
+
+- [Getting Started](Getting-Started) — install through your first `wip up`
+- [Choosing a Mode](Choosing-a-Mode) — the one decision you have to make before writing `wip.yml`
+- [Concepts](Concepts) — what `wip` is, the three modes, and the design stance behind them
+- [Glossary](Glossary) — primary container, sidecar, interaction, sync volume, shadow context
+
+## The three modes
+
+| Mode | wip's role | Page |
+|---|---|---|
+| `container` (default) | wip declares and drives containers itself from `wip.yml` | [Container Mode](Container-Mode) |
+| `compose-native` | wip parses your `compose.yml` and drives `wslc` directly | [Compose Native Mode](Compose-Native-Mode) |
+| `compose` | wip is a thin bridge to a third-party compose-for-`wslc` binary | [Compose Mode](Compose-Mode) |
+
+## Reference
+
+- [Configuration Reference](Configuration-Reference) — every `wip.yml` key, one page per feature
+- [CLI Command Reference](CLI-Command-Reference) — every command, one page each
+- [Global Options](Global-Options) — `--config`, `--env-file`, `--debug`, `--debug-log`
+- [Configuration Errors](Configuration-Errors) — every `ConfigError` and what triggers it
+
+## Usage
+
+- [Guides](Guides) — task-oriented how-tos
+- [Troubleshooting & FAQ](Troubleshooting-and-FAQ) — errors, diagnostics, frequently asked questions
+- [Comparison](Comparison) — how `wip` relates to `dip`, `docker compose`, and other tools
+
+## Project
+
+- [Development](Development) — dev setup, tests, and contributing
+- [Architecture](Architecture) — how the codebase is laid out
+- [Release Process](Release-Process) — versioning and how releases are cut
+
+## Related links
+
+- [GitHub repository](https://github.com/slidict/wip)
+- [Homepage](https://wslc-wip.slidict.com/)
+- [RubyGems](https://rubygems.org/gems/wslc-wip)
+- [CONTRIBUTING.md](https://github.com/slidict/wip/blob/main/CONTRIBUTING.md)

--- a/wiki/Interactions.md
+++ b/wiki/Interactions.md
@@ -1,0 +1,186 @@
+# Interactions
+
+Project commands declared in `wip.yml` and run as `wip <name> [args...]`. This is the feature that
+turns a twelve-flag `wslc exec` line into `wip rspec`.
+
+## Two spellings, one feature
+
+```yaml
+interaction:      # the primary key — same name dip uses
+  rspec:
+    command: bundle exec rspec
+```
+
+```yaml
+commands:         # accepted alias
+  rspec:
+    command: bundle exec rspec
+```
+
+Pick one. Declaring both in the same file is a `ConfigError`:
+
+```
+commands is mutually exclusive with interaction — pick one
+```
+
+`wip config` always prints the effective block under the name `commands:`, whichever you wrote.
+
+## Entry keys
+
+```yaml
+interaction:
+  rails:
+    type: exec            # exec (default) | run | build
+    command: bin/rails
+    container: app        # override which container to exec into
+    interactive: true
+    workdir: /app
+    user: "1000:1000"
+    env:
+      RAILS_ENV: development
+```
+
+| Key | Default | Notes |
+|---|---|---|
+| `type` | `exec` (`build` for an entry literally named `build`) | see below |
+| `command` | — | split with shell-word rules; extra CLI args are appended |
+| `interactive` | `false` | combined with real-TTY detection — see [TTY Allocation](TTY-Allocation) |
+| `container` | the primary container | `exec` target override |
+| `workdir`, `user`, `env`, `ports`, `volumes`, `image`, `remove` | inherited from the primary entry | any of them can be overridden per command |
+
+Every entry starts from the primary `dependencies:` entry's values and merges its own on top. That
+inheritance is why a minimal entry works:
+
+```yaml
+interaction:
+  bundle:
+    command: bundle       # inherits image, workdir, env, … from dependencies.app
+```
+
+## The three types
+
+### `type: exec` (default)
+
+Runs inside the already-running primary container:
+
+```
+wslc exec [-it] [-w WORKDIR] [-u USER] [-e KEY=VALUE …] CONTAINER command…
+```
+
+Ports and volumes are **not** applied — the container already exists. Requires the container to be
+up (`wip up -d` first).
+
+### `type: run`
+
+Runs in a fresh, ephemeral container:
+
+```yaml
+migrate:
+  type: run
+  command: bundle exec rails db:migrate
+  image: slidict/slidict:development
+  remove: true
+```
+
+```
+wslc run [--rm] [-it] [-w] [-u] [-e …] [-p …] [-v …] IMAGE command…
+```
+
+Unlike `exec`, this *does* apply ports and volumes, and needs an `image` (inherited from the
+primary entry unless overridden).
+
+Not supported under [`mode: compose`](Compose-Mode).
+
+### `type: build`
+
+Builds an image:
+
+```yaml
+build:
+  type: build
+  context: .
+  tag: slidict/slidict:development
+  shadow_context: /mnt/c/Users/me/AppData/Local/wip/build-contexts
+```
+
+```
+wslc build -t TAG [extra args…] CONTEXT
+```
+
+An entry named `build` defaults to `type: build` even without the key. `tag` falls back to the
+inherited `image`; an empty one is a `ConfigError`. Arguments you pass on the command line become
+extra `wslc build` flags. See [wip build](wip-build), [Dockerignore](Dockerignore), and
+[Shadow Build Context](Shadow-Build-Context).
+
+Not supported under [`mode: compose`](Compose-Mode).
+
+Any other `type` value:
+
+```
+Invalid command type for migrate: exectue
+```
+
+## Passing arguments
+
+Extra CLI arguments are appended to the configured command:
+
+```yaml
+interaction:
+  rails:
+    command: bin/rails
+```
+
+```bash
+wip rails console          # → bin/rails console
+wip rails db:migrate       # → bin/rails db:migrate
+wip rails g model User     # → bin/rails g model User
+```
+
+## Name collisions with built-ins
+
+Built-in commands always win. If you declare an interaction named `sync`, `build`, `up`, `config`,
+… then `wip sync` runs the built-in. wip says so where it can:
+
+```console
+$ wip sync
+wip: commands.sync in wip.yml is shadowed by the built-in `wip sync`; run it with `wip dispatch sync`
+```
+
+Run yours explicitly:
+
+```bash
+wip dispatch sync
+```
+
+See [wip dispatch](wip-dispatch). Reserved names to avoid: `init`, `version`, `doctor`, `config`,
+`build`, `up`, `stop`, `down`, `exec`, `run`, `shell`, `logs`, `sync`, `dispatch`, `help`.
+
+Note `build` is a special case: it's both a built-in *and* the conventional name for the build
+definition — `wip build` uses `interaction.build`'s `context`/`tag`, so that collision is by design.
+
+## Unknown names
+
+```console
+$ wip nope
+Unknown command: nope
+```
+
+Any first argument wip doesn't recognize as a built-in is routed to `dispatch`, which raises this
+if there's no matching entry.
+
+## Under compose mode
+
+Only `type: exec` is supported:
+
+```
+commands.migrate: type 'run' is not supported in compose mode (use `wslc-compose build`/`up --build` directly)
+```
+
+The command runs via the bridge's `exec` against `compose.service`.
+
+## Related
+
+- [wip dispatch](wip-dispatch)
+- [TTY Allocation](TTY-Allocation)
+- [Env Files](Env-Files)
+- [Migrating from dip](Migrating-from-dip)

--- a/wiki/Migrating-from-dip.md
+++ b/wiki/Migrating-from-dip.md
@@ -1,0 +1,169 @@
+# Migrating from dip
+
+`wip` is deliberately shaped like [`dip`](https://github.com/bibendi/dip), so most of a `dip.yml`
+carries over with renames rather than rewrites.
+
+## The short version
+
+1. `cp dip.yml wip.yml`
+2. Rename `docker_compose`-oriented keys to wip's `mode:` + `dependencies:` / `compose:` shape.
+3. Leave `interaction:` alone — it's the same key, with the same meaning.
+4. `wip doctor`, then `wip up -d`.
+
+## What carries over unchanged
+
+### `interaction:`
+
+This is the headline: no rename needed.
+
+```yaml
+# dip.yml                          # wip.yml
+interaction:                       interaction:
+  rails:                             rails:
+    service: app                       command: bin/rails
+    command: bundle exec rails         interactive: true
+```
+
+`interaction:` is wip's **primary** spelling, same as in dip. `commands:` is accepted as an alias
+if you prefer that name — but declaring both in one file is a `ConfigError`. See
+[Interactions](Interactions).
+
+Per-entry, the mapping is:
+
+| dip | wip |
+|---|---|
+| `command:` | `command:` |
+| `service:` | `container:` (only needed to override the primary one) |
+| `environment:` | `env:` |
+| `compose.run_options` | — (use `type: run` plus the entry's own keys) |
+| `subcommands:` | — (declare separate top-level entries) |
+
+### `.env`
+
+Loaded the same way, with the same syntax. Precedence differs slightly: in wip, `env:` in `wip.yml`
+always wins over `.env`. See [Env Files](Env-Files).
+
+## What changes
+
+### There's no `docker_compose:` key
+
+dip assumes Compose. wip makes orchestration explicit through `mode:`:
+
+| Your dip setup | wip equivalent |
+|---|---|
+| `dip.yml` + `docker-compose.yml` | [`mode: compose-native`](Compose-Native-Mode) — wip parses it directly |
+| `dip.yml` + `docker-compose.yml`, and you want a real compose tool | [`mode: compose`](Compose-Mode) |
+| No compose file; dip driving a single container | [`mode: container`](Container-Mode) |
+
+### Services become `dependencies:`
+
+Under `mode: container`, what Compose called services you declare directly:
+
+```yaml
+container: app
+dependencies:
+  app:
+    image: myapp:dev
+    workdir: /app
+  postgres:
+    image: postgres:16
+    env:
+      POSTGRES_PASSWORD: password
+```
+
+`container:` names the primary one — the target of `exec`/`run`/`build` and every interaction. It
+has **no default**, unlike dip's convention of assuming a `app`-ish service. See
+[Dependencies](Dependencies).
+
+### `provision:` has no equivalent yet
+
+dip's `provision:` (a list of setup commands run by `dip provision`) is not implemented. Express it
+as an interaction and run it yourself:
+
+```yaml
+interaction:
+  setup:
+    type: run
+    command: bin/setup
+```
+
+```bash
+wip setup
+```
+
+### Docker → WSLC
+
+Every command ends in `wslc`, not `docker`. Practical consequences:
+
+- Images must exist for your architecture — see [Multi Arch Images](Multi-Arch-Images).
+- Registry login is `wslc registry login`, not `docker login` — see
+  [Registry Authentication](Registry-Authentication).
+- Bind mounts cross a VM boundary and are slow enough to matter — see
+  [Fixing a Slow Boot](Fixing-a-Slow-Boot). This is the biggest practical difference from dip on
+  Docker Desktop, and the reason [`sync:`](Source-Sync) exists.
+- There's no `restart:` policy in the runtime; wip approximates it by polling — see
+  [Restart Policies](Restart-Policies).
+
+## Worked example
+
+**Before — `dip.yml` + `docker-compose.yml`:**
+
+```yaml
+# dip.yml
+version: '7'
+compose:
+  files:
+    - docker-compose.yml
+interaction:
+  bash:
+    service: app
+    command: bash
+  rails:
+    service: app
+    command: bundle exec rails
+  rspec:
+    service: app
+    command: bundle exec rspec
+```
+
+**After — `wip.yml`, reusing the same compose file:**
+
+```yaml
+version: 1
+mode: compose-native
+
+compose:
+  service: app
+  project: myapp
+
+interaction:
+  shell:
+    command: bash
+    interactive: true
+  rails:
+    command: bundle exec rails
+    interactive: true
+  rspec:
+    command: bundle exec rspec
+```
+
+Then:
+
+```bash
+wip doctor      # confirms the compose file parses within the supported subset
+wip up -d
+wip rspec
+```
+
+If `wip doctor` rejects a key, check [Compose File Support](Compose-File-Support) — and if your
+file needs something outside the subset, switch to [`mode: compose`](Compose-Mode).
+
+## Feature comparison
+
+A side-by-side table lives on [wip vs dip](wip-vs-dip).
+
+## Related
+
+- [Interactions](Interactions)
+- [Reusing an Existing compose.yml](Reusing-an-Existing-compose-yml)
+- [wip vs dip](wip-vs-dip)

--- a/wiki/Multi-Arch-Images.md
+++ b/wiki/Multi-Arch-Images.md
@@ -1,0 +1,141 @@
+# Multi Arch Images
+
+Fixing "the image doesn't run here" when your machine's CPU architecture doesn't match the image's.
+
+## The symptom
+
+```
+no matching manifest for linux/arm64 in the manifest list entries
+```
+
+wip detects this and prints a hint automatically:
+
+```
+The image does not contain a manifest for the current CPU architecture.
+
+Current architecture:
+  linux/arm64
+
+Inspect the image with:
+
+  docker buildx imagetools inspect <image>
+
+Rebuild and push a multi-platform image with:
+
+  docker buildx build \
+    --platform linux/amd64,linux/arm64 \
+    -t <image> \
+    --push .
+```
+
+## Confirm your architecture
+
+```console
+$ wip doctor
+[OK] Architecture: linux/arm64
+```
+
+wip reports `linux/amd64` for `x86_64`/`x64` hosts and `linux/arm64` for `aarch64`/`arm64`. This
+line is always `[OK]` — it's informational, not a check.
+
+## Inspect the image
+
+```bash
+docker buildx imagetools inspect ghcr.io/example/myapp:dev
+```
+
+```
+Manifests:
+  Name:      ghcr.io/example/myapp:dev@sha256:…
+  Platform:  linux/amd64
+```
+
+One platform listed, and it isn't yours → that's the problem.
+
+## Fix: publish a multi-arch image
+
+```bash
+docker buildx create --use          # once, if you have no builder
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  -t ghcr.io/example/myapp:dev \
+  --push .
+```
+
+`--push` is required: multi-platform manifests can't live in a local image store, only in a
+registry.
+
+Verify:
+
+```bash
+docker buildx imagetools inspect ghcr.io/example/myapp:dev
+```
+
+```
+Manifests:
+  Platform:  linux/amd64
+  Platform:  linux/arm64
+```
+
+Then pull it fresh:
+
+```bash
+wip down
+wip up -d
+```
+
+## If you can't rebuild the image
+
+It's third-party, or you don't control the registry.
+
+**Find an official multi-arch tag.** Most popular images (`postgres`, `redis`, `node`, `ruby`)
+publish both. Check with `imagetools inspect` before assuming.
+
+**Pin a different base.** For your own Dockerfile, a multi-arch base gets you multi-arch output as
+long as everything you install is available for both.
+
+**Emulate.** `wslc` may support running a foreign-architecture image under emulation depending on
+your setup, but it's slow enough that it isn't a real answer for a dev container.
+
+## Building multi-arch from a wip build?
+
+`wip build` shells out to `wslc build`, which builds for the host architecture. There is no
+`--platform` plumbing in `wip.yml`. Multi-arch publishing is a separate, CI-shaped concern — do it
+with `docker buildx` as above, then reference the published tag from `wip.yml`:
+
+```yaml
+dependencies:
+  app:
+    image: ghcr.io/example/myapp:dev
+```
+
+You can still pass extra flags through if your `wslc build` accepts them:
+
+```bash
+wip build -- --platform linux/arm64
+```
+
+## A CI recipe
+
+```yaml
+# .github/workflows/image.yml
+- uses: docker/setup-buildx-action@v3
+- uses: docker/login-action@v3
+  with:
+    registry: ghcr.io
+    username: ${{ github.actor }}
+    password: ${{ secrets.GITHUB_TOKEN }}
+- uses: docker/build-push-action@v6
+  with:
+    platforms: linux/amd64,linux/arm64
+    push: true
+    tags: ghcr.io/example/myapp:dev
+```
+
+Both an Apple Silicon laptop and an x86 workstation then pull the right variant of the same tag.
+
+## Related
+
+- [Architecture Mismatch](Architecture-Mismatch) — the error page
+- [wip doctor](wip-doctor)
+- [wip build](wip-build)

--- a/wiki/Networking.md
+++ b/wiki/Networking.md
@@ -1,0 +1,89 @@
+# Networking
+
+How containers reach each other by name.
+
+## Container mode: `network:`
+
+```yaml
+network: app-tier
+dependencies:
+  app:   { image: your/image:tag }
+  redis: { image: redis:latest }
+```
+
+Every entry under `dependencies:` joins this one network, so the app can connect to `redis://redis:6379`
+using the dependency name as the hostname — the same way Compose service names resolve.
+
+`network:` is optional. Leave it out and containers are created without `--network`, which means
+they get whatever default `wslc` gives them and generally **cannot** resolve each other by name.
+If your app talks to a sidecar, set it.
+
+### When the network is created
+
+At `wip up`, and only if it doesn't already exist:
+
+```console
+$ wip up -d
+wip: creating network 'app-tier'
+```
+
+wip lists existing networks first and matches on exact name. Creation failure is non-fatal — the
+boot continues, and the subsequent `run` will surface the real error.
+
+### When it is *not* removed
+
+`wip down` stops and removes containers, but leaves the network in place. Networks are cheap,
+shared, and may be referenced by containers wip doesn't manage; tearing one down as a side effect
+of `wip down` would be surprising. Remove it yourself if you need to:
+
+```bash
+wslc network remove app-tier
+```
+
+## Compose-native mode: derived from `compose.project`
+
+There is no `network:` key here — setting one alongside `compose:` is a `ConfigError`. Instead wip
+creates one project network for every service, named:
+
+1. `compose.project`, if set
+2. otherwise the basename of the directory holding `wip.yml`
+
+```yaml
+compose:
+  service: app
+  project: myapp     # → network "myapp"
+```
+
+This gives the same guarantee real Compose's per-project network does: every service in the file
+can reach every other by service name.
+
+`networks:` inside a compose service is accepted and **ignored** — every service already shares
+the one project network. Top-level `networks:` is ignored outright. See
+[Compose File Support](Compose-File-Support).
+
+## Compose mode: not wip's concern
+
+Under [`mode: compose`](Compose-Mode), the external compose binary owns networking entirely. wip
+never passes `--network`, and `network:` in `wip.yml` is rejected as mutually exclusive with
+`compose:`.
+
+## Ports
+
+Publishing is per-entry, not per-network:
+
+```yaml
+dependencies:
+  app:
+    ports:
+      - "3000:3000"
+```
+
+Ports are applied when a container is **created** (`wip up`, `wip run`) — not on `wip exec`, which
+attaches to an already-running container and therefore never re-publishes anything. If you added a
+port to `wip.yml` and it isn't listening, the container predates the change: `wip down && wip up -d`.
+
+## Related
+
+- [Dependencies](Dependencies)
+- [Compose Native Mode](Compose-Native-Mode)
+- [wip up](wip-up)

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -1,0 +1,57 @@
+# wiki/ — source for the GitHub wiki
+
+This directory mirrors the [wip wiki](https://github.com/slidict/wip/wiki) one file per page.
+Filenames are the page names: `wip-up.md` → the "wip up" page, linked as `[wip up](wip-up)`.
+
+Keeping the sources here means wiki changes can be reviewed in a pull request, unlike edits made
+through the wiki UI.
+
+> This `README.md` and `publish.sh` are tooling for the directory, not wiki pages — `publish.sh`
+> skips them.
+
+## Structure
+
+One page per feature. Hub pages index; feature pages explain.
+
+| Hub | Feature pages |
+|---|---|
+| `Home.md`, `_Sidebar.md` | navigation |
+| `Concepts.md`, `Choosing-a-Mode.md`, `Glossary.md` | introduction |
+| `Container-Mode.md`, `Compose-Mode.md`, `Compose-Native-Mode.md` | the three modes |
+| `Configuration-Reference.md` | one page per `wip.yml` feature |
+| `CLI-Command-Reference.md` | one page per command (`wip-*.md`) |
+| `Guides.md` | one page per task |
+| `Troubleshooting-and-FAQ.md` | one page per error, plus `FAQ.md` |
+| `Comparison.md` | one page per compared tool |
+| `Development.md` | `Architecture.md`, `Testing-and-Linting.md`, `Release-Process.md` |
+
+## Publishing
+
+The GitHub wiki is a separate git repository. To push this directory to it:
+
+```bash
+./wiki/publish.sh
+```
+
+Or by hand:
+
+```bash
+git clone https://github.com/slidict/wip.wiki.git /tmp/wip-wiki
+cp wiki/*.md /tmp/wip-wiki/
+rm -f /tmp/wip-wiki/README.md          # not a wiki page
+cd /tmp/wip-wiki
+git add -A && git commit -m "docs(wiki): sync from main repo" && git push
+```
+
+Requires push access to the wiki repository.
+
+## Conventions
+
+- **Filenames are page names.** Use `Title-Case-With-Hyphens.md`; hyphens render as spaces.
+  Command pages keep their command spelling (`wip-up.md`).
+- **Links are bare page names**, not paths or `.md`: `[wip up](wip-up)`. Anchors work:
+  `[Concepts](Concepts#design-stance)`.
+- **Update `_Sidebar.md`** when adding or renaming a page.
+- **One feature per page.** If a page grows two topics, split it and cross-link.
+- **Keep it accurate to the code.** Error messages, defaults, and flag names are quoted verbatim
+  from `lib/wip/` — when you change behavior there, grep this directory for the old text.

--- a/wiki/Registry-Authentication.md
+++ b/wiki/Registry-Authentication.md
@@ -1,0 +1,85 @@
+# Registry Authentication
+
+```
+pull access denied for example/private-image, repository does not exist or may require 'docker login'
+```
+
+wip recognizes this class of failure and prints:
+
+```
+The container registry rejected the request.
+
+Try logging in with:
+
+  wslc registry login -u <username> docker.io
+```
+
+## What triggers the hint
+
+Any of these in the failed command's output, case-insensitively:
+
+- `pull access denied`
+- `insufficient_scope`
+- `authorization failed`
+
+## Fix
+
+```bash
+wslc registry login -u <username> docker.io
+```
+
+You'll be prompted for a password or token. For other registries, name them explicitly:
+
+```bash
+wslc registry login -u <username> ghcr.io
+wslc registry login -u AWS <account>.dkr.ecr.<region>.amazonaws.com
+```
+
+Then retry:
+
+```bash
+wip up -d
+```
+
+Note this is `wslc registry login`, **not** `docker login` — a Docker credential store on the same
+machine doesn't carry over.
+
+## Use a token, not your password
+
+| Registry | Credential |
+|---|---|
+| Docker Hub | an access token from Account Settings → Security |
+| GitHub Container Registry | a PAT with `read:packages` |
+| GitLab | a deploy token or PAT with `read_registry` |
+| AWS ECR | `aws ecr get-login-password` |
+
+## When login isn't the problem
+
+`pull access denied` is what registries return for both "you're not authorized" and "it doesn't
+exist" — they deliberately don't distinguish, to avoid leaking whether a private repository exists.
+So check the obvious things too:
+
+- **Typo in the image name.** `wip config` prints the resolved image; read it.
+- **Wrong tag.** The repository exists, that tag doesn't.
+- **Wrong registry.** `myapp:dev` means Docker Hub. A GHCR image is `ghcr.io/owner/myapp:dev`.
+- **Genuinely no access.** For an org registry, your account may need to be granted it.
+
+## In CI
+
+Log in before any wip command that pulls:
+
+```bash
+echo "$REGISTRY_TOKEN" | wslc registry login -u "$REGISTRY_USER" --password-stdin ghcr.io
+wip up -d
+```
+
+(Use whatever stdin-password flag your `wslc` build supports; avoid putting the token in the
+command line, where it lands in process listings and logs.)
+
+See [Using wip in CI](Using-wip-in-CI).
+
+## Related
+
+- [wip up](wip-up)
+- [wip build](wip-build)
+- [Secret Masking](Secret-Masking)

--- a/wiki/Release-Process.md
+++ b/wiki/Release-Process.md
@@ -1,0 +1,125 @@
+# Release Process
+
+How a change gets from a merged PR to a published gem. Maintainer-facing.
+
+## The pipeline
+
+```
+PR merged to main
+   │
+   ├─► Changelog workflow ──► release-drafter updates the DRAFT release notes
+   │
+   └─► (when a version bump lands on main)
+        Ruby Gem workflow ──► publish to GitHub Packages
+                          ──► publish to RubyGems
+                          ──► publish the release notes (draft → released)
+```
+
+The Ruby Gem workflow is triggered by the Changelog workflow completing successfully on `main`, not
+by a tag push.
+
+## 1. Conventional Commits and labels
+
+Every PR's type drives its place in the release notes:
+
+| Label | Section |
+|---|---|
+| `feat` | 🚀 Features |
+| `fix` | 🐛 Fixes |
+| `chore`, `ci`, `docs`, `build`, `perf`, `test` | 🧰 Maintenance |
+
+Configured in `.github/release-drafter.yml`. Entries render as
+`- $TITLE @$AUTHOR (#$NUMBER)`, so PR titles are user-visible — write them for a reader, not for
+yourself.
+
+## 2. Draft notes accumulate
+
+The **Changelog** workflow (`.github/workflows/changelog.yml`) runs release-drafter with
+`publish: false` on every push to `main`, keeping a draft release continuously up to date. Nothing
+is released at this stage.
+
+## 3. Bump the version
+
+Run the **Bump Version** workflow manually (`workflow_dispatch`), choosing `patch`, `minor`, or
+`major`:
+
+| Bump | For |
+|---|---|
+| patch | bug fixes (`fix`) |
+| minor | new commands or features (`feat`) |
+| major | breaking changes |
+
+It:
+
+1. Reads the current version from `lib/wip/version.rb`
+2. Computes the next one per SemVer
+3. Rewrites `lib/wip/version.rb`
+4. Verifies the gemspec still builds (`gem build wslc-wip.gemspec`)
+5. Commits as `chore: bump version to vX.Y.Z` on a `bump-version-vX.Y.Z` branch
+6. Opens a PR
+
+Contributors never bump the version in a feature PR.
+
+## 4. Merge the bump PR
+
+Merging it to `main` triggers Changelog → Ruby Gem.
+
+## 5. Publish
+
+The **Ruby Gem** workflow (`.github/workflows/gem-push.yml`) runs only when the Changelog workflow
+succeeded on `main`. It:
+
+1. Extracts the version from `lib/wip/version.rb` → tag `vX.Y.Z`
+2. **Checks what already exists**, so a re-run is safe:
+   - RubyGems, via the versions API
+   - GitHub Packages, via the packages API
+   - a **published** (non-draft) GitHub release for the tag
+3. Publishes to GitHub Packages, if absent
+4. Publishes to RubyGems via trusted publishing (OIDC — no long-lived API key), if absent
+5. Publishes the release notes for the tag, if no published release exists
+
+Concurrency group `gem-push`, `cancel-in-progress: false` — publishes never overlap or get
+cancelled halfway.
+
+### Why the release check tests `isDraft`
+
+release-drafter keeps a draft release permanently updated, and `gh release view` matches drafts
+too. Checking mere existence would see the draft and skip publishing forever. So the workflow
+treats only `isDraft == false` as "already released" — the subject of a `fix(ci)` commit worth
+knowing about before you touch that step.
+
+## Idempotence
+
+Every publish step is guarded by an existence check, so re-running the workflow after a partial
+failure resumes rather than erroring on "version already exists". If RubyGems succeeded and GitHub
+Packages failed, a re-run pushes only the latter.
+
+## Manual verification after a release
+
+```bash
+gem install wslc-wip
+wip version
+```
+
+- [RubyGems](https://rubygems.org/gems/wslc-wip)
+- [Releases](https://github.com/slidict/wip/releases)
+
+## What ships in the gem
+
+`wslc-wip.gemspec`:
+
+```ruby
+spec.files = Dir['lib/**/*', 'exe/*', 'README.md', 'LICENSE']
+```
+
+So `spec/`, `docs/`, `.github/`, and this wiki are **not** in the gem — only the library, the
+executable, the README, and the licence. Adding a runtime file outside `lib/` or `exe/` means
+updating that glob.
+
+`rubygems_mfa_required` is set, and RubyGems publishing uses trusted publishing rather than a
+stored API key.
+
+## Related
+
+- [Development](Development)
+- [Testing and Linting](Testing-and-Linting)

--- a/wiki/Reporting-Issues.md
+++ b/wiki/Reporting-Issues.md
@@ -1,0 +1,126 @@
+# Reporting Issues
+
+Bug reports and feature requests go to
+[github.com/slidict/wip/issues](https://github.com/slidict/wip/issues).
+
+## Before filing
+
+1. Check [Troubleshooting & FAQ](Troubleshooting-and-FAQ) and
+   [Configuration Errors](Configuration-Errors) — most messages are documented with their cause.
+2. Run `wip doctor`. It catches environment and configuration problems that look like bugs.
+3. Search existing issues.
+
+## What to include
+
+### 1. Versions
+
+```bash
+wip version
+```
+
+Plus your OS, WSL, and WSLC versions:
+
+```powershell
+wsl --version
+wslc version
+```
+
+### 2. `wip doctor` output
+
+```bash
+wip doctor
+```
+
+Paste it whole, including the `[OK]` lines — they rule things out.
+
+### 3. Your `wip.yml`
+
+Redact secrets first. `wip config` is often better than the raw file, since it shows what wip
+actually resolved (defaults filled in, `${VAR}` substituted) and masks obvious secrets:
+
+```bash
+wip config
+```
+
+⚠️ Masking is a key-name heuristic — `API_KEY`, `DATABASE_URL`, and secrets embedded in values are
+**not** caught. Read the output before pasting. See [Secret Masking](Secret-Masking).
+
+Under compose-native mode, include the relevant part of `compose.yml` too.
+
+### 4. The exact command and its full output
+
+```console
+$ wip up -d
+wip: creating network 'app-tier'
+…the error…
+```
+
+Not a paraphrase — the exact text, including anything `wslc` printed.
+
+### 5. Debug output
+
+The single most useful attachment:
+
+```bash
+WIP_DEBUG=1 wip <the failing command> --debug-log=-
+```
+
+`--debug-log=-` forces resource snapshots inline instead of into a temp file, so one paste has
+everything. Environment values are masked as `KEY=***`. See [Debug Output](Debug-Output).
+
+### 6. What you expected
+
+One line. "I expected `wip run` to start a new container, but it exec'd into the running one" is
+enough — and sometimes reveals the behavior is documented rather than broken.
+
+## A template
+
+```markdown
+### Environment
+- wip: 1.1.3
+- Ruby: 3.4.1
+- WSL: 2.x
+- WSLC: 0.x
+- Host: Windows 11 / x86_64
+
+### What I did
+`wip up -d`
+
+### What I expected
+The app container to start.
+
+### What happened
+<full output>
+
+### wip doctor
+<full output>
+
+### wip config
+<redacted output>
+
+### Debug output
+<WIP_DEBUG=1 output>
+```
+
+## Feature requests
+
+Say what you're trying to do, not only what API you'd like. Several existing behaviors exist
+because a specific workflow demanded them — `sync:`, `--watch`, `shadow_context:` — and knowing the
+workflow makes it much easier to judge a proposal.
+
+Some things are deliberate non-goals; check [Concepts](Concepts#design-stance) first:
+
+- a background daemon or service
+- full Compose spec coverage in `compose-native` (bounded by the upstream gap it exists to fill)
+- picking a default third-party compose-for-`wslc` tool or rsync image
+
+## Contributing a fix
+
+See [Development](Development) and
+[CONTRIBUTING.md](https://github.com/slidict/wip/blob/main/CONTRIBUTING.md).
+
+## Related
+
+- [Troubleshooting & FAQ](Troubleshooting-and-FAQ)
+- [Debug Output](Debug-Output)
+- [Secret Masking](Secret-Masking)

--- a/wiki/Restart-Policies.md
+++ b/wiki/Restart-Policies.md
@@ -1,0 +1,131 @@
+# Restart Policies
+
+`restart:` records what should happen when a container exits. `wslc` has no restart policy of its
+own, so the value is inert until something acts on it — and the only thing that does is
+[`wip up --watch`](wip-up).
+
+## Declaring it
+
+```yaml
+# mode: container
+dependencies:
+  app:
+    image: your/image:tag
+    restart: unless-stopped
+  worker:
+    image: your/image:tag
+    command: bundle exec sidekiq
+    restart: on-failure:3
+```
+
+```yaml
+# compose.yml, under mode: compose-native
+services:
+  worker:
+    image: your/image:tag
+    restart: always
+```
+
+## Accepted values
+
+| Value | `--watch` restarts an exited container? |
+|---|---|
+| `no` (default) | no |
+| `always` | yes |
+| `unless-stopped` | yes |
+| `on-failure` | yes |
+| `on-failure:MAX_RETRIES` | yes |
+| anything else | no |
+
+Matching is exact — a typo like `always-restart` stays inert rather than accidentally matching via
+a prefix check. `on-failure` accepts an optional numeric suffix (`on-failure:3`); the number is
+accepted but not currently enforced as a retry cap.
+
+### `restart: no` and YAML
+
+An unquoted `no` parses as the boolean `false` in YAML, not the string `"no"`. wip normalizes
+`false`, `null`, and `""` to `"no"` in both `wip.yml` and `compose.yml`, so all of these are
+equivalent:
+
+```yaml
+restart: no
+restart: "no"
+restart:
+# (key omitted entirely)
+```
+
+### compose.yml values are not policed
+
+The compose parser accepts any `restart:` value as-is, including ones outside
+`always`/`unless-stopped`/`on-failure[:N]`. A `compose.yml` predates wip and is read by other
+tools; rejecting a valid Compose value would break projects that work today. `wip up --watch`
+simply doesn't act on values it doesn't recognize.
+
+## How `wip up --watch` acts on it
+
+```console
+$ wip up --watch
+wip: watching app, mysql for exited restart: containers every 5s (running detached; Ctrl-C to stop)
+```
+
+Each tick, for every dependency (the primary container included):
+
+1. read its `restart:` — skip unless it's one of the restarting values
+2. probe its current state via `wslc list --all --filter name=… --format json`
+3. if `State` is `3` (exited), run `wslc start <name>`
+
+```console
+wip: 'worker' has exited, restarting it (restart: on-failure:3)
+```
+
+`--interval N` sets the poll period (default `5` seconds). A non-positive value is rejected
+*before* anything is started:
+
+```
+--interval must be a positive number
+```
+
+## Known limitations
+
+These follow directly from polling, and are worth knowing before you rely on it:
+
+- **Status-based, not event-based.** Each tick asks "is it exited right now?", not "did it just
+  exit?" A container that crashes and is restarted by something else between ticks is invisible.
+- **Exit codes are not read.** All three restarting values behave identically — an exited
+  container is restarted regardless of exit status, unlike real `on-failure`, which skips a clean
+  (zero) exit. Reading the code would need a heavier call this loop doesn't make.
+- **Races with manual `stop`/`down`.** The loop can't tell "crashed on its own" from "you ran
+  `wip stop` in another terminal", so it may restart what you just stopped. `Ctrl-C` the watch
+  loop first.
+- **Foreground only.** It's a loop in your terminal, not a daemon. Closing the terminal stops
+  supervision. See [Concepts](Concepts#design-stance).
+- **`--watch` implies `-d`.** The primary container can't hold an attached TTY and be polled on the
+  same thread, so it always runs detached under `--watch`, whether or not you passed `-d`.
+- **Not available under `mode: compose`.** wip never parses a service list there, so there's
+  nothing to poll:
+  ```
+  `wip up --watch` is not supported under mode: compose (wip never parses a compose.yml
+  service list in that mode, so there is nothing to poll)
+  ```
+  Use whatever restart support your compose tool offers.
+- **`deleted` is not `exited`.** A removed container (state `4`) needs a fresh `wip up` to be
+  recreated; `--watch` will never bring it back.
+
+## Debugging "it never restarts"
+
+Run the loop with `--debug`. wip logs the raw `wslc list` entry it read for each dependency, so you
+can compare the reported `State` against the enum:
+
+```console
+$ wip up --watch --debug
+wip: [debug] 'worker': {"Name"=>"worker", "State"=>3, …}
+```
+
+`0` invalid, `1` created, `2` running, `3` exited, `4` deleted — see
+[Glossary](Glossary#wslccontainerstate).
+
+## Related
+
+- [wip up](wip-up)
+- [Auto Restarting Containers](Auto-Restarting-Containers) — worked example
+- [Dependencies](Dependencies)

--- a/wiki/Reusing-an-Existing-compose-yml.md
+++ b/wiki/Reusing-an-Existing-compose-yml.md
@@ -1,0 +1,161 @@
+# Reusing an Existing compose.yml
+
+You have a working `compose.yml` and don't want to duplicate it into `wip.yml`. There are two ways
+to reuse it, and the choice is really about whether you want to install an external binary.
+
+## The two options
+
+| | [`mode: compose-native`](Compose-Native-Mode) | [`mode: compose`](Compose-Mode) |
+|---|---|---|
+| External binary | none | required (`compose.command`) |
+| Compose coverage | a [documented subset](Compose-File-Support) | whatever your tool supports |
+| `wip run` | real `wslc run --rm` | falls back to `exec` |
+| `wip logs` | one service | multi-service |
+| `wip up --watch` | yes | no |
+| `type: run` / `type: build` interactions | yes | no |
+| `sync:` | works like container mode | needs `sync.image`/`sync.build`, `mode: run` only |
+
+**Start with `compose-native`.** Fall back to `compose` only when your file needs something outside
+the subset.
+
+## Try compose-native first
+
+```yaml
+# wip.yml
+version: 1
+mode: compose-native
+
+compose:
+  service: app       # which service is "the app"
+  project: myapp     # optional; also names the network
+```
+
+```bash
+wip doctor
+```
+
+`wip doctor` parses the file and reports the first thing it can't handle:
+
+```console
+[OK]   Found compose file /home/me/app/compose.yml
+[FAIL] compose.yml: services.app has unsupported key(s): healthcheck
+```
+
+If it parses, you're done:
+
+```console
+[OK] Parsed compose file
+```
+
+Then confirm wip read it the way you expect:
+
+```bash
+wip config
+```
+
+## Common blockers and what to do
+
+| Blocker | Options |
+|---|---|
+| `healthcheck:` + `depends_on: {condition: service_healthy}` | Drop the condition and let the app retry its DB connection on boot, or switch to `mode: compose` |
+| `deploy:` / `replicas:` | No scaling support — switch to `mode: compose` |
+| Long-syntax `volumes:` / `ports:` | Rewrite as short syntax (`"./src:/app"`, `"3000:3000"`) where possible |
+| `env_file:` | Move the values into `.env` next to `wip.yml` ([Env Files](Env-Files)) or inline them in `environment:` |
+| `extends:` | Inline it, or use YAML anchors — aliases are enabled in `compose.yml` |
+| `entrypoint:` | Fold into `command:`, or bake it into the image |
+| `profiles:` | Fine — gated services are skipped ([Compose Profiles](Compose-Profiles)) |
+| `tty:` / `stdin_open:` / `networks:` / `cap_add:` | Fine — accepted and ignored |
+
+Full list: [Compose File Support](Compose-File-Support).
+
+## Falling back to `mode: compose`
+
+Install a compose-for-`wslc` tool ([candidates](Third-Party-Compose-Tools)), then:
+
+```yaml
+version: 1
+mode: compose
+
+compose:
+  service: app
+  command: wslc-compose     # the binary you installed
+  file: compose.yml         # optional
+  project: myapp            # optional
+```
+
+```bash
+wip doctor       # confirms the binary resolves and responds to `version`
+```
+
+Then accept the constraints on that page: exec-only interactions, `wip run` falling back to
+`exec`, no `--watch`.
+
+## Keeping both files honest
+
+Whichever mode you pick, `compose.yml` stays the source of truth for services and `wip.yml` stays
+the source of truth for *your commands*:
+
+```yaml
+# wip.yml
+version: 1
+mode: compose-native
+compose:
+  service: app
+
+interaction:
+  rails:
+    command: bin/rails
+    interactive: true
+  rspec:
+    command: bundle exec rspec
+  console:
+    command: bin/rails console
+    interactive: true
+```
+
+Nothing about the services is duplicated. Other tooling (CI, a teammate on plain Docker) keeps
+using `compose.yml` unchanged.
+
+## Adding sync to a compose project
+
+Under **compose-native**, sync behaves exactly like container mode — wip rewrites the primary
+service's mounts for you:
+
+```yaml
+sync:
+  exclude: [".git", "tmp/", "node_modules/"]
+```
+
+Under **`mode: compose`**, wip rewrites nothing. Your compose service must declare the volume
+itself:
+
+```yaml
+# compose.yml
+services:
+  app:
+    volumes:
+      - app-src:/app
+volumes:
+  app-src:
+```
+
+```yaml
+# wip.yml
+sync:
+  volume: app-src
+  target: /app
+  mode: run
+  build:
+    dockerfile: |
+      FROM alpine:latest
+      RUN apk add --no-cache rsync
+```
+
+See [Sync Modes](Sync-Modes).
+
+## Related
+
+- [Compose Native Mode](Compose-Native-Mode)
+- [Compose Mode](Compose-Mode)
+- [Compose File Support](Compose-File-Support)
+- [wip vs docker compose](wip-vs-docker-compose)

--- a/wiki/Secret-Masking.md
+++ b/wiki/Secret-Masking.md
@@ -1,0 +1,81 @@
+# Secret Masking
+
+wip masks secret-looking values in two places: `wip config` output, and `--debug` command logs.
+Neither is encryption — they exist so that pasting output into an issue or a chat doesn't leak
+credentials.
+
+## In `wip config`
+
+Any **key** matching this pattern, case-insensitively, has its value replaced with `[REDACTED]`:
+
+```
+token | password | secret | credential | auth
+```
+
+The match is a substring match on the key name, applied recursively through the whole config —
+nested hashes and arrays included.
+
+```console
+$ wip config
+---
+dependencies:
+  development.mysql:
+    env:
+      MYSQL_ROOT_PASSWORD: "[REDACTED]"
+      MYSQL_DATABASE: development
+```
+
+`MYSQL_ROOT_PASSWORD` matches (`password`). `MYSQL_DATABASE` doesn't, and is printed as-is.
+
+### What it misses
+
+The pattern is a heuristic on key names. These are **not** masked:
+
+```yaml
+env:
+  API_KEY: sk-live-…          # "key" isn't in the pattern
+  DATABASE_URL: postgres://user:pw@db/app   # secret is inside the value
+  PRIVATE_PEM: "-----BEGIN…"
+```
+
+Don't treat unmasked output as "safe to share" — read it before pasting.
+
+## In `--debug` output
+
+Every logged command masks `-e KEY=value` pairs, regardless of the key name:
+
+```console
+$ wip rails c --debug
+wip: [debug] running: wslc.exe exec -it -w /app -e RAILS_ENV=*** -e DATABASE_URL=*** app bin/rails c
+```
+
+This is a blanket rule on the flag, not a pattern on the key — so it covers `API_KEY` and
+`DATABASE_URL` too. Other flags (`-v`, `-p`, `-u`) are printed verbatim, so a credential embedded
+in a volume path or a URL passed as a positional argument would still show.
+
+## What is not protected
+
+- **`wip.yml` on disk** is a plain file. Committing secrets there commits them.
+- **The container's environment.** Anything you pass reaches the process; `wslc exec … env` shows it.
+- **Shell history**, if you pass secrets as CLI arguments to an interaction.
+- **The `.env` file**, unless it's gitignored.
+
+## Recommended handling
+
+1. Keep real secrets in `.env`, not `wip.yml`.
+2. Make sure `.env` is ignored:
+   ```bash
+   echo '.env' >> .gitignore
+   git check-ignore .env
+   ```
+3. Reference them from `wip.yml` only by name (they're merged in automatically — see
+   [Env Files](Env-Files)).
+4. For anything genuinely sensitive, prefer your runtime environment or a secret manager over a
+   file in the repo at all.
+
+## Related
+
+- [Env Files](Env-Files)
+- [wip config](wip-config)
+- [Debug Output](Debug-Output)
+- [Reporting Issues](Reporting-Issues) — what's safe to attach to a bug report

--- a/wiki/Shadow-Build-Context.md
+++ b/wiki/Shadow-Build-Context.md
@@ -1,0 +1,127 @@
+# Shadow Build Context
+
+An optimization for projects living on WSL's native filesystem. It keeps a persistent copy of the
+build context on the **Windows** filesystem, so `wslc build` reads from fast local storage instead
+of pulling the tree across the VM boundary on every build.
+
+## The problem
+
+WSLC containers run in their own VM. A build context on the WSL side has to be shared in over
+virtiofs, file by file. For a project with tens of thousands of files, that transfer dominates the
+build — and it happens again on every single build, even when nothing changed.
+
+Projects already on `/mnt/c` (or another mounted Windows drive) don't have this problem: the files
+are already where the VM can read them cheaply.
+
+## Enabling it
+
+On a build interaction:
+
+```yaml
+interaction:
+  build:
+    type: build
+    context: .
+    tag: myapp:dev
+    shadow_context: /mnt/c/Users/me/AppData/Local/wip/build-contexts
+```
+
+On a compose-native service's `build:`:
+
+```yaml
+# compose.yml
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      shadow_context: /mnt/c/Users/me/AppData/Local/wip/build-contexts
+```
+
+Point it at a directory on the Windows filesystem. wip creates a subdirectory per source path
+underneath it, so one root can serve every project on the machine.
+
+## When it actually applies
+
+All three must hold, or wip silently builds directly instead:
+
+| Condition | Why |
+|---|---|
+| `shadow_context:` is set | opt-in; no default |
+| Running on WSL2 | WSL1 (and anything else) has no VM boundary to optimize across |
+| The context is **not** under `/mnt/<drive>` | already Windows-side; copying would only add work |
+
+You can tell which path was taken from the build output:
+
+```console
+wip: using shadow build context at /mnt/c/Users/me/AppData/Local/wip/build-contexts/<hash>/context
+```
+
+## How the incremental sync works
+
+Inside the shadow root, wip keeps one directory per source path, keyed by a hash of that path:
+
+```
+<shadow_root>/
+  <sha256-of-context-path>/
+    lock            # exclusive lock held for the duration of a build
+    manifest.json   # what was copied last time, and its fingerprints
+    context/        # the actual staged context handed to wslc
+```
+
+On each build:
+
+1. Walk the context, applying [`.dockerignore`](Dockerignore).
+2. Fingerprint every included file — symlinks by target, regular files by size + mtime (nanosecond
+   precision) + mode.
+3. Compare against `manifest.json`:
+   - **changed or new** → copied
+   - **removed, or newly ignored** → deleted from the shadow, pruning directories left empty
+   - **unchanged** → skipped entirely
+4. Write the new manifest and run `wslc build` against `context/`.
+
+So the first build copies everything; later builds copy only the delta.
+
+### Robustness details worth knowing
+
+- **An exclusive file lock** is held across the whole build, so two concurrent `wip build` runs on
+  the same context can't corrupt the shadow.
+- **Copies are atomic** — each entry is written to a temp name and renamed into place, so an
+  interrupted build leaves the previous copy intact rather than a half-written file.
+- **File modes are preserved**, so an executable stays executable even on a DrvFs mount whose
+  `fmask` would otherwise strip the bit and break a `RUN ./script`.
+- **A missing or unparsable manifest** discards the shadow and rebuilds it from scratch, rather
+  than leaving stale, deleted, or newly-ignored files in place.
+- **Symlinks stay symlinks** — never dereferenced.
+
+## Restrictions
+
+The shadow root must live **outside** the build context. Otherwise the next build would walk the
+shadow, copy it into itself, and grow without bound:
+
+```
+shadow_context (/home/me/app/.shadow) must not be inside the build context (/home/me/app)
+```
+
+The value must also be a non-empty string, and only makes sense on a `type: build` command:
+
+```
+commands.build.shadow_context must be a non-empty path for a build command
+```
+
+## Choosing a location
+
+Anything under your Windows user profile works. `AppData/Local` is a good default because it's
+machine-local and excluded from roaming profiles:
+
+```
+/mnt/c/Users/<you>/AppData/Local/wip/build-contexts
+```
+
+Avoid a synced folder (OneDrive, Dropbox) — you'd be paying sync cost on every build.
+
+## Related
+
+- [Dockerignore](Dockerignore) — what gets included in the first place
+- [wip build](wip-build)
+- [Compose Build](Compose-Build)

--- a/wiki/Source-Sync.md
+++ b/wiki/Source-Sync.md
@@ -1,0 +1,171 @@
+# Source Sync
+
+`sync:` mirrors your source tree into a named volume instead of bind-mounting it live, so the
+running app reads from fast storage inside the VM. It's the fix for the slow-boot problem described
+in [Fixing a Slow Boot](Fixing-a-Slow-Boot).
+
+Entirely optional. `sync: {}` alone already works — every key below has a default.
+
+## What it changes
+
+```
+without sync:                     with sync:
+  host ./  ──(virtiofs)──► /app     host ./ ──(virtiofs, read-only)──► /host-src
+                                                                          │ rsync
+                                                                          ▼
+                                    named volume app-src ──────────────► /app
+```
+
+The app only ever touches the volume. The bind mount still exists, but nothing reads from it
+except `rsync`, in bulk, on demand.
+
+## Minimal config
+
+```yaml
+sync:
+  exclude:
+    - .git
+    - tmp/
+    - node_modules/
+```
+
+## Every parameter
+
+```yaml
+sync:
+  source: .          # host path, relative to wip.yml (default: the wip.yml directory)
+  target: /app       # container path served by the volume
+  volume: app-src    # named volume holding the mirror
+  mount: /host-src   # where the source is bind-mounted read-only
+  exclude:           # rsync --exclude patterns
+    - .git
+    - tmp/
+  delete: true       # rsync --delete
+  command: rsync     # binary that does the mirroring
+  options: []        # extra flags appended to the rsync invocation
+  interval: 2        # seconds between syncs for `wip sync --watch`
+  mode: exec         # exec | run — see Sync Modes
+  image: null        # image for the mirror container
+  build:             # or have wip build that image itself
+    dockerfile: |
+      FROM alpine:latest
+      RUN apk add --no-cache rsync
+    tag: null
+```
+
+| Key | Default | Notes |
+|---|---|---|
+| `source` | the `wip.yml` directory | expanded against `wip.yml`, so it's identical from any subdirectory |
+| `target` | the primary container's `workdir`, else `/app` | must be absolute |
+| `volume` | `<container>-src` (`wip-src` if no container is named) | |
+| `mount` | `/host-src` | must be absolute, and must differ from `target` |
+| `exclude` | `[]` | each becomes `--exclude=PATTERN` |
+| `delete` | `true` | adds `--delete` |
+| `command` | `rsync` | point it at any tool with compatible flags |
+| `options` | `[]` | appended verbatim after the excludes |
+| `interval` | `2` | must be a positive number |
+| `mode` | `exec` (`run` under `mode: compose`) | see [Sync Modes](Sync-Modes) |
+| `image` / `build` | unset | see [Sync Modes](Sync-Modes) |
+
+## The rsync invocation
+
+```
+rsync -r -l -t --whole-file [--delete] [--exclude=… …] [options…] /host-src/ /app/
+```
+
+The base flags are deliberately minimal for a local-to-local mirror:
+
+| Flag | Why |
+|---|---|
+| `-r` | walk the tree |
+| `-l` | keep symlinks as symlinks |
+| `-t` | preserve mtimes, so re-syncs quick-check (size + mtime) instead of re-transferring |
+| `--whole-file` | skip the delta-transfer checksum pass, which only pays off over a slow network |
+
+Owner/group/permission preservation (`-o -g -p`, part of `-a`) is intentionally left out, since
+both sides are the same user. Add them back via `options: ["-o", "-g", "-p"]` if your project needs
+them.
+
+The trailing slashes on both paths matter: they copy the *contents* of the mount into the target
+rather than nesting it one directory deeper.
+
+## Mount rewriting
+
+With `sync:` configured, wip rewrites the **primary** container's volumes:
+
+- Any entry mounting `target` (or `mount`) — the usual `.:/app` — is dropped and replaced by
+  `<source>:/host-src:ro` plus `<volume>:/app`.
+- Every other volume (`bundle:/usr/local/bundle`, …) passes through untouched.
+- Sidecar `dependencies:` entries are never rewritten.
+
+Matching accounts for trailing mount options, so `.:/app:ro`, `.:/app:cached`, and `.:/app/` are
+all recognized as mounting the target.
+
+Under [`mode: compose`](Compose-Mode) no rewriting happens at all — compose owns the volume layout,
+so your compose service must declare the volume itself. See [Sync Modes](Sync-Modes).
+
+## When mirroring happens
+
+| Trigger | What runs |
+|---|---|
+| `wip up` | one mirror before the primary container boots (skip with `--no-sync`) |
+| `wip sync` | one mirror on demand |
+| `wip sync --watch` | a mirror every `interval` seconds until `Ctrl-C` |
+
+```console
+$ wip up -d
+wip: syncing /home/me/app -> app-src:/app
+wip: run `wip sync --watch` in another terminal to keep /app up to date
+```
+
+## The two things to keep in mind
+
+**1. rsync must exist somewhere.** Under `sync.mode: exec` it runs *inside* your app image, so that
+image needs it:
+
+```dockerfile
+RUN apt-get update && apt-get install -y rsync
+```
+
+Or point `sync.command` at a copy tool the image already has. See [rsync Not Found](rsync-Not-Found).
+
+**2. The mirror is one-way (host → volume).** Anything the app writes under `target` is removed by
+the next `--delete` pass. Three ways out:
+
+- `exclude` the path (`tmp/`, `log/`, `node_modules/`)
+- give it its own volume (`- bundle:/usr/local/bundle`)
+- set `delete: false`
+
+Generated files you *want* back on the host (a scaffold generator's output, a migration file) won't
+come back on their own — that's the trade-off for not paying the virtiofs cost.
+
+## Default `exclude` per `wip init --template`
+
+| `--template` | Stack | Default `exclude` |
+|---|---|---|
+| `rails` | Rails | `.git`, `log/`, `tmp/`, `storage/`, `public/assets/`, `public/packs/`, `.bundle/`, `vendor/bundle/`, `coverage/`, `node_modules/` |
+| `node` | Node.js | `.git`, `node_modules/`, `dist/`, `build/`, `.next/`, `.cache/`, `coverage/` |
+| `rust` | Rust | `.git`, `target/` |
+| `csharp` | C# | `.git`, `bin/`, `obj/`, `.vs/`, `packages/` |
+| *(omitted)* | — | `.git`, `tmp/`, `node_modules/` |
+
+These are written live into the generated `wip.yml` by [wip init](wip-init), mirroring each stack's
+own `github/gitignore` template.
+
+## Diagnostics
+
+```console
+$ wip doctor
+[OK] Sync source /home/me/app mirrors into volume app-src at /app
+```
+
+`wip doctor` fails if the source directory doesn't exist, and warns if you set `sync.image` /
+`sync.build` while using `sync.mode: exec` — those only cover the pre-boot mirror. See
+[wip doctor](wip-doctor).
+
+## Related
+
+- [Sync Modes](Sync-Modes) — `exec` vs. `run`, and the image requirements
+- [wip sync](wip-sync)
+- [Fixing a Slow Boot](Fixing-a-Slow-Boot) — why this exists
+- [Continuous Sync](Continuous-Sync) — the two-terminal workflow

--- a/wiki/Sync-Modes.md
+++ b/wiki/Sync-Modes.md
@@ -1,0 +1,115 @@
+# Sync Modes
+
+`sync.mode` decides **where** the mirror runs: inside the already-running app container (`exec`),
+or in a throwaway container wip boots just for it (`run`). That choice determines which image needs
+`rsync` installed.
+
+## The two modes
+
+| | `exec` | `run` |
+|---|---|---|
+| Where rsync runs | inside the running primary container | in a fresh `wslc run --rm` container |
+| Needs the app image to have rsync | **yes** | no |
+| Uses `sync.image` / `sync.build` | no (ignored) | yes |
+| Requires the container to be up | yes | no |
+| Overhead per mirror | none | one container start |
+| Default under `mode: container` / `compose-native` | ✔ | |
+| Default under `mode: compose` | | ✔ (and `exec` is rejected) |
+
+The mode is fixed by config, not guessed from whether a container happens to be running. That's
+deliberate: a mirror that silently changes behavior depending on machine state is a bad thing to
+debug.
+
+## The one exception: `wip up`'s pre-boot mirror
+
+`wip up` mirrors the source **before** the primary container exists, so that step always uses a
+throwaway container — regardless of `sync.mode`.
+
+This is the single most confusing thing about sync, so stated plainly:
+
+| Step | Container used | Image used |
+|---|---|---|
+| `wip up`'s pre-boot mirror | throwaway | `sync.build`'s tag → `sync.image` → the primary entry's image |
+| `wip sync` / `--watch` under `mode: exec` | the running primary container | the primary container's own image |
+| `wip sync` / `--watch` under `mode: run` | throwaway | `sync.build`'s tag → `sync.image` → the primary entry's image |
+
+So under the default `exec` mode, **both** images may need `rsync`: the throwaway one for pre-boot
+(which falls back to your app image anyway, unless you set `sync.image`/`sync.build`), and the app
+image for every later mirror.
+
+`wip doctor` warns about exactly this case:
+
+```
+[WARN] sync.image/sync.build only cover `wip up`'s one-time pre-boot mirror (the primary
+container isn't running yet, so that step always uses a throwaway container) — sync.mode:
+exec's `wip sync`/`wip sync --watch` run rsync inside the primary container instead, so its
+image needs rsync too
+```
+
+## Image resolution for the throwaway container
+
+In order:
+
+1. `sync.build`'s tag, if `sync.build` is configured (built first — see below)
+2. `sync.image`, if set
+3. the primary `dependencies:` entry's own `image`
+
+Under [`mode: compose`](Compose-Mode) step 3 doesn't exist — there's no `dependencies:` entry to
+borrow from — so one of `sync.image` / `sync.build` is **required**:
+
+```
+sync.image or sync.build is required under mode: compose (there's no dependencies: entry to
+borrow the mirror container's image from)
+```
+
+## Why `exec` is rejected under `mode: compose`
+
+```
+sync.mode: exec needs mode: container (compose owns its services' mounts, so it can't
+guarantee the running container has the sync mounts attached)
+```
+
+Only a container wip itself booted is guaranteed to have both the read-only source mount and the
+named volume attached. A compose service's mounts come from `compose.yml`, which wip doesn't
+rewrite. Running rsync inside it would mirror from a path that isn't there.
+
+## `sync.build`: a dedicated mirror image
+
+Under `sync.mode: run`, a fresh container starts on every mirror. Reusing your app's full image for
+something that only ever runs `rsync` just adds startup overhead. wip doesn't publish or default to
+a minimal image (same reasoning as `compose.command` — picking a third-party image for you isn't
+its call), but it can build one for you:
+
+```yaml
+sync:
+  mode: run
+  build:
+    dockerfile: |
+      FROM alpine:latest
+      RUN apk add --no-cache rsync
+    tag: my-sync:latest      # optional; default: wip-sync-<container>:latest
+```
+
+- The Dockerfile is written to a temp directory and built with `wslc build -t <tag> .`.
+- It's built **once per `wip up` / `wip sync` invocation** — including once before a `--watch` loop
+  starts, not on every tick.
+- `sync.build.dockerfile` must be non-empty (`sync.build.dockerfile must not be empty`).
+- If both are set, `sync.build`'s tag wins over `sync.image` — so don't configure both.
+
+Prefer managing the image yourself? Build and tag it however you like, then set `sync.image` to
+that tag.
+
+## Choosing
+
+| Situation | Mode |
+|---|---|
+| `mode: container` / `compose-native`, app image has (or can get) rsync | `exec` — fastest |
+| App image must stay minimal, you'd rather not add rsync to it | `run` + `sync.build` |
+| `mode: compose` | `run` (forced) + `sync.image` or `sync.build` (required) |
+
+## Related
+
+- [Source Sync](Source-Sync) — the full parameter list
+- [wip sync](wip-sync)
+- [rsync Not Found](rsync-Not-Found)
+- [Continuous Sync](Continuous-Sync)

--- a/wiki/TTY-Allocation.md
+++ b/wiki/TTY-Allocation.md
@@ -1,0 +1,105 @@
+# TTY Allocation
+
+Whether wip passes `-it` to `wslc` — and therefore whether you get an interactive terminal — is
+decided by combining three things.
+
+## The rule
+
+```
+TTY allocated  =  (config says interactive)  AND  (CLI didn't say otherwise)  AND  (stdin and stdout are both real TTYs)
+```
+
+All three must hold. Any one of them false means no `-it`.
+
+| Input | Where it comes from |
+|---|---|
+| **Config** | `interactive:` on the interaction, or on the `dependencies:` entry |
+| **CLI** | `--no-interactive` on `exec` / `run` (interactive is the default flag value) |
+| **Reality** | both `$stdin` and `$stdout` report as TTYs |
+
+## Defaults
+
+| Context | Default `interactive` |
+|---|---|
+| `dependencies:` entry | `false` |
+| `interaction:` entry | `false` |
+| `wip exec` / `wip run` CLI flag | `true` (disable with `--no-interactive`) |
+| `wip shell` | `true` |
+| `wip up` (attached, i.e. no `-d`) | `true` |
+| `wip up -d` | `false` |
+
+So `wip exec bash` gets a TTY in a terminal, but `wip rspec` (an interaction with no
+`interactive: true`) does not — unless you ask for it:
+
+```yaml
+interaction:
+  rails:
+    command: bin/rails
+    interactive: true      # needed for `wip rails console`
+  rspec:
+    command: bundle exec rspec   # no TTY needed
+```
+
+## The reality check exists so pipes work
+
+Because wip verifies that both streams are real TTYs, this behaves correctly with no extra flags:
+
+```bash
+wip rspec                    # interactive terminal → TTY if configured
+wip rspec | tee out.txt      # stdout is a pipe → no TTY
+wip rspec > out.txt          # same
+echo y | wip exec bin/thing  # stdin is a pipe → no TTY
+```
+
+In CI, neither stream is a TTY, so nothing is allocated even if `interactive: true` is set. You
+generally don't need `--no-interactive` in CI — though passing it is harmless and explicit. See
+[Using wip in CI](Using-wip-in-CI).
+
+## compose.yml `tty:` / `stdin_open:` are ignored
+
+Under [compose-native mode](Compose-Native-Mode), those keys are accepted and silently ignored.
+TTY allocation is a per-invocation decision — `wip rspec` and `wip rails console` against the same
+service want different answers — not a fixed property of a service. See
+[Compose File Support](Compose-File-Support).
+
+## What "interactive" changes mechanically
+
+When a TTY is allocated, wip runs the child behind a **pseudo-terminal** rather than piping its
+streams:
+
+- the child gets a genuine controlling terminal: job control, `Ctrl-C` → `SIGINT`, `isatty()`-gated
+  colored output all work
+- output still routes through wip first, so error hints can be generated — inherited file
+  descriptors would bypass wip entirely
+- wip's own terminal switches to raw mode so only the pty echoes your keystrokes
+- the pty is sized to your terminal and re-synced on `SIGWINCH`, so `less` / `vim` / `htop` render
+  correctly across a window resize
+
+Without a TTY, streams are piped and pumped, which closes the child's stdin immediately — fine for
+`rspec`, fatal for `rails console`.
+
+On native Windows there's no `openpty`, so wip lets the child inherit its real stdio instead.
+Everything still works; wip just can't observe the output, so no error hints on that path.
+
+## Under compose mode
+
+The bridge inverts the flag: `-T` (disable pseudo-TTY) is added when **non**-interactive, matching
+the Compose CLI's own convention.
+
+## Debugging
+
+`--debug` shows the resolved command, `-it` included or not:
+
+```console
+wip: [debug] running: wslc.exe exec -it -w /app app bin/rails c
+wip: [debug] running: wslc.exe exec -w /app app bundle exec rspec
+```
+
+If a console exits immediately with an EOF-ish error, that's a missing `-it` — check
+`interactive: true` and whether your terminal is really a TTY.
+
+## Related
+
+- [Interactions](Interactions)
+- [wip exec](wip-exec) / [wip run](wip-run) / [wip shell](wip-shell)
+- [Using wip in CI](Using-wip-in-CI)

--- a/wiki/Testing-and-Linting.md
+++ b/wiki/Testing-and-Linting.md
@@ -1,0 +1,142 @@
+# Testing and Linting
+
+## Running them
+
+```bash
+bundle exec rspec     # unit tests
+bundle exec rubocop   # style/lint
+bundle exec rake      # both — the default task
+```
+
+`rake` with no arguments runs `spec` then `rubocop`. CI runs them as separate steps
+(`rake spec`, `rake rubocop`) so a failure names which one.
+
+Useful during development:
+
+```bash
+bundle exec rspec spec/wip/config_spec.rb
+bundle exec rspec spec/wip/config_spec.rb:42
+bundle exec rspec --only-failures
+bundle exec rubocop -a          # safe autocorrect
+bundle exec rubocop -A          # includes unsafe autocorrect — review the diff
+```
+
+## No WSLC required
+
+The suite runs on any platform. Every layer that would touch the outside world is injectable:
+
+| Class | Injection point |
+|---|---|
+| `CommandResolver` | `executable:` — a callable deciding whether a candidate exists |
+| `CommandResolver` | `path:` — the `PATH` string to search |
+| `CommandBuilder` | `wslc:`, `config:`, `environment:`, `dotenv:` — and it only *builds* arrays |
+| `CommandRunner` | `stdin:` / `stdout:` / `stderr:` — `StringIO` in tests |
+| `CommandRunner` | `interpreter:` — a stub `ErrorInterpreter` |
+| `Doctor` | `loader:`, `resolver:`, `environment:`, `compose_resolver:` |
+| `Environment` | `stdin:` / `stdout:` for TTY detection |
+| `DebugReporter` / `ResourceMonitor` / `StagingProgress` | `out:` |
+
+Keep it that way. A change that hardcodes a real filesystem path, a real `PATH` lookup, or a real
+spawn makes that code untestable on CI.
+
+## Where a test belongs
+
+One spec file per class, mirroring `lib/`:
+
+```
+lib/wip/config.rb          →  spec/wip/config_spec.rb
+lib/wip/compose_file.rb    →  spec/wip/compose_file_spec.rb
+lib/wip/command_builder.rb →  spec/wip/command_builder_spec.rb
+```
+
+Test at the layer that owns the behavior:
+
+| Behavior | Spec |
+|---|---|
+| A validation rule / a `ConfigError` | `config_spec.rb`, `sync_settings_spec.rb`, `compose_file_spec.rb` |
+| The exact `wslc` arguments produced | `command_builder_spec.rb`, `compose_bridge_spec.rb` |
+| A diagnostic's level and message | `doctor_spec.rb` |
+| Flag parsing, command wiring, orchestration order | `cli_spec.rb` |
+| `.dockerignore` matching, staging, shadow sync | `docker_ignore_spec.rb`, `build_context_spec.rb` |
+
+Prefer the narrowest layer. A new `wip.yml` rule is a `config_spec.rb` test, not an end-to-end CLI
+test that happens to exercise it.
+
+## What a good test asserts
+
+**For command construction — the exact array:**
+
+```ruby
+expect(builder.exec(['bin/rails', 'c'], interactive: true)).to eq(
+  ['wslc.exe', 'exec', '-it', '-w', '/app', '-e', 'RAILS_ENV=development', 'app', 'bin/rails', 'c']
+)
+```
+
+Arrays, not joined strings — the array *is* the injection-safety guarantee.
+
+**For validation — the message, not just the class:**
+
+```ruby
+expect { described_class.new(raw) }
+  .to raise_error(Wip::ConfigError, /container: must be set when dependencies: has entries/)
+```
+
+Every `ConfigError` in this codebase names the offending key. Asserting on the message keeps that
+property from eroding.
+
+**For defaults — assert the default explicitly**, so a change to it is a visible test failure.
+
+## RuboCop configuration
+
+`.rubocop.yml`:
+
+| Setting | Value |
+|---|---|
+| `TargetRubyVersion` | 3.2 |
+| `NewCops` | enabled |
+| `Layout/LineLength` | 120 |
+| `Metrics/MethodLength` | 20 |
+| `Metrics/AbcSize` | 25 |
+| `Metrics/ClassLength` | 160, waived for `cli.rb`, `compose_file.rb`, `config.rb` |
+| `Metrics/BlockLength` | waived for `spec/**/*` |
+
+Every file starts with `# frozen_string_literal: true`.
+
+The three class-length exemptions are acknowledged debt, not permission to keep growing those
+files. Prefer extracting a collaborator over widening the waiver.
+
+### Inline disables
+
+Occasionally necessary — with a reason:
+
+```ruby
+file = File.open(path, 'a') # rubocop:disable Style/FileOpen -- closed by `step`'s ensure block
+```
+
+A bare `rubocop:disable` with no explanation will get a review comment.
+
+## The CI matrix
+
+`.github/workflows/test.yml`, on every PR and every push to `main`:
+
+- Ruby **3.2, 3.3, 3.4, 4.0** (`fail-fast: false`)
+- `bundle exec rake spec`
+- `bundle exec rake rubocop`
+- CLI smoke test: `bundle exec exe/wip help | grep -q '^Commands:'`
+
+The smoke test is a cheap guard against a change that breaks the executable while every unit test
+still passes.
+
+## Before opening a PR
+
+```bash
+bundle exec rake
+```
+
+Clean output, on the oldest supported Ruby if you can — 3.2 is the target version, and syntax newer
+than that will pass locally on 3.4 and fail in CI.
+
+## Related
+
+- [Development](Development)
+- [Architecture](Architecture)

--- a/wiki/Third-Party-Compose-Tools.md
+++ b/wiki/Third-Party-Compose-Tools.md
@@ -1,0 +1,103 @@
+# Third Party Compose Tools
+
+`wslc` has no native Compose support yet — tracked upstream in
+[microsoft/WSL#40948](https://github.com/microsoft/WSL/issues/40948). Independent projects fill the
+gap, and [`mode: compose`](Compose-Mode) bridges to whichever one you install.
+
+## Known implementations
+
+| Project | Language |
+|---|---|
+| [bacarndiaye/wslc-compose](https://github.com/bacarndiaye/wslc-compose) | Python |
+| [inuyume/wslc-compose](https://github.com/inuyume/wslc-compose) | Go |
+
+Others exist and more will appear — `wslc` is new and still evolving. This list is a starting
+point, not an endorsement or an exhaustive survey.
+
+## Why wip doesn't pick one
+
+`compose.command` has **no default**, unlike `wslc.command`, which defaults to `auto` and searches
+a candidate list. That asymmetry is deliberate:
+
+- The ecosystem is young and moving. Baking in a favorite would make wip's behavior depend on
+  someone else's release cadence.
+- Every implementation is treated equally. `compose.command` takes a binary name or an absolute
+  path — nothing about wip prefers one shape of tool.
+- Choosing a third-party dependency for your project isn't wip's call to make.
+
+The same reasoning applies to `sync.image`: wip doesn't publish or default to an rsync image
+either — see [Sync Modes](Sync-Modes).
+
+## What wip requires of one
+
+Whichever tool you point at must understand this subset of the Compose CLI vocabulary:
+
+```
+<command> -f FILE [-p PROJECT] up [-d]
+<command> -f FILE [-p PROJECT] stop
+<command> -f FILE [-p PROJECT] down
+<command> -f FILE [-p PROJECT] exec [-T] SERVICE COMMAND...
+<command> -f FILE [-p PROJECT] logs [-f] [SERVICE...]
+```
+
+That's all wip drives. Notably absent: `run`, which is why `wip run` falls back to `exec` under
+this mode.
+
+## Configuring it
+
+```yaml
+version: 1
+mode: compose
+compose:
+  service: app
+  command: wslc-compose        # binary name on PATH, or an absolute path
+  file: compose.yml            # optional
+  project: myapp               # optional
+```
+
+```bash
+wip doctor
+```
+
+```console
+[OK] Found wslc-compose
+[OK] compose command is available
+[OK] Found compose file /home/me/app/compose.yml
+```
+
+If the binary can't be resolved, wip says so and points you here:
+
+```
+compose command was not found.
+
+Checked:
+  wslc-compose
+
+wip doesn't bundle or pin a compose-for-wslc implementation — install one and set
+compose.command in wip.yml to its binary name or path, e.g.:
+
+  https://github.com/bacarndiaye/wslc-compose
+  https://github.com/inuyume/wslc-compose
+```
+
+## Do you need one at all?
+
+Often not. [`mode: compose-native`](Compose-Native-Mode) reads the same `compose.yml` with no
+external binary, and gives you a real `wslc run --rm` plus `wip up --watch` that `mode: compose`
+can't. Reach for an external tool when your compose file needs features outside
+[the supported subset](Compose-File-Support) — health checks, scaling, long-syntax mounts,
+`extends`.
+
+Decision help: [Reusing an Existing compose.yml](Reusing-an-Existing-compose-yml).
+
+## When wslc ships Compose support
+
+Both compose modes exist because of the upstream gap. wip's stated intent is that `wip.yml`'s shape
+(`mode:`, `compose:`) stays stable for existing `container` / `compose` / `compose-native` setups,
+so whatever happens once `wslc` catches up won't require rewriting your config.
+
+## Related
+
+- [Compose Mode](Compose-Mode)
+- [Compose Native Mode](Compose-Native-Mode)
+- [Comparison](Comparison)

--- a/wiki/Troubleshooting-and-FAQ.md
+++ b/wiki/Troubleshooting-and-FAQ.md
@@ -1,0 +1,83 @@
+# Troubleshooting & FAQ
+
+Start here when something failed. Each error has its own page with cause, fix, and verification.
+
+## First step, always
+
+```bash
+wip doctor
+```
+
+It checks WSL2, Windows interop, the `wslc` binary, your configuration, the compose file, and the
+sync source in one pass. See [wip doctor](wip-doctor) for what every line means.
+
+Then, if a specific command is failing:
+
+```bash
+wip <the failing command> --debug
+```
+
+See [Debug Output](Debug-Output).
+
+## By error message
+
+| Message (or symptom) | Page |
+|---|---|
+| `WSLC was not found. Checked: …` | [WSLC Not Found](WSLC-Not-Found) |
+| `pull access denied`, `insufficient_scope`, `authorization failed` | [Registry Authentication](Registry-Authentication) |
+| `no matching manifest for linux/amd64` (or `arm64`) | [Architecture Mismatch](Architecture-Mismatch) |
+| `0x8007000e`, "too many mounted volumes" | [Volume Limit Reached](Volume-Limit-Reached) |
+| `rsync: not found`, `executable file not found … rsync` | [rsync Not Found](rsync-Not-Found) |
+| `wip.yml was not found (searched from … to the filesystem root)` | [Config File Discovery](Config-File-Discovery) |
+| Anything mentioning a `wip.yml` / `compose.yml` key | [Configuration Errors](Configuration-Errors) |
+| `Unknown command: NAME` | [wip dispatch](wip-dispatch) |
+| `` `wip logs` is only available in compose mode `` | [wip logs](wip-logs) |
+
+## By symptom
+
+| Symptom | Where to look |
+|---|---|
+| Boot takes minutes; CPU/memory/IO all idle | [Fixing a Slow Boot](Fixing-a-Slow-Boot) |
+| Every build re-sends the whole source tree | [Shadow Build Context](Shadow-Build-Context), [Dockerignore](Dockerignore) |
+| The app can't resolve `db` / `redis` by hostname | [Networking](Networking) |
+| A new `ports:` / `volumes:` / `env:` entry has no effect | `wip down && wip up -d` — see [wip down](wip-down) |
+| Files the container writes keep disappearing | [Source Sync](Source-Sync) — one-way mirror with `--delete` |
+| Host edits don't reach the container | [Continuous Sync](Continuous-Sync) |
+| `rails console` exits immediately with an EOF error | [TTY Allocation](TTY-Allocation) |
+| `wip <name>` runs a built-in instead of my command | [wip dispatch](wip-dispatch) |
+| `wip up --watch` never restarts anything | [Restart Policies](Restart-Policies) |
+| A compose service is missing from `wip config` | [Compose Profiles](Compose-Profiles) |
+| A `${VAR}` in compose.yml came out empty | [Compose Variable Interpolation](Compose-Variable-Interpolation) |
+| `wip run` says it's exec'ing instead | [Compose Mode](Compose-Mode) — expected there |
+
+## Environment problems
+
+### `[FAIL] Not running on WSL2`
+
+wip couldn't find WSL2 markers in `/proc/version` (or, on native Windows, `wsl.exe --status`
+failed). Check your distro is WSL2, not WSL1:
+
+```powershell
+wsl -l -v
+wsl --set-version <distro> 2
+```
+
+### `[FAIL] Windows executable interoperability is disabled`
+
+WSL can't launch `wslc.exe` at all. Usually `/etc/wsl.conf`:
+
+```ini
+[interop]
+enabled = true
+appendWindowsPath = true
+```
+
+Then `wsl --shutdown` from Windows and reopen the shell.
+
+## Questions rather than errors
+
+See [FAQ](FAQ).
+
+## Nothing here covers it
+
+See [Reporting Issues](Reporting-Issues) for what to include in a bug report.

--- a/wiki/Using-wip-in-CI.md
+++ b/wiki/Using-wip-in-CI.md
@@ -1,0 +1,128 @@
+# Using wip in CI
+
+wip is built for interactive development, but nothing stops it running unattended — provided you
+account for the absence of a TTY and the absence of anyone to answer a prompt.
+
+> Note: CI runners rarely have WSL2 and WSLC available. In practice most projects run their tests
+> on plain Docker in CI and use wip locally. This page is for the cases where you do have a
+> WSLC-capable runner (a self-hosted Windows/WSL2 machine, for example).
+
+## TTY handling is already automatic
+
+wip only allocates a TTY when **both** stdin and stdout are real TTYs. In CI neither is, so nothing
+is allocated even for commands configured `interactive: true`. You don't need `--no-interactive` —
+though passing it is harmless and documents the intent:
+
+```bash
+wip exec --no-interactive bundle exec rspec
+```
+
+See [TTY Allocation](TTY-Allocation).
+
+## Exit codes propagate
+
+wip exits with the child's exit code, so a failing test suite fails the step:
+
+| Code | Meaning |
+|---|---|
+| `0` | success |
+| `1` | wip-level failure (`ConfigError`, `wip doctor` found a `[FAIL]`) |
+| `127` | the resolved binary couldn't be executed |
+| `130` | interrupted |
+| `128 + N` | killed by signal `N` |
+| other | passed through from the child |
+
+## A workable pipeline
+
+```bash
+set -euo pipefail
+
+wip version                 # record versions in the log
+wip doctor                  # exits 1 on any [FAIL]
+wip build --no-cache
+wip up -d
+wip exec --no-interactive bundle exec rspec
+wip down
+```
+
+`wip doctor` as a gate is worth it: it turns "the container silently didn't have what it needed"
+into an explicit failure with a message.
+
+## Things to get right
+
+### Never leave a `--watch` loop running
+
+`wip up --watch` and `wip sync --watch` are foreground loops that never exit. A CI step running one
+hangs until the job times out. Use `wip up -d` and `wip sync` (one-shot) instead.
+
+### Always tear down
+
+Containers outlive the process. On a self-hosted runner they'll still be there next build:
+
+```bash
+trap 'wip down || true' EXIT
+```
+
+### Configuration is environment-specific
+
+Use `--config` and `--env-file` rather than mutating files in place:
+
+```bash
+wip --config ci/wip.yml --env-file ci/.env up -d
+```
+
+See [Global Options](Global-Options).
+
+### Secrets
+
+Pass them through the environment or an `--env-file` written at runtime, never a committed
+`wip.yml`. Remember `wip config`'s masking is a key-name heuristic — don't dump config into a
+public build log without reading it. See [Secret Masking](Secret-Masking).
+
+### Registry login happens before wip
+
+```bash
+wslc registry login -u "$REGISTRY_USER" ghcr.io
+wip up -d
+```
+
+See [Registry Authentication](Registry-Authentication).
+
+### Debug output when a build fails
+
+```bash
+wip up -d --debug --debug-log=-
+```
+
+`--debug-log=-` forces resource snapshots inline rather than into a temp file you'd have to hunt
+for afterwards. See [Debug Output](Debug-Output).
+
+## Sync in CI
+
+Usually unnecessary — a CI checkout is a one-shot copy, and the slow-boot problem
+[sync solves](Fixing-a-Slow-Boot) is about repeated interactive boots. If you do use it, note:
+
+- `wip up` mirrors once before boot anyway; no watcher needed.
+- `--no-sync` skips even that, if the image already contains the source.
+- Under `sync.mode: exec`, rsync must exist in the app image.
+
+## Concurrency
+
+Container and network names come from `wip.yml`, so two jobs on the same runner will collide.
+Isolate with per-job config:
+
+```bash
+export JOB_ID="${CI_JOB_ID}"
+wip --config "ci/wip-${JOB_ID}.yml" up -d
+```
+
+Under compose-native, `compose.project` names the network, so varying it per job is enough to keep
+networks apart — container names still come from service names, so you'll want distinct configs
+regardless.
+
+## Related
+
+- [TTY Allocation](TTY-Allocation)
+- [Global Options](Global-Options)
+- [wip doctor](wip-doctor)
+- [CLI Command Reference](CLI-Command-Reference) — the exit code table

--- a/wiki/Volume-Limit-Reached.md
+++ b/wiki/Volume-Limit-Reached.md
@@ -1,0 +1,93 @@
+# Volume Limit Reached
+
+```
+0x8007000e
+```
+
+or "too many mounted volumes" (in whichever language your Windows is set to). The WSLC session has
+run out of mount slots.
+
+## The hint wip prints
+
+```
+The WSLC session has reached its mounted-volume limit.
+
+Stop any containers you no longer need, then restart the session:
+
+  wslc container list
+  wslc container stop <container-name>
+  wslc system session terminate
+
+Then retry the command.
+```
+
+Triggered by output containing `0x8007000e`, "too many mounted volumes", or its Japanese
+equivalent.
+
+## Why it happens
+
+Every bind mount and named volume attached to a running container consumes a slot in the WSLC
+session, and the session has a fixed ceiling. Slots aren't always released promptly when a
+container stops, so they accumulate over a long working session — especially with:
+
+- several projects up at once, each with a handful of volumes
+- `sync:` configured, which adds two mounts per container (read-only source + named volume)
+- repeated `wip run` invocations that each attach the full volume set
+- containers left running from a previous project
+
+## Fix
+
+**1. See what's running:**
+
+```bash
+wslc container list
+```
+
+**2. Stop what you don't need:**
+
+```bash
+wip down                        # this project
+wslc container stop <name>      # anything else
+```
+
+**3. Restart the session** — this is the step that actually reclaims the slots:
+
+```bash
+wslc system session terminate
+```
+
+**4. Retry:**
+
+```bash
+wip up -d
+```
+
+Terminating the session stops every WSLC container on the machine, not just yours. Check with other
+people if you share it.
+
+## Reducing pressure
+
+**Trim your volume list.** Every entry in `volumes:` costs a slot on every container that declares
+it. Consolidate where you can.
+
+**Don't declare volumes on sidecars that don't need them.** A Postgres container needs its data
+volume; it doesn't need your source tree.
+
+**Tear down projects you're not using**, rather than leaving three stacks up all day:
+
+```bash
+cd ~/project-a && wip down
+```
+
+**With `sync:`, drop the now-redundant bind mount.** wip already replaces `.:/app` with the
+read-only mount plus the volume — but any *other* mount of the same tree you declared by hand is
+extra. Check `wip config`.
+
+**Prefer `sync.mode: exec` over `run`** where you can. A throwaway container per mirror attaches
+the mount set each time; exec'ing into the existing one doesn't. See [Sync Modes](Sync-Modes).
+
+## Related
+
+- [Source Sync](Source-Sync)
+- [Dependencies](Dependencies)
+- [wip down](wip-down)

--- a/wiki/WSLC-Not-Found.md
+++ b/wiki/WSLC-Not-Found.md
@@ -1,0 +1,140 @@
+# WSLC Not Found
+
+```
+WSLC was not found.
+
+Checked:
+  wslc.exe
+  wslc
+  /mnt/c/Windows/System32/wslc.exe
+
+Install or update the WSL container tooling, then run:
+
+  wip doctor
+```
+
+Every wip command except [`wip version`](wip-version) fails with this when the `wslc` binary can't
+be resolved.
+
+## The lookup order
+
+With `wslc.command: auto` (the default), wip tries, in order:
+
+1. `wslc.exe` — searched across `PATH`
+2. `wslc` — searched across `PATH`
+3. `/mnt/c/Windows/System32/wslc.exe` — checked directly
+
+The first one that is **executable** wins. A name containing a path separator is checked with
+`File.executable?` directly; a bare name is looked up in every `PATH` entry.
+
+With any other value, that exact value must be executable — there is no fallback:
+
+```yaml
+wslc:
+  command: /mnt/c/Program Files/WSL/wslc.exe
+```
+
+```
+WSLC was not found.
+
+Checked:
+  /mnt/c/Program Files/WSL/wslc.exe
+```
+
+## Diagnosing
+
+**Is it there at all?**
+
+```bash
+which wslc.exe wslc
+ls -l /mnt/c/Windows/System32/wslc.exe
+wslc.exe version
+```
+
+**Is Windows interop enabled?** Without it, WSL can't execute `.exe` files at all — which looks
+identical to "not installed":
+
+```bash
+wip doctor
+```
+
+```
+[FAIL] Windows executable interoperability is disabled
+```
+
+Fix in `/etc/wsl.conf`, then `wsl --shutdown` from Windows:
+
+```ini
+[interop]
+enabled = true
+appendWindowsPath = true
+```
+
+**Is System32 on your PATH?** `appendWindowsPath = false` in `/etc/wsl.conf` removes Windows paths
+from `PATH`, so `wslc.exe` won't be found by name. That's exactly what the third candidate covers —
+but only for the default install location.
+
+## Fixes
+
+### Install or update the tooling
+
+Install Microsoft's WSL container tooling on the Windows side, then confirm from Windows itself
+before returning to WSL:
+
+```powershell
+wslc version
+```
+
+### Point at it explicitly
+
+If it lives somewhere non-standard:
+
+```yaml
+wslc:
+  command: /mnt/c/Tools/wslc/wslc.exe
+```
+
+Verify:
+
+```bash
+ls -l /mnt/c/Tools/wslc/wslc.exe    # must be executable
+wip doctor
+```
+
+### On native Windows
+
+wip runs there too. `wslc.exe` needs to be on `PATH`, or named absolutely with a Windows path:
+
+```yaml
+wslc:
+  command: C:\Program Files\WSL\wslc.exe
+```
+
+## "Found" but "version failed"
+
+```
+[OK]   Found wslc.exe
+[FAIL] WSLC version failed
+```
+
+Different problem: the binary exists and is executable but doesn't respond to `version`. Usually a
+partial or broken install, or a stale shim on `PATH` shadowing the real binary. Check what you're
+actually resolving:
+
+```bash
+which -a wslc.exe wslc
+```
+
+## Verify the fix
+
+```console
+$ wip doctor
+[OK] Found wslc.exe
+[OK] WSLC is available
+```
+
+## Related
+
+- [Config File Discovery](Config-File-Discovery) — the `wslc:` block
+- [wip doctor](wip-doctor)
+- [wip version](wip-version)

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,86 @@
+**[Home](Home)**
+
+**Introduction**
+- [Getting Started](Getting-Started)
+- [Choosing a Mode](Choosing-a-Mode)
+- [Concepts](Concepts)
+- [Glossary](Glossary)
+
+**Modes**
+- [Container Mode](Container-Mode)
+- [Compose Mode](Compose-Mode)
+- [Compose Native Mode](Compose-Native-Mode)
+
+**Configuration**
+- [Configuration Reference](Configuration-Reference)
+- [Config File Discovery](Config-File-Discovery)
+- [Dependencies](Dependencies)
+- [Networking](Networking)
+- [Interactions](Interactions)
+- [Restart Policies](Restart-Policies)
+- [Env Files](Env-Files)
+- [Secret Masking](Secret-Masking)
+- [Dockerignore](Dockerignore)
+- [Shadow Build Context](Shadow-Build-Context)
+- [Source Sync](Source-Sync)
+- [Sync Modes](Sync-Modes)
+
+**compose.yml support**
+- [Compose File Support](Compose-File-Support)
+- [Compose Build](Compose-Build)
+- [Compose Depends On](Compose-Depends-On)
+- [Compose Profiles](Compose-Profiles)
+- [Compose Variable Interpolation](Compose-Variable-Interpolation)
+
+**Commands**
+- [CLI Command Reference](CLI-Command-Reference)
+- [wip init](wip-init)
+- [wip version](wip-version)
+- [wip doctor](wip-doctor)
+- [wip config](wip-config)
+- [wip build](wip-build)
+- [wip up](wip-up)
+- [wip stop](wip-stop)
+- [wip down](wip-down)
+- [wip exec](wip-exec)
+- [wip run](wip-run)
+- [wip shell](wip-shell)
+- [wip logs](wip-logs)
+- [wip sync](wip-sync)
+- [wip dispatch](wip-dispatch)
+- [Global Options](Global-Options)
+- [Debug Output](Debug-Output)
+- [TTY Allocation](TTY-Allocation)
+
+**Guides**
+- [Guides](Guides)
+- [Migrating from dip](Migrating-from-dip)
+- [Reusing an Existing compose.yml](Reusing-an-Existing-compose-yml)
+- [Fixing a Slow Boot](Fixing-a-Slow-Boot)
+- [Continuous Sync](Continuous-Sync)
+- [Auto Restarting Containers](Auto-Restarting-Containers)
+- [Multi Arch Images](Multi-Arch-Images)
+- [Using wip in CI](Using-wip-in-CI)
+
+**Troubleshooting**
+- [Troubleshooting & FAQ](Troubleshooting-and-FAQ)
+- [FAQ](FAQ)
+- [Configuration Errors](Configuration-Errors)
+- [WSLC Not Found](WSLC-Not-Found)
+- [Registry Authentication](Registry-Authentication)
+- [Architecture Mismatch](Architecture-Mismatch)
+- [Volume Limit Reached](Volume-Limit-Reached)
+- [rsync Not Found](rsync-Not-Found)
+- [Reporting Issues](Reporting-Issues)
+
+**Comparison**
+- [Comparison](Comparison)
+- [wip vs dip](wip-vs-dip)
+- [wip vs docker compose](wip-vs-docker-compose)
+- [Third Party Compose Tools](Third-Party-Compose-Tools)
+
+**Project**
+- [Development](Development)
+- [Architecture](Architecture)
+- [Testing and Linting](Testing-and-Linting)
+- [Release Process](Release-Process)

--- a/wiki/publish.sh
+++ b/wiki/publish.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Publish wiki/*.md to the GitHub wiki repository.
+#
+# The wiki lives in a separate git repo (slidict/wip.wiki.git), so it can't be
+# updated by a pull request against this repository. This script mirrors the
+# directory into a clone of it and pushes.
+#
+# Usage:
+#   ./wiki/publish.sh [commit message]
+#
+# Requires push access to the wiki repository.
+
+set -euo pipefail
+
+WIKI_REMOTE="${WIKI_REMOTE:-https://github.com/slidict/wip.wiki.git}"
+MESSAGE="${1:-docs(wiki): sync from main repo}"
+
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "Cloning $WIKI_REMOTE"
+git clone --quiet "$WIKI_REMOTE" "$WORK_DIR/wiki"
+
+# Remove pages that no longer exist in the source, then copy the current set.
+# README.md and publish.sh are tooling for this directory, not wiki pages.
+find "$WORK_DIR/wiki" -maxdepth 1 -name '*.md' -delete
+for file in "$SOURCE_DIR"/*.md; do
+  name="$(basename "$file")"
+  [ "$name" = "README.md" ] && continue
+  cp "$file" "$WORK_DIR/wiki/$name"
+done
+
+cd "$WORK_DIR/wiki"
+
+if git diff --quiet && git diff --cached --quiet && [ -z "$(git status --porcelain)" ]; then
+  echo "No changes to publish."
+  exit 0
+fi
+
+git add -A
+git commit --quiet -m "$MESSAGE"
+git push --quiet origin HEAD
+echo "Published to $WIKI_REMOTE"

--- a/wiki/rsync-Not-Found.md
+++ b/wiki/rsync-Not-Found.md
@@ -1,0 +1,124 @@
+# rsync Not Found
+
+```
+rsync: not found
+rsync: command not found
+exec: "rsync": executable file not found in $PATH
+```
+
+The container running the mirror doesn't have `rsync`.
+
+## The hint wip prints
+
+```
+`wip sync` needs rsync inside the image.
+
+Install it in your Dockerfile:
+
+  RUN apt-get update && apt-get install -y rsync
+
+Or point sync.command at a tool the image already has.
+```
+
+## Which image is missing it?
+
+This is the part that trips people up: the answer depends on `sync.mode` **and** on which step
+failed.
+
+| Step | Container | Image that needs rsync |
+|---|---|---|
+| `wip up`'s pre-boot mirror | throwaway (always) | `sync.build`'s tag → `sync.image` → the primary entry's image |
+| `wip sync` / `--watch`, `mode: exec` | the running primary container | the primary container's image |
+| `wip sync` / `--watch`, `mode: run` | throwaway | `sync.build`'s tag → `sync.image` → the primary entry's image |
+
+So under the default `sync.mode: exec` with no `sync.image`/`sync.build`, **your app image** needs
+rsync for both paths — the pre-boot mirror falls back to it too.
+
+`wip doctor` warns about the half-configured case:
+
+```
+[WARN] sync.image/sync.build only cover `wip up`'s one-time pre-boot mirror … sync.mode: exec's
+`wip sync`/`wip sync --watch` run rsync inside the primary container instead, so its image
+needs rsync too
+```
+
+Full explanation: [Sync Modes](Sync-Modes).
+
+## Fix 1: install rsync in the app image
+
+```dockerfile
+# Debian/Ubuntu
+RUN apt-get update && apt-get install -y rsync && rm -rf /var/lib/apt/lists/*
+
+# Alpine
+RUN apk add --no-cache rsync
+```
+
+```bash
+wip build
+wip down && wip up -d
+```
+
+Simplest option, and it keeps `sync.mode: exec` — the fastest mode, since there's no container
+start per mirror.
+
+## Fix 2: a dedicated mirror image
+
+Keep your app image minimal and let wip build a tiny one just for rsync:
+
+```yaml
+sync:
+  mode: run
+  build:
+    dockerfile: |
+      FROM alpine:latest
+      RUN apk add --no-cache rsync
+```
+
+Built once per `wip up` / `wip sync` invocation (not per `--watch` tick), tagged
+`wip-sync-<container>:latest` unless you set `build.tag`.
+
+Or point at an image you manage yourself:
+
+```yaml
+sync:
+  mode: run
+  image: my-registry/rsync:latest
+```
+
+`sync.build`'s tag wins if both are set — don't configure both.
+
+Required under [`mode: compose`](Compose-Mode), where there's no `dependencies:` entry to borrow an
+image from.
+
+## Fix 3: use a different tool
+
+If your image already has something that can mirror a tree with compatible flags:
+
+```yaml
+sync:
+  command: /usr/local/bin/my-mirror
+```
+
+wip builds the invocation as:
+
+```
+<command> -r -l -t --whole-file [--delete] [--exclude=… …] [options…] /host-src/ /app/
+```
+
+so your tool must accept those flags. In practice this means an rsync-compatible binary
+(`rsync`-from-busybox often is not — check before relying on it).
+
+## Verify
+
+```bash
+wip up -d
+wip exec which rsync
+wip sync
+```
+
+## Related
+
+- [Sync Modes](Sync-Modes)
+- [Source Sync](Source-Sync)
+- [wip sync](wip-sync)

--- a/wiki/wip-build.md
+++ b/wiki/wip-build.md
@@ -1,0 +1,114 @@
+# wip build
+
+Builds the image described by the `build` interaction in `wip.yml`, applying `.dockerignore` first.
+
+```
+wip build [--no-cache] [-- OPTIONS...]
+```
+
+## Configuration
+
+`wip build` reads the interaction named `build`:
+
+```yaml
+interaction:
+  build:
+    type: build                            # implied for an entry named `build`
+    context: .                             # relative to wip.yml's directory
+    tag: slidict/slidict:development       # falls back to the inherited `image`
+    shadow_context: /mnt/c/Users/me/AppData/Local/wip/build-contexts   # optional
+```
+
+Resulting invocation:
+
+```
+wslc build -t <tag> [extra options…] .
+```
+
+The `tag` falls back to the primary container's `image` when unset. An empty one fails:
+
+```
+Build image/tag must not be empty
+```
+
+## What happens
+
+```console
+$ wip build
+wip: staging build context (/home/me/my-project)
+wip: copying build context files: 1240/1240
+wip: [debug] running: wslc.exe build -t myapp:dev .
+```
+
+1. Resolve `context` against `wip.yml`'s directory.
+2. Read `.dockerignore` from the context root and stage only the included files — see
+   [Dockerignore](Dockerignore).
+3. If `shadow_context:` applies, sync a persistent Windows-side copy instead — see
+   [Shadow Build Context](Shadow-Build-Context).
+4. `chdir` into the staged directory and run `wslc build … .`
+
+Step 4 uses `.` rather than an absolute path because `wslc build` crashes
+(`ERROR_UNHANDLED_EXCEPTION`) when handed an absolute context.
+
+## Flags
+
+### `--no-cache`
+
+```bash
+wip build --no-cache
+```
+
+`wslc build` reuses matching local layers by default (like `docker build` without `--pull`).
+`--no-cache` disables that. Note `wslc build` has no `--cache-from` flag — passing one is a hard
+error.
+
+### Extra options after `--`
+
+Anything after `--` is passed straight through to `wslc build`:
+
+```bash
+wip build -- --build-arg RUBY_VERSION=3.4
+wip build -- -f Dockerfile.dev
+wip build --no-cache -- --build-arg TAG=ci
+```
+
+The `--` separator itself is stripped. `--no-cache` is inserted only once even if you also pass it
+after `--`.
+
+## Compose-native services
+
+`wip build` builds the `build` **interaction**, which is a `wip.yml` concept. Services in
+`compose.yml` that declare `build:` are built by `wip up`, not by this command:
+
+```console
+$ wip up -d
+wip: building service 'app' (tag: myapp:dev) from /home/me/app
+```
+
+See [Compose Build](Compose-Build). `wip up --no-cache` applies `--no-cache` to those builds.
+
+## Compose mode
+
+Under [`mode: compose`](Compose-Mode), builds belong to your compose tool. A `type: build`
+interaction is rejected:
+
+```
+commands.build: type 'build' is not supported in compose mode (use `wslc-compose build`/`up --build` directly)
+```
+
+## Common problems
+
+| Symptom | Cause | Page |
+|---|---|---|
+| Staging copies far too many files | no/insufficient `.dockerignore` | [Dockerignore](Dockerignore) |
+| Every build re-transfers the whole tree | context is WSL-side, no shadow configured | [Shadow Build Context](Shadow-Build-Context) |
+| `pull access denied` | registry auth | [Registry Authentication](Registry-Authentication) |
+| `no matching manifest for linux/…` | image arch mismatch | [Architecture Mismatch](Architecture-Mismatch) |
+| Build fails fetching a `git:` dependency | Git missing in the build environment (`wip doctor` warns) | [wip doctor](wip-doctor) |
+
+## Related
+
+- [Interactions](Interactions) — the `build` entry's keys
+- [Dockerignore](Dockerignore)
+- [Shadow Build Context](Shadow-Build-Context)
+- [wip up](wip-up)

--- a/wiki/wip-config.md
+++ b/wiki/wip-config.md
@@ -1,0 +1,137 @@
+# wip config
+
+Prints the **effective** configuration as YAML: every default filled in, every derived value
+resolved, every secret-looking value masked.
+
+```
+wip config
+```
+
+This is the fastest way to answer "what did wip actually make of my `wip.yml`?" — especially under
+[compose-native mode](Compose-Native-Mode), where most of the config comes from `compose.yml`.
+
+## Example
+
+```console
+$ wip config
+---
+version: 1
+wslc:
+  command: auto
+mode: container
+container: app
+network: app-tier
+dependencies:
+  app:
+    image: slidict/slidict:development
+    workdir: /app
+    interactive: false
+    remove: true
+    env:
+      RAILS_ENV: development
+    ports:
+    - '3000:3000'
+    volumes:
+    - .:/app
+  redis:
+    image: redis:latest
+compose:
+sync:
+  source: "/home/me/my-project"
+  target: "/app"
+  mount: "/host-src"
+  volume: app-src
+  delete: true
+  exclude:
+  - ".git"
+  - tmp/
+  command: rsync
+  options: []
+  interval: 2
+  mode: exec
+  image:
+  build:
+commands:
+  rspec:
+    image: slidict/slidict:development
+    workdir: /app
+    type: exec
+    command: bundle exec rspec
+```
+
+## What it shows that your file doesn't
+
+| | |
+|---|---|
+| **Defaults** | `mode`, `wslc.command`, every `dependencies:` entry key, every `sync:` key |
+| **Derived values** | `sync.source` / `target` / `volume`, compose-native's `container` and `network` |
+| **Interaction inheritance** | each entry merged on top of the primary container's values |
+| **compose.yml** | under compose-native, services rendered as `dependencies:` entries in dependency order |
+| **Interpolated `${VAR}`** | post-substitution values — see [Compose Variable Interpolation](Compose-Variable-Interpolation) |
+
+Two normalizations worth noting:
+
+- **`interaction:` is always printed as `commands:`**, whichever spelling you wrote. They're
+  aliases for one feature — see [Interactions](Interactions).
+- **Every `env` value is a string.** `PORT: 3000` in your file appears as `PORT: '3000'`.
+
+## Secret masking
+
+Any key matching `token`, `password`, `secret`, `credential`, or `auth` (case-insensitive,
+substring) has its value replaced:
+
+```yaml
+env:
+  MYSQL_ROOT_PASSWORD: "[REDACTED]"
+```
+
+The match is on **key names only**, so a secret hidden inside a value (`DATABASE_URL`,
+`API_KEY`) is printed in full. Read the output before pasting it anywhere — see
+[Secret Masking](Secret-Masking).
+
+## Uses
+
+**Debug a config that "isn't taking effect":**
+
+```bash
+wip config | grep -A5 'sync:'
+```
+
+**Check what compose-native made of your compose file:**
+
+```bash
+wip config
+```
+
+If a service is missing, it's probably [profile-gated](Compose-Profiles). If a value looks empty,
+a `${VAR}` didn't resolve.
+
+**Diff two setups:**
+
+```bash
+wip config > /tmp/mine.yml
+# on the machine where it works
+wip config > /tmp/theirs.yml
+diff /tmp/mine.yml /tmp/theirs.yml
+```
+
+**Confirm `.env` is being picked up** — note that `.env` values are merged in at command-build
+time, not shown in `wip config`'s `env:` maps. To verify those, use `--debug` and read the `-e`
+flags (masked as `KEY=***`), or run `wip exec env`.
+
+## Failure
+
+`wip config` loads and validates the config, so it fails exactly where every other command would:
+
+```console
+$ wip config
+container: must be set when dependencies: has entries
+```
+
+See [Configuration Errors](Configuration-Errors).
+
+## Related
+
+- [Configuration Reference](Configuration-Reference)
+- [Secret Masking](Secret-Masking)
+- [wip doctor](wip-doctor)

--- a/wiki/wip-dispatch.md
+++ b/wiki/wip-dispatch.md
@@ -1,0 +1,107 @@
+# wip dispatch
+
+Runs a `wip.yml` [interaction](Interactions) explicitly, by name.
+
+```
+wip dispatch NAME [ARGS...]
+```
+
+## You usually don't need it
+
+`dispatch` is the default command: any first argument wip doesn't recognize as a built-in is routed
+here automatically. These are identical:
+
+```bash
+wip rspec --fail-fast
+wip dispatch rspec --fail-fast
+```
+
+So you only reach for `dispatch` when the automatic routing can't reach your entry — which happens
+in exactly one case.
+
+## Resolving a name collision
+
+Built-in commands always win. If you declare an interaction whose name matches a built-in, `wip
+<name>` runs the **built-in**:
+
+```yaml
+interaction:
+  sync:
+    command: bin/sync-fixtures
+  build:
+    type: build
+    context: .
+    tag: myapp:dev
+```
+
+```bash
+wip sync            # → the built-in mirror, not bin/sync-fixtures
+wip dispatch sync   # → bin/sync-fixtures
+```
+
+Where it can, wip warns rather than silently shadowing:
+
+```console
+$ wip sync
+wip: commands.sync in wip.yml is shadowed by the built-in `wip sync`; run it with `wip dispatch sync`
+```
+
+### Reserved names
+
+`init`, `version`, `doctor`, `config`, `build`, `up`, `stop`, `down`, `exec`, `run`, `shell`,
+`logs`, `sync`, `dispatch`, `help`.
+
+Prefer renaming your entry (`sync-fixtures` rather than `sync`) — `dispatch` is the escape hatch,
+not the intended daily spelling.
+
+`build` is the deliberate exception: [`wip build`](wip-build) *is* driven by the `build`
+interaction's `context`/`tag`, so that collision is by design rather than a shadowing problem.
+
+## With no arguments
+
+```console
+$ wip dispatch
+```
+
+prints wip's help, the same as `wip help`.
+
+## Unknown names
+
+```console
+$ wip dispatch nope
+Unknown command: nope
+```
+
+## Behavior
+
+The entry is resolved from `interaction:` / `commands:`, merged on top of the primary container's
+values, and run according to its `type`:
+
+| `type` | Runs as |
+|---|---|
+| `exec` (default) | [`wip exec`](wip-exec) into the primary container |
+| `run` | [`wip run`](wip-run) in a fresh `--rm` container |
+| `build` | [`wip build`](wip-build) |
+
+Extra arguments are appended to the configured `command`. TTY allocation follows the entry's
+`interactive:` value combined with real-TTY detection — see [TTY Allocation](TTY-Allocation).
+
+Under [`mode: compose`](Compose-Mode), only `type: exec` is supported:
+
+```
+commands.migrate: type 'run' is not supported in compose mode (use `wslc-compose build`/`up --build` directly)
+```
+
+## Global options work here too
+
+```bash
+wip --config other/wip.yml dispatch rspec
+wip dispatch rspec --debug
+```
+
+See [Global Options](Global-Options).
+
+## Related
+
+- [Interactions](Interactions)
+- [CLI Command Reference](CLI-Command-Reference)

--- a/wiki/wip-doctor.md
+++ b/wiki/wip-doctor.md
@@ -1,0 +1,154 @@
+# wip doctor
+
+Diagnoses the environment and the configuration, one line per check.
+
+```
+wip doctor
+```
+
+```console
+$ wip doctor
+[OK] Running on WSL2
+[OK] Windows executable interoperability is enabled
+[OK] Architecture: linux/amd64
+[OK] Loaded wip.yml
+[OK] Found wslc.exe
+[OK] WSLC is available
+[OK] Sync source /home/me/app mirrors into volume app-src at /app
+[OK] Git is available
+```
+
+## Levels and exit code
+
+| Level | Meaning |
+|---|---|
+| `[OK]` | fine |
+| `[WARN]` | worth knowing, doesn't block |
+| `[FAIL]` | blocks execution |
+
+**Exit `1` if any check failed; otherwise `0`** — warnings alone still exit `0`, so
+`wip doctor && wip up -d` is safe in a script.
+
+## The checks, in order
+
+### 1. WSL2
+
+```
+[OK]   Running on WSL2          / [OK]   WSL2 is available      (on native Windows)
+[FAIL] Not running on WSL2      / [FAIL] WSL2 is not available
+```
+
+On Linux/WSL, read from `/proc/version`. On native Windows, wip asks Windows itself via
+`wsl.exe --status`, since there's no `/proc/version` to read.
+
+### 2. Windows interop
+
+Skipped entirely on native Windows.
+
+```
+[OK]   Windows executable interoperability is enabled
+[FAIL] Windows executable interoperability is disabled
+```
+
+Detected via `/proc/sys/fs/binfmt_misc/WSLInterop` or the `WSL_INTEROP` environment variable.
+Without it, WSL can't run `wslc.exe` at all. Usually caused by `interop.enabled=false` in
+`/etc/wsl.conf`.
+
+### 3. Architecture
+
+```
+[OK] Architecture: linux/amd64
+```
+
+Informational, **always `[OK]`**. Reported as `linux/amd64` / `linux/arm64` (or `linux/<host_cpu>`
+for anything else). Compare it against your image when a container refuses to start — see
+[Architecture Mismatch](Architecture-Mismatch).
+
+### 4. Configuration
+
+```
+[OK]   Loaded wip.yml
+[FAIL] wip.yml was not found (searched from … to the filesystem root)
+[FAIL] container: must be set when dependencies: has entries
+[FAIL] No dependencies.app entry
+[FAIL] compose.service 'app' has no matching service in compose.yml
+```
+
+Any `ConfigError` surfaces here as a `[FAIL]` with the exact message, and the remaining
+config-dependent checks are skipped. Catalog: [Configuration Errors](Configuration-Errors).
+
+### 5. WSLC binary
+
+```
+[OK]   Found wslc.exe
+[OK]   WSLC is available
+[FAIL] WSLC was not found. Checked: …
+[FAIL] WSLC version failed
+```
+
+First resolves `wslc.command`, then actually runs `<binary> version`. "Found" but "version failed"
+means the file exists and is executable but doesn't respond — usually a broken or partial install.
+See [WSLC Not Found](WSLC-Not-Found).
+
+### 6. Compose (`mode: compose` only)
+
+```
+[OK]   Found wslc-compose
+[OK]   compose command is available
+[OK]   Found compose file /home/me/app/compose.yml
+[FAIL] compose command was not found. Checked: …
+[FAIL] Compose file not found: /home/me/app/compose.yml
+```
+
+Resolves and version-checks `compose.command`, then confirms the compose file exists. wip does
+**not** parse the file in this mode — that's the external tool's job.
+
+### 7. Compose (`mode: compose-native` only)
+
+```
+[OK]   Found compose file /home/me/app/compose.yml
+[OK]   Parsed compose file
+[FAIL] compose.yml: services.app has unsupported key(s): healthcheck
+```
+
+Here wip does parse it, so every rule on [Compose File Support](Compose-File-Support) is checked.
+Parsing is skipped if the file wasn't found.
+
+### 8. Sync (only when `sync:` is configured)
+
+```
+[OK]   Sync source /home/me/app mirrors into volume app-src at /app
+[FAIL] Sync source not found: /home/me/app/src
+[WARN] sync.image/sync.build only cover `wip up`'s one-time pre-boot mirror …
+```
+
+The warning fires when `sync.mode: exec` is combined with `sync.image` / `sync.build` — a common
+misunderstanding worth its own explanation on [Sync Modes](Sync-Modes).
+
+### 9. Git
+
+```
+[OK]   Git is available
+[WARN] Git is not available to the WSLC build environment
+```
+
+**A warning, never a failure.** Many images fetch dependencies from Git during a build (Bundler
+`git:` gems, Go modules, npm `git+https:` deps), and those builds fail confusingly without it — but
+plenty of projects never touch Git in a build, so it can't be fatal.
+
+## Reading a failure
+
+`wip doctor` reports; it doesn't fix. Each `[FAIL]` maps to a page:
+
+| Failure | Page |
+|---|---|
+| WSL2 / interop | [Troubleshooting & FAQ](Troubleshooting-and-FAQ) |
+| WSLC not found | [WSLC Not Found](WSLC-Not-Found) |
+| Config errors | [Configuration Errors](Configuration-Errors) |
+| compose parse errors | [Compose File Support](Compose-File-Support) |
+| Sync source missing | [Source Sync](Source-Sync) |
+
+## Related
+
+- [wip config](wip-config) — what wip resolved, once doctor says the config loads
+- [Reporting Issues](Reporting-Issues) — `wip doctor` output belongs in every bug report

--- a/wiki/wip-down.md
+++ b/wiki/wip-down.md
@@ -1,0 +1,72 @@
+# wip down
+
+Stops **and removes** the primary container and every sidecar.
+
+```
+wip down
+```
+
+## Behavior
+
+| Mode | What runs |
+|---|---|
+| `container` | `wslc remove -f <container>`, then `wslc remove -f <name>` for each sidecar |
+| `compose-native` | the same, across every service from `compose.yml` |
+| `compose` | `<compose command> -f FILE [-p PROJECT] down` |
+
+`-f` forces removal of a still-running container, so there's no need to `wip stop` first.
+
+Failures are non-fatal — wip works through the whole list rather than aborting on the first
+container that doesn't exist.
+
+## What survives
+
+| | Removed by `wip down`? |
+|---|---|
+| Containers | **yes** |
+| Anything written inside a container's filesystem | **yes** (gone with the container) |
+| The `network:` | no |
+| Named volumes, including the sync volume | no |
+| Images | no |
+
+### Why the network is left in place
+
+Networks are cheap and shared, and may be referenced by containers wip doesn't manage. Removing one
+as a side effect of `wip down` would be surprising. Remove it yourself when you mean to:
+
+```bash
+wslc network remove app-tier
+```
+
+### Why the sync volume is left in place
+
+The mirror is expensive to rebuild and holds no state you'd miss deleting deliberately. `wip up`
+re-mirrors into it anyway. To start truly clean:
+
+```bash
+wip down
+wslc volume remove app-src     # name from `wip config`
+wip up -d
+```
+
+## When to use it
+
+- After changing `ports:`, `volumes:`, `env:`, `command:`, or `image:` — those apply at container
+  **creation**, so an existing container won't pick them up.
+- When a container is in a state you don't want to reason about.
+- Before switching branches with meaningfully different container config.
+
+For an ordinary "done for now", [`wip stop`](wip-stop) is cheaper: it keeps the containers so the
+next `wip up` is a `start` rather than a `run`.
+
+## Interaction with `--watch`
+
+Stop any [`wip up --watch`](Restart-Policies) loop first. Removed containers report state `deleted`
+(`4`), not `exited` (`3`), so the loop won't recreate them — but a container that's mid-shutdown
+can be caught in `exited` and restarted out from under you.
+
+## Related
+
+- [wip stop](wip-stop)
+- [wip up](wip-up)
+- [Networking](Networking)

--- a/wiki/wip-exec.md
+++ b/wiki/wip-exec.md
@@ -1,0 +1,101 @@
+# wip exec
+
+Runs a command inside the **already-running** primary container.
+
+```
+wip exec [--no-interactive] COMMAND...
+```
+
+```bash
+wip exec bundle install
+wip exec bin/rails db:migrate
+wip exec ls -la /app
+```
+
+## What it builds
+
+```
+wslc exec [-it] [-w WORKDIR] [-u USER] [-e KEY=VALUE …] CONTAINER command…
+```
+
+Values come from the primary `dependencies:` entry (or `compose.service`'s definition under
+compose-native): `workdir`, `user`, `env`, plus everything from `.env`.
+
+**Ports and volumes are not applied.** The container already exists with whatever it was created
+with; `exec` attaches to it. If you added a port or a mount to `wip.yml`, you need
+`wip down && wip up -d`, not `exec`.
+
+## Flags
+
+### `--no-interactive`
+
+Skips the `-it` flags, so nothing is attached to stdin:
+
+```bash
+wip exec --no-interactive bundle exec rspec
+```
+
+Use it in scripts and CI, or when the command reads from a pipe. Note that even without this flag,
+wip only allocates a TTY when stdin **and** stdout are both real TTYs — so piped output already
+degrades gracefully. See [TTY Allocation](TTY-Allocation).
+
+## Requires a running container
+
+```console
+$ wip exec ls
+Error: container "app" is not running
+```
+
+(The exact message comes from `wslc`.) Start it first:
+
+```bash
+wip up -d
+```
+
+If you want a command that doesn't need a running container, use [`wip run`](wip-run) instead.
+
+## `exec` vs. `run`
+
+| | `wip exec` | [`wip run`](wip-run) |
+|---|---|---|
+| Container | the existing one | a fresh `--rm` one |
+| Requires `wip up` first | yes | no |
+| Shares state with the running app | yes | no |
+| Ports / volumes applied | no | yes |
+| Startup cost | none | a container start |
+| Under `mode: compose` | bridged `exec` | falls back to `exec` |
+
+Reach for `exec` by default — it's faster and sees the same filesystem the app does.
+
+## Under compose mode
+
+Bridged to the external tool:
+
+```
+<compose command> -f FILE [-p PROJECT] exec [-T] <compose.service> command…
+```
+
+`-T` is added when non-interactive.
+
+## Prefer named interactions
+
+Typing `wip exec bundle exec rspec` every time is what `interaction:` exists to avoid:
+
+```yaml
+interaction:
+  rspec:
+    command: bundle exec rspec
+```
+
+```bash
+wip rspec --fail-fast
+```
+
+See [Interactions](Interactions).
+
+## Related
+
+- [wip run](wip-run)
+- [wip shell](wip-shell)
+- [TTY Allocation](TTY-Allocation)
+- [Interactions](Interactions)

--- a/wiki/wip-init.md
+++ b/wiki/wip-init.md
@@ -1,0 +1,114 @@
+# wip init
+
+Writes a starter `wip.yml`, pre-filled with commented defaults and `TODO:` markers.
+
+```
+wip init [--force] [--template rails|node|rust|csharp] [--config PATH]
+```
+
+## Mode detection
+
+`wip init` makes one real decision for you — the mode — because it's the one thing a placeholder
+can't express. It looks for a compose file next to the `wip.yml` it's about to write:
+
+```
+compose.yml → compose.yaml → docker-compose.yml → docker-compose.yaml
+```
+
+| Found | Writes |
+|---|---|
+| yes | `mode: compose-native`, with a `compose:` block pointing at that file |
+| no | `mode: container`, with a `dependencies:` skeleton |
+
+```console
+$ wip init
+wip: wrote /home/me/my-project/wip.yml (mode: container)
+```
+
+It never writes `mode: compose` on its own — that mode needs a `compose.command` only you can name.
+Switch by hand if you want it; see [Compose Mode](Compose-Mode).
+
+## Flags
+
+### `--force`
+
+Without it, an existing `wip.yml` is left alone:
+
+```
+/home/me/my-project/wip.yml already exists (use --force to overwrite)
+```
+
+`--force` overwrites it. There's no backup — commit first.
+
+### `--template NAME`
+
+Picks the default `sync.exclude` patterns for a stack, written **live** into the generated file
+(not as a commented suggestion):
+
+| `--template` | Stack | Default `exclude` |
+|---|---|---|
+| `rails` | Rails | `.git`, `log/`, `tmp/`, `storage/`, `public/assets/`, `public/packs/`, `.bundle/`, `vendor/bundle/`, `coverage/`, `node_modules/` |
+| `node` | Node.js | `.git`, `node_modules/`, `dist/`, `build/`, `.next/`, `.cache/`, `coverage/` |
+| `rust` | Rust | `.git`, `target/` |
+| `csharp` | C# | `.git`, `bin/`, `obj/`, `.vs/`, `packages/` |
+| *(omitted)* | — | `.git`, `tmp/`, `node_modules/` |
+
+Each list mirrors that stack's own `github/gitignore` template — directories that are either
+regenerated inside the container or too large to be worth mirroring.
+
+An unknown name fails before writing anything:
+
+```
+unknown --template "python" (valid: rails, node, rust, csharp)
+```
+
+### `--config PATH`
+
+Writes to `PATH` instead of `./wip.yml`. Mode detection then looks for a compose file next to
+`PATH`, not next to your current directory.
+
+## What you have to fill in
+
+The generated file is heavily commented; the parts that actually need you:
+
+**Container mode**
+
+```yaml
+container: app                 # rename freely — must match a dependencies: key
+dependencies:
+  app:
+    image: your/image:tag      # TODO
+    workdir: /app              # TODO: match your image, or delete
+```
+
+**Compose-native mode**
+
+```yaml
+compose:
+  service: app                 # TODO: which service in compose.yml is the app
+```
+
+## What's deliberately left commented
+
+- **`interaction:`** — an empty `interaction: {}` is indistinguishable from omitting the key, so
+  the example block stays commented out. Uncomment and edit to add `wip test` etc. See
+  [Interactions](Interactions).
+- **Derived `sync:` keys** (`target`, `volume`) — they track another key (`workdir`, the container
+  name) and would go stale if hardcoded. See [Source Sync](Source-Sync).
+- **`compose.file` / `compose.project`** — auto-detected and directory-derived respectively; the
+  comment shows what they'd resolve to.
+- **`network:` under compose-native** — it's derived from `compose.project`, and setting it
+  directly is a `ConfigError`.
+
+## After running it
+
+```bash
+wip doctor      # confirm the environment and the config
+wip up -d
+```
+
+## Related
+
+- [Getting Started](Getting-Started)
+- [Choosing a Mode](Choosing-a-Mode)
+- [Source Sync](Source-Sync)

--- a/wiki/wip-logs.md
+++ b/wiki/wip-logs.md
@@ -1,0 +1,84 @@
+# wip logs
+
+Follows container logs. **Compose modes only.**
+
+```
+wip logs [-f] [SERVICE...]
+```
+
+## Availability
+
+| Mode | Available | Services per invocation |
+|---|---|---|
+| `container` | ✘ | — |
+| `compose-native` | ✔ | at most **one** |
+| `compose` | ✔ | as many as your compose tool accepts |
+
+```console
+$ wip logs        # under mode: container
+`wip logs` is only available in compose mode
+```
+
+Under `mode: container`, use `wslc logs` directly:
+
+```bash
+wslc logs -f app
+```
+
+## Compose-native: one service at a time
+
+`wslc logs`, like `docker logs`, follows a single container — there's no multi-service aggregation
+the way a real compose tool provides. So:
+
+```bash
+wip logs              # follows compose.service
+wip logs worker       # follows the "worker" service
+wip logs app worker   # error
+```
+
+```
+`wip logs` under mode: compose-native takes at most one SERVICE (wslc logs, unlike a real
+compose tool, only follows one container at a time)
+```
+
+Resulting invocation:
+
+```
+wslc logs [-f] <service>
+```
+
+To watch several at once, run one `wip logs` per terminal — or use [`mode: compose`](Compose-Mode),
+where the external tool aggregates.
+
+## Compose mode: full pass-through
+
+```
+<compose command> -f FILE [-p PROJECT] logs [-f] [SERVICE…]
+```
+
+Every service name you pass is forwarded, so multi-service following works exactly as your compose
+tool implements it.
+
+## Flags
+
+### `-f` / `--follow`
+
+**On by default.** `wip logs` follows; pass `--no-follow` to print what's there and exit:
+
+```bash
+wip logs --no-follow
+wip logs --no-follow worker
+```
+
+This is the opposite of `docker logs`, where following is opt-in — worth remembering if you script
+it, since the default will otherwise block forever.
+
+## Stopping
+
+`Ctrl-C`. wip exits `130`.
+
+## Related
+
+- [Compose Native Mode](Compose-Native-Mode)
+- [Compose Mode](Compose-Mode)
+- [Debug Output](Debug-Output) — for wip's own timing, rather than container output

--- a/wiki/wip-run.md
+++ b/wiki/wip-run.md
@@ -1,0 +1,90 @@
+# wip run
+
+Runs a command in a **fresh, ephemeral container**.
+
+```
+wip run [--no-interactive] COMMAND...
+```
+
+```bash
+wip run bundle exec rails db:migrate
+wip run bundle install
+```
+
+## What it builds
+
+```
+wslc run [--rm] [-it] [-w WORKDIR] [-u USER] [-e KEY=VALUE …] [-p PORT …] [-v VOLUME …] IMAGE command…
+```
+
+Everything comes from the primary `dependencies:` entry (or `compose.service`'s definition under
+compose-native): `image`, `workdir`, `user`, `env`, `ports`, `volumes`, `remove`, plus `.env`.
+
+Unlike [`wip exec`](wip-exec), **ports and volumes are applied**, since this container is being
+created. `--rm` is added when the entry's `remove` is true (the default).
+
+## No running container needed
+
+This is the reason to use it. `wip run` works before `wip up`, or after `wip down` — useful for
+setup steps that must happen before the app can boot:
+
+```bash
+wip run bundle install
+wip run bin/rails db:create db:migrate
+wip up -d
+```
+
+## Flags
+
+### `--no-interactive`
+
+Skips `-it`. See [TTY Allocation](TTY-Allocation).
+
+## Caveats
+
+- **Nothing is shared with the running app** beyond declared volumes. Files written outside a
+  volume vanish with the container.
+- **Ports may conflict.** If the primary container is up and publishing `3000:3000`, a `wip run`
+  that also publishes it will fail. Either stop the app first or declare a `type: run` interaction
+  with `ports: []`.
+- **With `sync:` configured**, the run container gets the rewritten mounts (read-only source +
+  named volume), same as `wip up` — so it sees the mirrored tree, not your live host edits, unless
+  you've synced recently.
+
+## Under compose mode: falls back to exec
+
+The compose bridge's vocabulary is exec-only — there's no ephemeral-container equivalent — so
+`wip run` execs into the already-running service instead, and says so:
+
+```console
+$ wip run bundle install
+wip: compose mode has no ephemeral 'run'; executing in the running 'app' service instead
+```
+
+Which means under [`mode: compose`](Compose-Mode), `wip run` **does** require the service to be up.
+This is one of the concrete reasons to prefer [`mode: compose-native`](Compose-Native-Mode), where
+`wip run` gets a real `wslc run --rm`.
+
+## As an interaction
+
+Declare frequently-run one-offs instead of typing them:
+
+```yaml
+interaction:
+  migrate:
+    type: run
+    command: bundle exec rails db:migrate
+    remove: true
+```
+
+```bash
+wip migrate
+```
+
+`type: run` interactions are rejected under `mode: compose`. See [Interactions](Interactions).
+
+## Related
+
+- [wip exec](wip-exec) — the comparison table lives there
+- [Interactions](Interactions)
+- [Compose Mode](Compose-Mode)

--- a/wiki/wip-shell.md
+++ b/wiki/wip-shell.md
@@ -1,0 +1,86 @@
+# wip shell
+
+Opens an interactive shell in the primary container.
+
+```
+wip shell
+```
+
+## Resolution order
+
+1. **If `interaction.shell` is defined in `wip.yml`, it wins** — `wip shell` runs your entry
+   verbatim, exactly as `wip dispatch shell` would.
+2. Otherwise, try `bash` via `wslc exec -it`.
+3. If that exits non-zero, try `sh`.
+
+The `bash` → `sh` fallback covers Alpine-based images, which typically ship only `sh`.
+
+## Customizing it
+
+```yaml
+interaction:
+  shell:
+    command: zsh
+    interactive: true
+```
+
+Or with a different working directory / user:
+
+```yaml
+interaction:
+  shell:
+    command: bash -l
+    workdir: /app
+    user: "1000:1000"
+    interactive: true
+```
+
+Since your entry replaces the built-in behavior entirely, the `bash` → `sh` fallback no longer
+applies — you're naming the shell yourself.
+
+## Requires a running container
+
+`wip shell` is an `exec`, so the container must be up:
+
+```bash
+wip up -d
+wip shell
+```
+
+For a shell in a fresh container instead:
+
+```bash
+wip run bash
+```
+
+## Interactive behavior
+
+The shell runs behind a pseudo-terminal, which is what makes job control, `Ctrl-C`, editors, and
+pagers work correctly. wip also keeps the pty sized to your real terminal and re-syncs on resize,
+so full-screen programs (`less`, `vim`, `htop`) render properly when you resize the window.
+
+wip's own terminal is switched to raw mode for the duration, so only the pty's line discipline
+echoes your input — otherwise every keystroke would appear twice.
+
+On native Windows, where Ruby has no `openpty`, wip falls back to letting the child inherit its
+real stdio instead. Everything still works; wip just can't observe the output, so error hints
+aren't generated on that path.
+
+If stdin or stdout isn't a real TTY (piped, redirected, CI), no TTY is allocated at all. See
+[TTY Allocation](TTY-Allocation).
+
+## Under compose mode
+
+Bridged, with the same fallback:
+
+```
+<compose command> -f FILE [-p PROJECT] exec <compose.service> bash
+<compose command> -f FILE [-p PROJECT] exec <compose.service> sh
+```
+
+## Related
+
+- [wip exec](wip-exec)
+- [wip run](wip-run)
+- [TTY Allocation](TTY-Allocation)
+- [Interactions](Interactions)

--- a/wiki/wip-stop.md
+++ b/wiki/wip-stop.md
@@ -1,0 +1,51 @@
+# wip stop
+
+Stops the primary container and every sidecar, **without removing them**.
+
+```
+wip stop
+```
+
+## Behavior
+
+| Mode | What runs |
+|---|---|
+| `container` | `wslc stop <container>`, then `wslc stop <name>` for each sidecar |
+| `compose-native` | the same, across every service from `compose.yml` |
+| `compose` | `<compose command> -f FILE [-p PROJECT] stop` |
+
+Failures are non-fatal: wip continues through the rest of the list rather than aborting on the
+first container that was already stopped or never existed. The command's own exit code is not
+propagated, so `wip stop` on an already-stopped stack is a quiet no-op.
+
+## `stop` vs. `down`
+
+| | `wip stop` | [`wip down`](wip-down) |
+|---|---|---|
+| Container process | stopped | stopped |
+| Container itself | **kept** | removed |
+| Container filesystem changes | **kept** | lost |
+| Named volumes | kept | kept |
+| Network | kept | kept |
+| Next `wip up` | `start` — fast | `run --name …` — recreates |
+
+Use `stop` when you're done for the day and want to pick up where you left off. Use `down` when you
+want a clean slate, or after changing `ports:` / `volumes:` / `env:` in `wip.yml`, since those only
+take effect on creation.
+
+## Interaction with `--watch`
+
+If [`wip up --watch`](Restart-Policies) is running in another terminal, it may restart what you
+just stopped: the loop checks whether a container is *currently* exited, not whether it exited on
+its own. `Ctrl-C` the watch loop first.
+
+## Profile-gated services
+
+Under compose-native, services behind `profiles:` are never started by wip, so they're not stopped
+either. See [Compose Profiles](Compose-Profiles).
+
+## Related
+
+- [wip down](wip-down)
+- [wip up](wip-up)
+- [Dependencies](Dependencies)

--- a/wiki/wip-sync.md
+++ b/wiki/wip-sync.md
@@ -1,0 +1,122 @@
+# wip sync
+
+Mirrors the host source tree into the sync volume, once or continuously.
+
+```
+wip sync [-w|--watch] [--interval N]
+```
+
+Requires a `sync:` block:
+
+```
+`wip sync` needs a sync: block in wip.yml
+```
+
+See [Source Sync](Source-Sync) for the configuration, and [Sync Modes](Sync-Modes) for `exec` vs.
+`run`.
+
+## One-shot
+
+```console
+$ wip sync
+```
+
+Runs a single `rsync` pass from the read-only source mount into the volume. Where it runs depends
+on `sync.mode`:
+
+| `sync.mode` | Runs in |
+|---|---|
+| `exec` (default under container / compose-native) | the already-running primary container |
+| `run` (default and only option under compose) | a throwaway `wslc run --rm` container |
+
+Under `exec`, the container must be up — start it with `wip up -d` first.
+
+Fails loudly: a non-zero exit from `rsync` exits wip with the same code.
+
+## Watch mode
+
+```console
+$ wip sync --watch
+wip: syncing /home/me/app -> app-src:/app every 2s (Ctrl-C to stop)
+```
+
+Re-mirrors every `interval` seconds until interrupted:
+
+```console
+^C
+wip: sync stopped
+```
+
+Unlike the one-shot form, a failed mirror inside the loop does **not** exit — it prints the error
+and tries again on the next tick, so a container restarting mid-loop doesn't kill your watcher.
+
+### `--interval N`
+
+Overrides `sync.interval` (default `2`) for this run:
+
+```bash
+wip sync --watch --interval 5
+```
+
+Must be positive:
+
+```
+--interval must be a positive number
+```
+
+### The two-terminal workflow
+
+```bash
+# terminal 1
+wip up -d
+
+# terminal 2
+wip sync --watch
+```
+
+This is a foreground loop, not a daemon — keep the terminal open. See
+[Continuous Sync](Continuous-Sync) for the full workflow and its gotchas.
+
+## `sync.build` is built once per invocation
+
+If `sync.build` is configured, wip builds that image before mirroring — once per `wip sync`
+invocation, including once before a `--watch` loop starts, **not** on every tick. See
+[Sync Modes](Sync-Modes).
+
+## Name collision
+
+If you also declare an interaction named `sync`, the built-in wins and wip tells you:
+
+```console
+$ wip sync
+wip: commands.sync in wip.yml is shadowed by the built-in `wip sync`; run it with `wip dispatch sync`
+```
+
+See [wip dispatch](wip-dispatch).
+
+## The one-way gotcha
+
+The mirror is host → volume only, with `--delete` on by default. Anything the app writes under the
+target is removed by the next pass:
+
+- generated files (scaffolds, migrations) don't come back to the host
+- `tmp/`, `log/`, `node_modules/` installed inside the container get wiped
+
+Fix by excluding the path, giving it its own volume, or setting `delete: false`. See
+[Source Sync](Source-Sync).
+
+## Common problems
+
+| Symptom | Cause |
+|---|---|
+| `rsync: not found` | the image running the mirror lacks rsync — [rsync Not Found](rsync-Not-Found) |
+| `wip sync` says the container isn't running | `sync.mode: exec` needs `wip up -d` first |
+| Changes don't appear in the container | the watcher isn't running, or the path is in `exclude` |
+| Files the app wrote keep disappearing | `--delete` — see the gotcha above |
+
+## Related
+
+- [Source Sync](Source-Sync)
+- [Sync Modes](Sync-Modes)
+- [Continuous Sync](Continuous-Sync)
+- [Fixing a Slow Boot](Fixing-a-Slow-Boot)

--- a/wiki/wip-up.md
+++ b/wiki/wip-up.md
@@ -1,0 +1,116 @@
+# wip up
+
+Brings the stack up: builds what needs building, creates the network, starts sidecars, mirrors the
+source, and starts the primary container.
+
+```
+wip up [-d] [--no-sync] [--no-cache] [--watch] [--interval N]
+```
+
+## What it does, in order
+
+Under `mode: container` and `mode: compose-native`:
+
+1. **Validate `--interval`** (only when `--watch` is given) — before any side effect, so a bad
+   value doesn't leave a half-started stack behind.
+2. **Build compose-native `build:` services** — once per invocation, in `depends_on` order. No-op
+   in container mode. See [Compose Build](Compose-Build).
+3. **Create the network** if `network:` is set and missing. See [Networking](Networking).
+4. **Start every sidecar**, by name. Existing ones are `start`ed, missing ones created.
+5. **Mirror the source** into the sync volume, if `sync:` is configured and `--no-sync` wasn't
+   passed. See [Source Sync](Source-Sync).
+6. **Start the primary container** — `start` if it exists, `run --name …` if not.
+7. **Enter the watch loop**, if `--watch` was given.
+
+```console
+$ wip up -d
+wip: creating network 'app-tier'
+wip: dependency 'redis' not found, creating it
+wip: starting existing dependency 'development.mysql'
+wip: syncing /home/me/app -> app-src:/app
+wip: run `wip sync --watch` in another terminal to keep /app up to date
+wip: container 'app' not found, creating it
+```
+
+Under [`mode: compose`](Compose-Mode) it's much shorter: mirror the source (unless `--no-sync`),
+then delegate to `<compose command> -f FILE [-p PROJECT] up [-d]`.
+
+## Flags
+
+### `-d` / `--detach`
+
+Run the primary container in the background. Without it, wip attaches to the container and your
+terminal is held until it exits.
+
+Sidecars are **always** started detached, regardless of this flag.
+
+### `--no-sync`
+
+Skip step 5. Useful when you know the volume is already current and want a faster boot, or when
+you're about to run `wip sync --watch` anyway.
+
+Has no effect without a `sync:` block.
+
+### `--no-cache`
+
+Passes `--no-cache` to the compose-native image builds in step 2. No effect in container mode
+(nothing is built there) or compose mode.
+
+### `--watch` / `-w` and `--interval N`
+
+Poll every `N` seconds (default `5`) and restart any dependency that has exited and whose
+`restart:` allows it:
+
+```console
+$ wip up --watch
+wip: watching app, mysql for exited restart: containers every 5s (running detached; Ctrl-C to stop)
+wip: 'mysql' has exited, restarting it (restart: unless-stopped)
+```
+
+Key points:
+
+- **Implies `-d`.** The primary container can't hold an attached TTY while the loop polls on the
+  same thread.
+- **Foreground loop.** `Ctrl-C` stops supervision; closing the terminal does too.
+- **Not available under `mode: compose`** — there's no service list to poll.
+- **Status-based, not event-based** — it can't distinguish a crash from a `wip stop` you ran
+  elsewhere.
+
+Full semantics and limitations: [Restart Policies](Restart-Policies).
+
+`--interval` must be positive:
+
+```
+--interval must be a positive number
+```
+
+## Idempotence
+
+Re-running `wip up` against a running stack is safe. Existing containers are `start`ed, which is a
+no-op when they're already running. Nothing is recreated.
+
+That also means **config changes don't apply to existing containers**. New ports, volumes, or env
+vars require:
+
+```bash
+wip down && wip up -d
+```
+
+## Common problems
+
+| Symptom | Likely cause |
+|---|---|
+| App can't resolve `redis` / `db` by name | `network:` unset — see [Networking](Networking) |
+| New `ports:` entry isn't listening | container predates the change; `wip down && wip up -d` |
+| `container: must be set…` | [Dependencies](Dependencies) |
+| `pull access denied` | [Registry Authentication](Registry-Authentication) |
+| `no matching manifest for linux/…` | [Architecture Mismatch](Architecture-Mismatch) |
+| Boot hangs with low CPU | bind-mount overhead — [Fixing a Slow Boot](Fixing-a-Slow-Boot) |
+| `0x8007000e` / too many mounted volumes | [Volume Limit Reached](Volume-Limit-Reached) |
+
+## Related
+
+- [wip stop](wip-stop) / [wip down](wip-down)
+- [Restart Policies](Restart-Policies)
+- [Source Sync](Source-Sync)
+- [Debug Output](Debug-Output) — `wip up --debug` when boot is slow

--- a/wiki/wip-version.md
+++ b/wiki/wip-version.md
@@ -1,0 +1,55 @@
+# wip version
+
+Prints wip's own version, then asks `wslc` for its version.
+
+```
+wip version
+```
+
+```console
+$ wip version
+wip 1.1.3
+wslc version 0.1.x
+```
+
+## Behavior
+
+1. Prints `wip <VERSION>` — always, unconditionally.
+2. Loads `wip.yml` and resolves `wslc.command`.
+3. Runs `<resolved wslc> version`, whose output goes straight to your terminal.
+
+## It degrades gracefully
+
+Step 2 or 3 failing is **not** an error here. If `wip.yml` is missing, unparsable, or `wslc` can't
+be found, `wip version` still prints wip's own version and exits `0`:
+
+```console
+$ cd /tmp && wip version
+wip 1.1.3
+```
+
+That's deliberate — `wip version` is what you run to check the install, so it must work before
+anything else does. Every other command fails loudly in the same situation.
+
+## Uses
+
+**Confirming an install or upgrade:**
+
+```bash
+gem install wslc-wip
+wip version
+```
+
+**Running from a source checkout:**
+
+```bash
+bundle exec exe/wip version
+```
+
+**In a bug report** — always include this output; see [Reporting Issues](Reporting-Issues).
+
+## Related
+
+- [wip doctor](wip-doctor) — the full environment diagnosis, when `version` isn't enough
+- [WSLC Not Found](WSLC-Not-Found) — if the second line never appears
+- [Config File Discovery](Config-File-Discovery) — how `wslc.command` is resolved

--- a/wiki/wip-vs-dip.md
+++ b/wiki/wip-vs-dip.md
@@ -1,0 +1,77 @@
+# wip vs dip
+
+[`dip`](https://github.com/bibendi/dip) is the tool `wip` is modeled on. If you know dip, most of
+wip will feel familiar — the differences come almost entirely from the runtime underneath.
+
+## Shared ground
+
+| | Both |
+|---|---|
+| Named project commands | `interaction:` — same key, same idea |
+| Alias for it | `commands:` |
+| A single verb hiding run-vs-exec | ✔ |
+| `.env` loading | ✔ |
+| Sidecar services alongside the app | ✔ |
+| Run from any subdirectory | ✔ (walks up to find the config) |
+| Extra CLI args appended to the configured command | ✔ |
+
+The design goal is the same: `dip rspec` / `wip rspec` should work on a fresh clone without anyone
+remembering the underlying invocation.
+
+## Differences
+
+| | `wip` | `dip` |
+|---|---|---|
+| Runtime | Microsoft WSLC (`wslc.exe` / `wslc`) | Docker |
+| Config file | `wip.yml` | `dip.yml` |
+| Orchestration | explicit `mode:` — `container` / `compose` / `compose-native` | assumes Docker Compose |
+| Declaring services without Compose | ✔ `dependencies:` | ✘ |
+| Primary container | `container:` — **no default** | conventionally a named service per command |
+| Source-sync for slow mounts | ✔ `sync:` | ✘ (Docker Desktop's own mount tuning instead) |
+| Restart policies | approximated by `wip up --watch` polling | via Compose |
+| Build-context filtering | wip applies `.dockerignore` itself | Docker does it |
+| Persistent Windows-side build context | ✔ `shadow_context:` | n/a |
+| `provision:` | ✘ not implemented | ✔ |
+| `dip ssh` / agent forwarding | ✘ | ✔ |
+| Shell completion | ✘ | ✔ |
+
+## Why the extra concepts exist
+
+Most of what wip has and dip doesn't traces back to WSLC:
+
+- **`sync:`** — WSLC bind mounts always cross a VM boundary over virtiofs, so a framework that
+  stats thousands of files at boot is unusably slow. Docker Desktop has its own mitigations; WSLC
+  doesn't. See [Fixing a Slow Boot](Fixing-a-Slow-Boot).
+- **`.dockerignore` handling** — `wslc build` sends the context as-is, with no ignore support of
+  its own. See [Dockerignore](Dockerignore).
+- **`shadow_context:`** — the same boundary makes re-sending a large build context expensive. See
+  [Shadow Build Context](Shadow-Build-Context).
+- **`mode: compose-native`** — `wslc` has no native Compose support
+  ([microsoft/WSL#40948](https://github.com/microsoft/WSL/issues/40948)), so someone has to parse
+  `compose.yml`. dip could always assume Compose was there.
+- **`--watch` restarts** — no restart policy in the runtime, and no event stream to build one on.
+  See [Restart Policies](Restart-Policies).
+
+## What dip has that wip doesn't
+
+- **`provision:`** — a declared list of setup commands. Express it as an interaction and run it
+  yourself:
+  ```yaml
+  interaction:
+    setup:
+      type: run
+      command: bin/setup
+  ```
+- **`dip ssh`** and SSH-agent forwarding.
+- **Shell completion.**
+- **Nested `subcommands:`** — declare separate top-level entries instead.
+
+## Migrating
+
+Step-by-step: [Migrating from dip](Migrating-from-dip).
+
+## Which should you use?
+
+Straightforward: **whichever matches your runtime.** wip has no Docker backend and dip has no WSLC
+backend. If you're running both (a Docker CI and a WSLC laptop, say), keeping both config files is
+normal — the `interaction:` blocks look nearly identical.

--- a/wiki/wip-vs-docker-compose.md
+++ b/wiki/wip-vs-docker-compose.md
@@ -1,0 +1,98 @@
+# wip vs docker compose
+
+wip is not a Compose implementation and doesn't try to be. This page is about what wip adds *on
+top of* driving `wslc` yourself, and how its `compose.yml` handling compares to the real thing.
+
+## wip vs. driving `wslc` by hand
+
+Without wip, a typical project command looks like:
+
+```bash
+wslc exec -it -w /app \
+  -e RAILS_ENV=development \
+  -e DATABASE_URL=postgres://db/app \
+  app bin/rails console
+```
+
+With wip:
+
+```bash
+wip rails console
+```
+
+What you get beyond the shorter line:
+
+| | Benefit |
+|---|---|
+| **Argument-array safety** | Every value is passed as one literal argument — no shell re-interpretation of spaces, quotes, `;`, or `$(...)` in an env value or path |
+| **`.env` support** | Loaded automatically, like Compose; `wslc` has none — see [Env Files](Env-Files) |
+| **`.dockerignore` support** | `wslc build` sends the context as-is; wip filters it first — see [Dockerignore](Dockerignore) |
+| **Build-context caching** | A persistent Windows-side shadow copy, incrementally updated — see [Shadow Build Context](Shadow-Build-Context) |
+| **Source sync** | The fix for slow bind-mounted boots — see [Fixing a Slow Boot](Fixing-a-Slow-Boot) |
+| **Sidecar orchestration** | Network creation and ordered startup, so `db`/`redis` resolve by name — see [Networking](Networking) |
+| **Restart approximation** | `wip up --watch` — see [Restart Policies](Restart-Policies) |
+| **Diagnostics** | `wip doctor`, `--debug` timings, resource snapshots, error hints |
+| **One place for commands** | A fresh clone runs `wip rspec` without tribal knowledge |
+
+## wip vs. real Docker Compose
+
+Where `compose-native` deliberately stops short:
+
+| Compose feature | wip `compose-native` |
+|---|---|
+| `image`, `command`, `environment`, `working_dir`, `user` | ✔ |
+| `ports`, `volumes` | short syntax only |
+| `build` (context, dockerfile, args) | ✔ — see [Compose Build](Compose-Build) |
+| `depends_on` ordering | ✔ — see [Compose Depends On](Compose-Depends-On) |
+| `depends_on` health conditions | ✘ |
+| `healthcheck` | ✘ |
+| `restart` | stored; approximated by `--watch` |
+| `profiles` | parsed; gated services skipped — see [Compose Profiles](Compose-Profiles) |
+| `${VAR}` interpolation | ✔ — see [Compose Variable Interpolation](Compose-Variable-Interpolation) |
+| YAML anchors / merge keys | ✔ |
+| `deploy` / scaling | ✘ |
+| `env_file` | ✘ (use `.env` next to `wip.yml`) |
+| `extends` | ✘ |
+| `entrypoint` | ✘ |
+| Top-level `networks:` / `volumes:` / `configs:` / `secrets:` | ignored (not rejected) |
+| Multi-service `logs` | one at a time |
+| `tty` / `stdin_open` / `networks` / `cap_add` per service | accepted and ignored |
+
+Full detail: [Compose File Support](Compose-File-Support).
+
+Anything unsupported **inside a service** is a load-time error naming the key, rather than a silent
+drop — so you find out at `wip doctor`, not three hours into debugging.
+
+## Can I keep using both?
+
+Yes, and it's a common setup: `compose.yml` stays the source of truth for services, `wip.yml` adds
+your commands on top. Teammates on plain Docker keep using `docker compose` against the same file;
+nothing about the services is duplicated.
+
+```yaml
+# wip.yml
+version: 1
+mode: compose-native
+compose:
+  service: app
+
+interaction:
+  rspec:
+    command: bundle exec rspec
+```
+
+The constraint is that your `compose.yml` must stay within the supported subset for
+`compose-native` to read it — or you use [`mode: compose`](Compose-Mode), which has no such limit
+because it delegates.
+
+## The honest summary
+
+If you're on Docker, use Docker Compose — it's more complete, more mature, and wip has no Docker
+backend. wip exists because WSLC has no equivalent, and the gaps around it (no `.dockerignore`,
+no `.env`, no Compose, slow bind mounts) are real enough to need filling.
+
+## Related
+
+- [Comparison](Comparison)
+- [Reusing an Existing compose.yml](Reusing-an-Existing-compose-yml)
+- [Third Party Compose Tools](Third-Party-Compose-Tools)


### PR DESCRIPTION
The wiki pages were outlines listing what each page should cover. Turn them
into a full wiki with one page per feature, sourced in-repo under wiki/ so
changes go through review instead of the wiki UI.

- 68 pages: hub pages index, feature pages explain
- one page per command (wip-init … wip-dispatch), per wip.yml feature
  (Dependencies, Interactions, Source Sync, Sync Modes, …), per compose.yml
  sub-feature, per error, and per guide
- new reference pages the outlines didn't call for: Configuration Errors
  (every ConfigError and its trigger), Compose Profiles, Compose Variable
  Interpolation, Compose Depends On, TTY Allocation, Architecture
- content verified against lib/wip/: error messages, defaults, flag names,
  and lookup orders are quoted from the source
- wiki/publish.sh mirrors the directory into the wiki repository

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012JXPYvP9qi4XLmjEEpe3sA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive wiki covering setup, configuration, operating modes, Compose support, commands, synchronization, builds, networking, troubleshooting, CI, and security.
  * Added command references, comparison guides, FAQs, glossary content, and task-oriented navigation.
  * Added guidance for architecture mismatches, restart policies, TTY behavior, registry authentication, missing tools, and performance issues.
  * Added documentation publishing and maintenance guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->