### PR TITLE
Document winget manifest structure and add example manifests

### DIFF
--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -6,8 +6,8 @@ it, registers `wip.exe` under a links directory, and puts that directory on PATH
 
 `.github/workflows/winget.yml` opens the pull request against
 [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) automatically when a release
-is published. The manifests below are what that produces; they live here so the shape is
-reviewable in this repository and can be validated by hand before the first submission.
+is published. [`manifests/`](manifests) holds what that produces, so the shape is reviewable
+in this repository and can be validated by hand before the first submission.
 
 ## The token is the risky part — read this first
 
@@ -60,71 +60,44 @@ onward, not the first.
 ## Validating locally before the first submission
 
 The first submission gets a human review, and a rejected one costs days. Check it locally
-first, against a real published release:
+first, against a real published release. Both commands are Windows-only — winget does not
+run under WSL2, so use a PowerShell or cmd prompt on the host:
 
 ```powershell
-winget validate --manifest packaging/winget/manifests
-winget install --manifest packaging/winget/manifests
+cd packaging\winget
+winget validate --manifest .\manifests
+winget install --manifest .\manifests
 ```
+
+`winget install --manifest` really installs, so expect `wip` on PATH afterwards; undo it with
+`winget uninstall Slidict.Wip`.
+
+Both commands need a winget client that knows the schema version the manifests declare —
+`winget --version` should be 1.10 or newer for the 1.10.0 manifests here. An older client
+rejects them at parse time, which looks like a manifest error but is not one.
 
 ## Manifest shape
 
-Three files are required. `<version>` and `<sha256>` are filled in per release; everything
-else is stable.
+Three files are required, and they live in [`manifests/`](manifests):
 
-`ManifestVersion` below shows the shape, not a version to copy: winget-pkgs retires older
-schema versions and can reject a submission that uses one. The automation emits whatever
-schema its tooling targets, so **check the schema version currently accepted by winget-pkgs
-before the first submission** and let `winget validate` confirm it.
+| File | `ManifestType` | What it carries |
+|---|---|---|
+| [`Slidict.Wip.yaml`](manifests/Slidict.Wip.yaml) | `version` | The identifier and which locale is the default |
+| [`Slidict.Wip.installer.yaml`](manifests/Slidict.Wip.installer.yaml) | `installer` | The archive URL, its hash, and the nested-portable wiring |
+| [`Slidict.Wip.locale.en-US.yaml`](manifests/Slidict.Wip.locale.en-US.yaml) | `defaultLocale` | Publisher, license and description metadata |
 
-```yaml
-# Slidict.Wip.installer.yaml
-PackageIdentifier: Slidict.Wip
-PackageVersion: <version>
-Installers:
-  # The installer-shape keys sit on the entry rather than at the root: that is where the
-  # schema always accepts them, and it is the shape an arm64 sibling needs anyway.
-  - Architecture: x64
-    InstallerType: zip
-    NestedInstallerType: portable
-    NestedInstallerFiles:
-      - RelativeFilePath: wip.exe
-        PortableCommandAlias: wip
-    InstallerUrl: https://github.com/slidict/wip/releases/download/v<version>/wip-<version>-win-x64.zip
-    InstallerSha256: <sha256>
-ManifestType: installer
-ManifestVersion: 1.6.0
-```
+`PackageVersion`, `ReleaseDate`, `InstallerUrl` and `InstallerSha256` change per release;
+everything else is stable. The hash is the one the release publishes in `SHA256SUMS`
+alongside the zip, so it can be copied from there rather than recomputed.
 
