### PR TITLE
ci: publish the release from Linux, not the Windows build job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,16 +81,17 @@ jobs:
             fi
           fi
 
+  # Windows only because Native AOT cannot cross-compile between operating systems. Nothing
+  # else in the release needs it, and the publish job below exists because one of those other
+  # things actively breaks here.
   build:
-    name: Build and publish release
+    name: Build release artifacts
     needs: check
     if: needs.check.outputs.needed == 'true'
     runs-on: windows-latest
 
     permissions:
-      contents: write
-      # release-drafter builds the notes by reading merged pull requests.
-      pull-requests: read
+      contents: read
       id-token: write
       attestations: write
 
@@ -134,10 +135,45 @@ jobs:
 
           "archive=dist/$name" >> $env:GITHUB_OUTPUT
 
+      # Attested here rather than after the handoff so the subject is the file as it left the
+      # machine that built it.
       - name: Attest build provenance
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
         with:
           subject-path: ${{ steps.package.outputs.archive }}
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-dist
+          path: dist/
+          if-no-files-found: error
+          # Only has to survive the handoff to the next job.
+          retention-days: 1
+
+  # Split off the Windows job because release-drafter is not Windows-compatible: it builds the
+  # config path with node:path's join, so on a Windows runner it asks the GitHub API for
+  # `.github\release-drafter.yml` and gets a 404. There is no input that works around it --
+  # passing `.github/release-drafter.yml` is normalised to backslashes too, and then joined a
+  # second time. Publishing from Linux is the fix.
+  publish:
+    name: Publish release
+    needs: [check, build]
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      # release-drafter builds the notes by reading merged pull requests.
+      pull-requests: read
+
+    steps:
+      # No checkout: release-drafter reads its config through the API, and the artifacts
+      # come from the build job.
+      - name: Download build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: release-dist
+          path: dist
 
       # Publishes the draft that changelog.yml has been accumulating on every merge, and
       # creates the tag while doing it. The draft is what the decision to release was made
@@ -173,7 +209,7 @@ jobs:
   # automated release unsubmitted with nothing to show for it.
   winget:
     name: Submit to WinGet
-    needs: [check, build]
+    needs: [check, publish]
     uses: ./.github/workflows/winget.yml
     with:
       tag: ${{ needs.check.outputs.tag }}

--- a/docs/csharp-migration-plan.md
+++ b/docs/csharp-migration-plan.md
@@ -363,19 +363,27 @@ Cover the layers where input → output is a pure function:
 merge a version bump to main
       │
       ▼
-┌─ release.yml (windows-latest) ───────────────┐
+┌─ check (ubuntu-latest) ──────────────────────┐
+│  read <Version>; is that tag already out?    │
+└──────────────────┬───────────────────────────┘
+                   ▼  only if it is not
+┌─ build (windows-latest) ─────────────────────┐
 │  dotnet publish -r win-x64                   │
 │  → wip.exe → ZIP → SHA256                    │
 │  → actions/attest-build-provenance           │
 └──────────────────┬───────────────────────────┘
-                   ▼
-        GitHub Release (publish the release-drafter draft)
-                   │  on: release published
-                   ▼
+                   ▼  upload-artifact / download-artifact
+┌─ publish (ubuntu-latest) ────────────────────┐
+│  publish the release-drafter draft (= tag)   │
+│  attach the ZIP and SHA256SUMS               │
+└──────────────────┬───────────────────────────┘
+                   ▼  workflow_call
         winget.yml → opens a PR against microsoft/winget-pkgs
 ```
 
-Native AOT cannot cross-compile across operating systems, so **a Windows runner is mandatory**. Being Windows-only, though, **the matrix is a single job** (two, if arm64 ships).
+Native AOT cannot cross-compile across operating systems, so **a Windows runner is mandatory** for the build — and only for the build. Being Windows-only, **the build matrix is a single job** (two, if arm64 ships).
+
+Publishing is a separate Linux job because **release-drafter does not run on Windows**: it builds its config path with `node:path`'s `join`, so a Windows runner asks the API for `.github\release-drafter.yml` and gets a 404. No input works around it — `.github/release-drafter.yml` is normalised to backslashes and then joined a second time — so the Windows job hands its artifacts to Linux and the release is published there.
 
 ### 9.2 Changing the release trigger
 


### PR DESCRIPTION
Fixes the failure that stopped the v2.0.2 release.

## What broke

`release-drafter` does not run on Windows. It builds its config path with `node:path`'s `join` ([`src/common/config/normalize-filepath.ts:52`](https://github.com/release-drafter/release-drafter/blob/main/src/common/config/normalize-filepath.ts)):

```ts
import { dirname, isAbsolute, join, normalize } from 'node:path'
...
return join('.github', _filepath)
```

On a Windows runner that produces `.github\release-drafter.yml`, and the string goes straight to the GitHub contents API, which 404s:

```
Config not found in slidict/wip, falling back to slidict/.github
Error: Repo load failed. Config file not found with error 404.
       (target: slidict/.github:.github\release-drafter.yml)
```

`changelog.yml` has always worked because it runs on `ubuntu-latest`.

There is no input that works around this. Passing `config-name: .github/release-drafter.yml` fails too — the `normalize()` on the line above converts `/` to `\` on Windows, so the `startsWith('.github/')` guard is false and the path gets joined a second time into `.github\.github\release-drafter.yml`.

## What changed

Only the AOT build actually needs Windows, so publishing moves to its own Linux job:

```
check (ubuntu) → build (windows) → publish (ubuntu) → winget
                 ZIP/SHA256/attest ↓ artifact ↑ publish draft + attach assets
```

- `build` stops at the artifacts and hands them over via `upload-artifact`/`download-artifact`. Its permissions drop from `contents: write` to `contents: read`.
- The provenance attestation stays on the Windows runner, so the subject is the file as it left the machine that built it.
- `publish` needs no checkout — `release-drafter` reads its config through the API, and the artifacts come from the build job.
- `winget` now depends on `publish` rather than `build`.

The two new action pins are commit SHAs, not tag objects (both tags are lightweight, verified with `git ls-remote --tags` showing no `^{}` entry).

Section 9.1 of the migration plan is updated to match, including why the split exists.

## Release state

The v2.0.2 run failed at the publish step, so no tag and no release were created. The `check` job treats a missing release as unfinished, so once this lands the next push to `main` releases v2.0.2 as normal — nothing to clean up by hand.

## Note on the branch

PR #89 is already merged, so this branch was rebuilt from `origin/main` and the fix cherry-picked onto it. That keeps the dependabot bumps that landed in the meantime (`softprops/action-gh-release` 3.0.2, `attest-build-provenance`) and the v2.0.2 version bump, rather than reverting them. The diff against `main` is the two files below and nothing else.

---
_Generated by [Claude Code](https://claude.ai/code/session_016dGCDr3cjJda8mJj4c15TC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Release artifacts are now built and packaged on Windows, then published separately from Linux.
  * Release notes and downloadable artifacts are attached during the publishing stage.
  * WinGet submissions now begin after release publication is complete.

* **Documentation**
  * Updated the release pipeline diagram to reflect the separated build and publishing steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->