### PR TITLE
fix: decide `wip up` from the container's state, not just its existence

### DIFF
--- a/src/Wip.Cli/CliContext.cs
+++ b/src/Wip.Cli/CliContext.cs
@@ -34,7 +34,47 @@ internal sealed partial class CliContext
     /// "dead" state — only <c>exited</c> is a live, restartable exit; <c>deleted</c> means the
     /// container itself is gone and needs <c>wip up</c> to recreate it, not <c>start</c>.
     /// </summary>
+    private const int WslcContainerStateRunning = 2;
+
     private const int WslcContainerStateExited = 3;
+
+    private const int WslcContainerStateDeleted = 4;
+
+    /// <summary>What <c>wip up</c> should do about a container that is already listed.</summary>
+    internal enum ContainerAction
+    {
+        /// <summary>No such container: create it.</summary>
+        Create,
+
+        /// <summary>Listed and startable: start it.</summary>
+        Start,
+
+        /// <summary>Already running: there is nothing to do.</summary>
+        AlreadyRunning,
+    }
+
+    /// <summary>
+    /// Decides from a container's listed state alone, so the rule is testable without a wslc.
+    /// <c>wslc list --all</c> reports containers in every state, so existence is not the same
+    /// question as startability: <c>start</c> on a running or deleted container fails with
+    /// ERROR_INVALID_STATE, which used to surface as a bare "not in an appropriate state"
+    /// from a plain <c>wip up</c>.
+    /// </summary>
+    /// <remarks>
+    /// An unreadable state falls through to <see cref="ContainerAction.Start"/> — the
+    /// behaviour before this existed. A state wslc reports in a shape wip does not understand
+    /// is a reason to keep doing what used to work, not to start deleting and recreating
+    /// containers on a guess.
+    /// </remarks>
+    internal static ContainerAction DecideContainerAction(bool exists, int? state) => (exists, state) switch
+    {
+        (false, _) => ContainerAction.Create,
+        (true, WslcContainerStateRunning) => ContainerAction.AlreadyRunning,
+
+        // Listed but gone. Starting it cannot work; recreating is the only way forward.
+        (true, WslcContainerStateDeleted) => ContainerAction.Create,
+        _ => ContainerAction.Start,
+    };
 
     private readonly CliOptions options;
     private Config? config;
@@ -348,18 +388,6 @@ internal sealed partial class CliContext
         return (code, output.ToString());
     }
 
-    private bool ResourceExists(IReadOnlyList<string> findCommand)
-    {
-        var (code, output) = Probe(findCommand);
-        if (code != 0)
-        {
-            return false;
-        }
-
-        using var document = ParseArray(output);
-        return document is not null && document.RootElement.GetArrayLength() > 0;
-    }
-
     /// <summary>
     /// Parses wslc's <c>--format json</c> output, or returns null when it is not a JSON array.
     /// </summary>
@@ -431,30 +459,46 @@ internal sealed partial class CliContext
 
     private void EnsureDependency(string name)
     {
-        if (ResourceExists(Builder.DependencyFind(name)))
+        var (exists, state) = ContainerEntry(Builder.DependencyFind(name), name);
+        switch (DecideContainerAction(exists, state))
         {
-            Console.Error.WriteLine($"wip: starting existing dependency '{name}'");
-            Execute(Builder.DependencyStart(name));
-        }
-        else
-        {
-            Console.Error.WriteLine($"wip: dependency '{name}' not found, creating it");
-            Execute(Builder.DependencyUp(name));
+            case ContainerAction.AlreadyRunning:
+                Console.Error.WriteLine($"wip: dependency '{name}' is already running");
+                break;
+
+            case ContainerAction.Start:
+                Console.Error.WriteLine($"wip: starting existing dependency '{name}'");
+                Execute(Builder.DependencyStart(name));
+                break;
+
+            default:
+                Console.Error.WriteLine($"wip: dependency '{name}' not found, creating it");
+                Execute(Builder.DependencyUp(name));
+                break;
         }
     }
 
     private void EnsureContainer(bool detach)
     {
         var interactive = Tty(!detach);
-        if (ResourceExists(Builder.Find()))
+        // Builder.Find() rather than the raw name: it goes through the builder's required-value
+        // check, so a config with no container: still fails the same way it always did.
+        var (exists, state) = ContainerEntry(Builder.Find(), Config.Container ?? "");
+        switch (DecideContainerAction(exists, state))
         {
-            Console.Error.WriteLine($"wip: starting existing container '{Config.Container}'");
-            Execute(Builder.Start(detach), interactive);
-        }
-        else
-        {
-            Console.Error.WriteLine($"wip: container '{Config.Container}' not found, creating it");
-            Execute(Builder.Up(detach), interactive);
+            case ContainerAction.AlreadyRunning:
+                Console.Error.WriteLine($"wip: container '{Config.Container}' is already running");
+                break;
+
+            case ContainerAction.Start:
+                Console.Error.WriteLine($"wip: starting existing container '{Config.Container}'");
+                Execute(Builder.Start(detach), interactive);
+                break;
+
+            default:
+                Console.Error.WriteLine($"wip: container '{Config.Container}' not found, creating it");
+                Execute(Builder.Up(detach), interactive);
+                break;
         }
     }
 