-```yaml
-# Slidict.Wip.locale.en-US.yaml
-PackageIdentifier: Slidict.Wip
-PackageVersion: <version>
-PackageLocale: en-US
-Publisher: slidict
-PublisherUrl: https://github.com/slidict
-PackageName: wip
-PackageUrl: https://github.com/slidict/wip
-License: MIT
-LicenseUrl: https://github.com/slidict/wip/blob/main/LICENSE
-ShortDescription: A developer-friendly CLI wrapper for Microsoft WSLC.
-Tags:
-  - wsl
-  - wslc
-  - containers
-  - cli
-ManifestType: defaultLocale
-ManifestVersion: 1.6.0
-```
-
-```yaml
-# Slidict.Wip.yaml
-PackageIdentifier: Slidict.Wip
-PackageVersion: <version>
-DefaultLocale: en-US
-ManifestType: version
-ManifestVersion: 1.6.0
-```
+`ManifestVersion` is **not** a set-and-forget field: winget-pkgs retires older schema
+versions and can reject a submission that uses one. These files declare `1.10.0`, the newest
+schema in `microsoft/winget-cli` at the time they were written. Before the first submission,
+confirm that is still current — the schema directory in
+[winget-cli](https://github.com/microsoft/winget-cli/tree/master/schemas/JSON/manifests) is
+the authority — and let `winget validate` have the last word. Past the first submission the
+automation emits whatever schema its own tooling targets, and these files are the
+hand-checked reference rather than the thing submitted.
 
 ## If code signing is adopted
 

--- a/packaging/winget/manifests/Slidict.Wip.installer.yaml
+++ b/packaging/winget/manifests/Slidict.Wip.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Slidict.Wip
+PackageVersion: 2.0.2
+ReleaseDate: 2026-08-15
+Installers:
+  # The installer-shape keys sit on the entry rather than at the root: that is where the
+  # schema always accepts them, and it is the shape an arm64 sibling needs anyway.
+  - Architecture: x64
+    InstallerType: zip
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      # The archive holds wip.exe at its root -- no version-stamped directory to walk
+      # through -- so this path is just the file name.
+      - RelativeFilePath: wip.exe
+        PortableCommandAlias: wip
+    InstallerUrl: https://github.com/slidict/wip/releases/download/v2.0.2/wip-2.0.2-win-x64.zip
+    InstallerSha256: EE2782F4E8C1EFA2985D802BE67BEA1C7868DD9EB858B2A5190B8AD82C06C238
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/packaging/winget/manifests/Slidict.Wip.locale.en-US.yaml
+++ b/packaging/winget/manifests/Slidict.Wip.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Slidict.Wip
+PackageVersion: 2.0.2
+PackageLocale: en-US
+Publisher: slidict
+PublisherUrl: https://github.com/slidict
+PublisherSupportUrl: https://github.com/slidict/wip/issues
+PackageName: wip
+PackageUrl: https://github.com/slidict/wip
+License: MIT
+LicenseUrl: https://github.com/slidict/wip/blob/main/LICENSE
+ShortDescription: A developer-friendly CLI wrapper for Microsoft WSLC.
+Tags:
+  - wsl
+  - wslc
+  - containers
+  - cli
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/packaging/winget/manifests/Slidict.Wip.yaml
+++ b/packaging/winget/manifests/Slidict.Wip.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Slidict.Wip
+PackageVersion: 2.0.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary
This PR reorganizes and expands the winget packaging documentation to be clearer and more actionable, and adds concrete example manifest files for the v2.0.2 release.

## Key Changes
- **Reorganized README structure**: Moved manifest examples from inline YAML blocks into a new `manifests/` directory with actual files, making them easier to reference and validate
- **Added three manifest files** for v2.0.2:
  - `Slidict.Wip.yaml` (version manifest)
  - `Slidict.Wip.installer.yaml` (installer details with URL and hash)
  - `Slidict.Wip.locale.en-US.yaml` (metadata and description)
- **Improved validation instructions**: Clarified that validation commands are Windows-only, require a recent winget client (1.10+), and provided exact command syntax with proper path handling
- **Clarified manifest versioning**: Emphasized that `ManifestVersion` is not set-and-forget, explained the schema retirement risk, and documented how to verify current schema versions before submission
- **Added manifest change summary**: Created a table showing which fields change per release vs. which are stable, and noted that hashes can be copied from `SHA256SUMS` in releases
- **Added schema language server directives**: Each manifest file includes the appropriate `yaml-language-server` comment for IDE schema validation

## Notable Details
- Manifests now declare schema version `1.10.0` with proper schema URIs
- Example includes v2.0.2 with a real release date and installer hash
- Documentation clarifies the distinction between hand-checked reference manifests (these files) and automation-generated submissions to winget-pkgs
- Added note about `winget uninstall` for cleanup after testing

https://claude.ai/code/session_01Sdn4GRPgTMTvHf4ePfkZeg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WinGet manifests for Slidict.Wip version 2.0.2.
  * Enabled portable x64 ZIP installation with a command alias and verified download checksum.
  * Added package metadata, licensing, description, tags, and release information.

* **Documentation**
  * Updated WinGet installation and validation instructions, including PATH changes and supported client requirements.
  * Documented manifest files, release fields, schema version, and validation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->