### PR TITLE
chore: Update homepage and metadata URIs in gemspec

### DIFF
--- a/lib/wip/version.rb
+++ b/lib/wip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wip
-  VERSION = '1.1.3'
+  VERSION = '1.1.4'
 end

--- a/wslc-wip.gemspec
+++ b/wslc-wip.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors = ['Wip contributors']
   spec.summary = 'A developer-friendly CLI wrapper for Microsoft WSLC'
   spec.description = 'Wip provides project commands and diagnostics for WSLC development environments.'
-  spec.homepage = 'https://wslc-wip.slidict.com/'
+  spec.homepage = 'https://github.com/slidict/wip'
   spec.license = 'MIT'
   spec.required_ruby_version = '>= 3.2'
   spec.files = Dir['lib/**/*', 'exe/*', 'README.md', 'LICENSE']
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thor', '~> 1.3'
   spec.metadata['rubygems_mfa_required'] = 'true'
   spec.metadata['homepage_uri'] = spec.homepage
-  spec.metadata['source_code_uri'] = 'https://github.com/slidict/wip'
   spec.metadata['changelog_uri'] = 'https://github.com/slidict/wip/releases'
-  spec.metadata['bug_tracker_uri'] = 'https://github.com/slidict/wip/issues'
+  spec.metadata['source_code_uri'] = 'https://github.com/slidict/wip/tree/v1.1.4'
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release**
  * Updated the package version to 1.1.4, making the latest release identifiable in package metadata.
  * Updated the project homepage and source code links to point to the GitHub repository, including the version-specific source view.
  * Removed the bug tracker metadata entry.
  * These updates provide clearer navigation to project information and the source associated with this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->