@@ -674,18 +718,29 @@ internal sealed partial class CliContext
     /// a one-line change. The raw entry is logged under --debug so that is immediately
     /// visible instead of silently doing nothing forever.
     /// </summary>
-    private int? ContainerStatus(string name)
+    private int? ContainerStatus(string name) => ContainerEntry(Builder.DependencyFind(name), name).State;
+
+    /// <summary>
+    /// One probe answering both questions, because they come from the same listing. Splitting
+    /// them across two calls would run <c>wslc list</c> twice and leave room for the answers
+    /// to disagree, which is exactly the gap this is here to close.
+    /// </summary>
+    /// <returns>
+    /// Whether the container is listed at all, and the state it reports. A null state on a
+    /// listed container means wslc reported it in a shape wip does not understand.
+    /// </returns>
+    private (bool Exists, int? State) ContainerEntry(IReadOnlyList<string> findCommand, string name)
     {
-        var (code, output) = Probe(Builder.DependencyFind(name));
+        var (code, output) = Probe(findCommand);
         if (code != 0)
         {
-            return null;
+            return (false, null);
         }
 
         using var document = ParseArray(output);
         if (document is null)
         {
-            return null;
+            return (false, null);
         }
 
         var first = document.RootElement.EnumerateArray().FirstOrDefault();
@@ -694,13 +749,16 @@ internal sealed partial class CliContext
             Console.Error.WriteLine($"wip: [debug] '{name}': {first}");
         }
 
+        if (first.ValueKind != JsonValueKind.Object)
+        {
+            return (false, null);
+        }
+
         // TryGetInt32 rather than GetInt32: a future wslc could report State as a string, and
         // a watch loop should keep polling instead of taking the whole command down.
-        return first.ValueKind == JsonValueKind.Object &&
-               first.TryGetProperty("State", out var state) &&
-               state.TryGetInt32(out var value)
-            ? value
-            : null;
+        return first.TryGetProperty("State", out var state) && state.TryGetInt32(out var value)
+            ? (true, value)
+            : (true, null);
     }
 
     /// <summary>Runs <paramref name="body"/> every <paramref name="interval"/> seconds until Ctrl-C.</summary>

--- a/tests/Wip.Tests/ContainerActionTests.cs
+++ b/tests/Wip.Tests/ContainerActionTests.cs
@@ -1,0 +1,88 @@
+using Wip.Cli;
+
+namespace Wip.Tests;
+
+/// <summary>
+/// `wslc list --all` reports containers in every state, so a container being listed does not
+/// mean it can be started. `start` on a running or deleted container fails with
+/// ERROR_INVALID_STATE — which a plain `wip up` used to surface as an unexplained
+/// "not in an appropriate state" after a successful build.
+/// </summary>
+public class ContainerActionTests
+{
+    private const int Invalid = 0;
+    private const int Created = 1;
+    private const int Running = 2;
+    private const int Exited = 3;
+    private const int Deleted = 4;
+
+    [Fact]
+    public void MissingContainerIsCreated()
+    {
+        Assert.Equal(
+            CliContext.ContainerAction.Create,
+            CliContext.DecideContainerAction(exists: false, state: null));
+    }
+
+    [Theory]
+    [InlineData(Created)]
+    [InlineData(Exited)]
+    public void ListedAndStartableIsStarted(int state)
+    {
+        Assert.Equal(
+            CliContext.ContainerAction.Start,
+            CliContext.DecideContainerAction(exists: true, state: state));
+    }
+
+    [Fact]
+    public void RunningContainerIsLeftAlone()
+    {
+        Assert.Equal(
+            CliContext.ContainerAction.AlreadyRunning,
+            CliContext.DecideContainerAction(exists: true, state: Running));
+    }
+
+    /// <summary>
+    /// Listed but gone. Starting it cannot work, so the only way forward is to recreate it —
+    /// which is what wslc's own state list means by `deleted`.
+    /// </summary>
+    [Fact]
+    public void DeletedContainerIsRecreated()
+    {
+        Assert.Equal(
+            CliContext.ContainerAction.Create,
+            CliContext.DecideContainerAction(exists: true, state: Deleted));
+    }
+
+    /// <summary>
+    /// A state wip cannot read is a reason to keep doing what used to work, not to start
+    /// removing and recreating containers on a guess. `invalid` is included deliberately: it
+    /// is not a state wslc parks a container in, and treating it as "recreate" would risk
+    /// destroying one over a transient read.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData(Invalid)]
+    [InlineData(99)]
+    public void UnreadableStateKeepsTheOldBehaviour(int? state)
+    {
+        Assert.Equal(
+            CliContext.ContainerAction.Start,
+            CliContext.DecideContainerAction(exists: true, state: state));
+    }
+
+    /// <summary>
+    /// Existence wins over any state: a container that is not listed is created regardless of
+    /// what a stale state value might say.
+    /// </summary>
+    [Theory]
+    [InlineData(Running)]
+    [InlineData(Exited)]
+    [InlineData(Deleted)]
+    public void AbsenceOutranksState(int state)
+    {
+        Assert.Equal(
+            CliContext.ContainerAction.Create,
+            CliContext.DecideContainerAction(exists: false, state: state));
+    }
+}


