### PR TITLE
feat: add ruby --template preset to wip init

### DIFF
--- a/lib/wip/initializer.rb
+++ b/lib/wip/initializer.rb
@@ -11,6 +11,7 @@ module Wip
     # --template values wip init accepts, and the label used in the exclude: comment.
     TEMPLATE_LABELS = {
       'rails' => 'Rails',
+      'ruby' => 'Ruby',
       'node' => 'Node.js',
       'rust' => 'Rust',
       'csharp' => 'C#'
@@ -22,6 +23,7 @@ module Wip
     TEMPLATE_EXCLUDES = {
       'rails' => %w[.git log/ tmp/ storage/ public/assets/ public/packs/ .bundle/ vendor/bundle/
                     coverage/ node_modules/],
+      'ruby' => %w[.git log/ tmp/ .bundle/ vendor/bundle/ coverage/],
       'node' => %w[.git node_modules/ dist/ build/ .next/ .cache/ coverage/],
       'rust' => %w[.git target/],
       'csharp' => %w[.git bin/ obj/ .vs/ packages/]


### PR DESCRIPTION
Adds a plain-Ruby sync.exclude preset alongside the existing rails one, for non-Rails Ruby projects (.git, log/, tmp/, .bundle/, vendor/bundle/, coverage/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Ruby as a supported project template.
  - Added Ruby-specific exclusions to prevent temporary files, logs, dependency artifacts, coverage reports, and version-control data from being included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->