### PR TITLE
docs: note the Ruby to C# switch in the README intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ commands into a single `wip.yml`, and forwards them to `wslc.exe` / `wslc` as sa
 
 > **Status:** early release. Expect to track WSLC's own interface as it evolves.
 
+> **v2 switched from Ruby to a C# Native AOT binary.** Through v1, wip was a Ruby gem, which
+> meant a Ruby installation and a gem to keep in step with it. From v2 there is neither: `wip.exe`
+> is a single self-contained executable with no runtime to install, and no interpreter to start
+> before a command runs, so it should be noticeably quicker off the mark.
+>
+> The Ruby implementation has no further updates planned, but it is not gone — it stays available
+> at [v1.1.4](https://github.com/slidict/wip/releases/tag/v1.1.4) and as the
+> [`wslc-wip` gem](https://rubygems.org/gems/wslc-wip) on RubyGems.
+
 This README covers the fastest path to a running `wip.yml`. For everything else — every config
 key, every command's flags, guides, and troubleshooting — see the **[wip Wiki](https://github.com/slidict/wip/wiki)**.
 


### PR DESCRIPTION
The rewrite was only mentioned under **Known gaps & TODO**, where it reads as a note about how complete the port is rather than as something a reader arriving at v2 needs to know up front. This adds it to the intro section, next to the existing status note.

It covers the three things asked for:

- **What changed** — through v1 wip was a Ruby gem; from v2 it is a C# Native AOT binary.
- **Why it is better** — no Ruby installation and no gem to keep in step with it, and no interpreter to start before a command runs.
- **Where v1 still lives** — no further updates planned for the Ruby implementation, but it remains available at the [v1.1.4](https://github.com/slidict/wip/releases/tag/v1.1.4) tag and as the [`wslc-wip` gem](https://rubygems.org/gems/wslc-wip) on RubyGems.

The speed claim is deliberately phrased as an expectation ("should be noticeably quicker off the mark") rather than a figure, since nothing here has been benchmarked against the gem. The mechanism behind it — no runtime load — is stated as fact because it is one.

Docs only; one file, nine lines added.

---
_Generated by [Claude Code](https://claude.ai/code/session_016dGCDr3cjJda8mJj4c15TC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added migration guidance for version 2, including the transition from the Ruby gem to a self-contained C# Native AOT executable.
  * Clarified that version 2 requires no separate runtime or interpreter.
  * Added links to the retained Ruby v1.1.4 release and RubyGems package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->