### PR DESCRIPTION
## The bug

A plain `wip up` failed right after a successful build:

```
wip: building service 'app' (tag: wip-compose-app:latest) from C:\Users\yusuk\codes\btape
...
exporting to image
wip: starting existing container 'app'
グループまたはリソースは要求した操作の実行に適切な状態ではありません。
エラー コード: ERROR_INVALID_STATE
```

`EnsureContainer` asked only whether the container was listed:

```csharp
if (ResourceExists(Builder.Find()))
{
    Execute(Builder.Start(detach), interactive);   // no state check
}
```

`Builder.Find()` is `wslc list --all --filter name=… --format json`. **`--all` lists containers in every state**, so being listed never meant being startable. Two states make `start` invalid — `running` (2) and `deleted` (4) — and both landed in that branch, where wslc rejected the transition. The user's only way through was `wip down && wip up`.

The information needed was already there. `CliContext` documents wslc's state list (confirmed against microsoft/WSL's `ContainerModel.h`) and says outright that `deleted` "needs `wip up` to recreate it, **not `start`**", and `ContainerStatus()` already reads it — but only `--watch`'s restart loop ever called it. The rule was written down and not applied where it mattered.

## The fix

| state | before | after |
|---|---|---|
| 1 created / 3 exited | `start` | `start` (unchanged) |
| 2 running | `start` → error | nothing to do |
| 4 deleted | `start` → error | recreate |
| unreadable | `start` | `start` (unchanged) |

An unreadable state deliberately keeps the old behaviour rather than recreating a container on a guess — a state wslc reports in a shape wip does not understand is a reason to keep doing what worked, not to start destroying things. `invalid` (0) is covered by a test for the same reason.

Dependencies had the identical existence-then-start shape and are fixed the same way.

Existence and state now come from **one** probe. They are answers to the same listing, so asking twice would run `wslc list` twice and leave room for the two answers to disagree — which is the gap being closed.

## On the design choice

For a foreground `wip up` on an already-running container, this reports "already running" and stops rather than attaching. Attaching would need something other than `wslc start -a -i`, which is precisely what a running container rejects; that is a separate feature, not part of fixing the error.

## Testing

The decision is a pure function, so it is verifiable without a wslc — `CliContext` reaches the outside world through a real process runner, and a rule this small should not need one to test. 11 new cases in `ContainerActionTests`.

- Full suite: **520 passed, 2 skipped** (the 2 skips are pre-existing).
- Mutation-checked: pointing the `running` and `deleted` arms back at `Start` fails exactly 2 tests, so the assertions do constrain the arms rather than passing by construction.
- The golden corpus is untouched — it covers `CommandBuilder` argv and `Config`, i.e. what commands look like, not when they are issued.

Note that `Builder.Find()` is still what the primary container probes with, so a config with no `container:` fails through the builder's required-value check exactly as before.

---
_Generated by [Claude Code](https://claude.ai/code/session_016dGCDr3cjJda8mJj4c15TC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `wip up` startup behavior based on container state.
  * Running containers are preserved, startable containers are started, and deleted containers are recreated.
  * Missing or unreadable container information continues to use safe fallback behavior.

* **Tests**
  * Added coverage for missing, running, deleted, startable, unreadable, and conflicting container states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->