### PR TITLE
fix(platform): refuse WSL-side bind mounts instead of mounting them empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,15 +118,17 @@ through WinGet does not move it, because the alias it puts on PATH stays at a fi
 > resolves a `-v` source as a Windows path, and when the result does not exist it mounts an
 > *empty directory* rather than failing — so wip's earlier translation of that UNC path to
 > `/home/u/proj` booted a container with none of your files in it and no error to explain
-> why. wip therefore refuses `sync.source` on the WSL filesystem by name, and `wip up` warns
-> about `volumes:`, which wslc resolves itself. Put the project on `C:\`
+> why. wip therefore refuses `sync.source` on the WSL filesystem by name, and `wip up` and
+> `wip run` warn about `volumes:`, which wslc resolves itself. Put the project on `C:\`
 > (`C:\src\myproject`) and run wip from there.
 >
 > **Whether wslc can mount the UNC path directly is a separate question, and unmeasured** —
 > refusing is the safe default until someone runs it, not a measured verdict. This all comes
 > from reading wslc's source, so both other readings stay one environment variable away:
 > `WIP_WSL_PATH=unc` hands wslc the UNC path unchanged and `WIP_WSL_PATH=linux` restores the
-> old `/home/...` translation. If you measure what wslc really does, please
+> old `/home/...` translation. Either way it changes only what `sync.source` resolves to — it
+> rewrites no `volumes:` entry, so the `wip up` / `wip run` warning stands under every value.
+> If you measure what wslc really does, please
 > [say so in an issue](https://github.com/slidict/wip/issues) — see
 > [the migration plan](docs/csharp-migration-plan.md) §3.
 

--- a/README.md
+++ b/README.md
@@ -114,17 +114,19 @@ path, so put the full path in by hand. Re-run the snippet if `wip.exe` ever move
 through WinGet does not move it, because the alias it puts on PATH stays at a fixed location.
 
 > **Keep the project on the Windows filesystem.** A project under `~/proj` inside a
-> distribution reaches wip as a UNC path (`\\wsl.localhost\Ubuntu\home\u\proj`), and wslc
-> cannot bind-mount that: it resolves a `-v` source as a Windows path, and when the result
-> does not exist it mounts an *empty directory* rather than failing. A WSL-side project would
-> therefore boot a container with none of your files in it and no error to explain why — so
-> wip refuses `sync.source` there by name, and `wip up` warns about `volumes:`, which wslc
-> resolves itself. Put the project on `C:\` (`C:\src\myproject`) and run wip from there.
+> distribution reaches wip as a UNC path (`\\wsl.localhost\Ubuntu\home\u\proj`). wslc
+> resolves a `-v` source as a Windows path, and when the result does not exist it mounts an
+> *empty directory* rather than failing — so wip's earlier translation of that UNC path to
+> `/home/u/proj` booted a container with none of your files in it and no error to explain
+> why. wip therefore refuses `sync.source` on the WSL filesystem by name, and `wip up` warns
+> about `volumes:`, which wslc resolves itself. Put the project on `C:\`
+> (`C:\src\myproject`) and run wip from there.
 >
-> This comes from reading wslc's source, not from a run on real hardware, so both other
-> readings stay one environment variable away: `WIP_WSL_PATH=unc` hands wslc the UNC path
-> unchanged and `WIP_WSL_PATH=linux` restores wip's earlier `/home/...` translation. If you
-> measure what wslc really does, please
+> **Whether wslc can mount the UNC path directly is a separate question, and unmeasured** —
+> refusing is the safe default until someone runs it, not a measured verdict. This all comes
+> from reading wslc's source, so both other readings stay one environment variable away:
+> `WIP_WSL_PATH=unc` hands wslc the UNC path unchanged and `WIP_WSL_PATH=linux` restores the
+> old `/home/...` translation. If you measure what wslc really does, please
 > [say so in an issue](https://github.com/slidict/wip/issues) — see
 > [the migration plan](docs/csharp-migration-plan.md) §3.
 
@@ -286,13 +288,14 @@ listed here rather than left implicit — see
 
 ### Needs verification on real hardware
 
-- [ ] **Which host paths `wslc` accepts** — the one open design question, now answered from
-      wslc's source but not yet from a run on real hardware. wslc resolves a `-v` source with
-      `GetFullPathNameW` — as a Windows path — and mounts an empty directory instead of
-      failing when it does not exist, so wip no longer translates a UNC path into
-      `/home/...`: `Platform/WslPath.ForWslc` refuses the WSL filesystem with an explanation,
-      and `WIP_WSL_PATH=unc` / `WIP_WSL_PATH=linux` keep the other two readings testable in
-      place. Measure `wslc run -v` against a Linux path, a Windows-local path, and a UNC path;
+- [ ] **Which host paths `wslc` accepts** — the one open design question. wslc's source rules
+      one answer out: a `-v` source is resolved with `GetFullPathNameW` — as a Windows path —
+      and a source that does not exist mounts an empty directory instead of failing, so
+      translating a UNC path into `/home/...` broke silently. `Platform/WslPath.ForWslc` now
+      refuses the WSL filesystem with an explanation, which is a safe default rather than a
+      measurement: **whether wslc mounts a UNC path directly is still unknown**, and
+      `WIP_WSL_PATH=unc` / `WIP_WSL_PATH=linux` keep both other readings testable in place.
+      Measure `wslc run -v` against a Linux path, a Windows-local path, and a UNC path;
       whichever wins becomes the default, and that one function is still all that changes.
       See the plan §3.
 - [ ] **Interactive TTY from a WSL2 shell** — confirm `wslc exec -it`, Ctrl-C, and terminal

--- a/README.md
+++ b/README.md
@@ -113,11 +113,20 @@ appends — that is where WinGet's `wip.exe` alias lives. If you have turned tha
 path, so put the full path in by hand. Re-run the snippet if `wip.exe` ever moves; upgrading
 through WinGet does not move it, because the alias it puts on PATH stays at a fixed location.
 
-> **Note on project location.** A project on the WSL filesystem reaches wip as a UNC path
-> (`\\wsl.localhost\...`), which changes what `sync.source` and `volumes:` hand to wslc. What
-> wslc accepts there is still being measured — see
-> [the migration plan](docs/csharp-migration-plan.md) §3. Projects on the Windows filesystem
-> are unaffected.
+> **Keep the project on the Windows filesystem.** A project under `~/proj` inside a
+> distribution reaches wip as a UNC path (`\\wsl.localhost\Ubuntu\home\u\proj`), and wslc
+> cannot bind-mount that: it resolves a `-v` source as a Windows path, and when the result
+> does not exist it mounts an *empty directory* rather than failing. A WSL-side project would
+> therefore boot a container with none of your files in it and no error to explain why — so
+> wip refuses `sync.source` there by name, and `wip up` warns about `volumes:`, which wslc
+> resolves itself. Put the project on `C:\` (`C:\src\myproject`) and run wip from there.
+>
+> This comes from reading wslc's source, not from a run on real hardware, so both other
+> readings stay one environment variable away: `WIP_WSL_PATH=unc` hands wslc the UNC path
+> unchanged and `WIP_WSL_PATH=linux` restores wip's earlier `/home/...` translation. If you
+> measure what wslc really does, please
+> [say so in an issue](https://github.com/slidict/wip/issues) — see
+> [the migration plan](docs/csharp-migration-plan.md) §3.
 
 ## Quick start
 
@@ -277,12 +286,15 @@ listed here rather than left implicit — see
 
 ### Needs verification on real hardware
 
-- [ ] **Which host paths `wslc` accepts** — the one open design question. A project on the WSL
-      filesystem reaches `wip.exe` as a UNC path (`\\wsl.localhost\...`), which changes what
-      `sync.source` and `volumes:` hand to `wslc`. Measure `wslc run -v` against a Linux path,
-      a Windows-local path, and a UNC path. The translation lives in one function,
-      `Platform/WslPath.ForWslc`, which currently assumes Linux paths are accepted; if that is
-      wrong, that function is the only thing that changes. See the plan §3.
+- [ ] **Which host paths `wslc` accepts** — the one open design question, now answered from
+      wslc's source but not yet from a run on real hardware. wslc resolves a `-v` source with
+      `GetFullPathNameW` — as a Windows path — and mounts an empty directory instead of
+      failing when it does not exist, so wip no longer translates a UNC path into
+      `/home/...`: `Platform/WslPath.ForWslc` refuses the WSL filesystem with an explanation,
+      and `WIP_WSL_PATH=unc` / `WIP_WSL_PATH=linux` keep the other two readings testable in
+      place. Measure `wslc run -v` against a Linux path, a Windows-local path, and a UNC path;
+      whichever wins becomes the default, and that one function is still all that changes.
+      See the plan §3.
 - [ ] **Interactive TTY from a WSL2 shell** — confirm `wslc exec -it`, Ctrl-C, and terminal
       resizing behave when `wip.exe` is launched from bash rather than PowerShell.
 - [ ] **UNC walk performance** — staging a large build context reads every file over 9p.

--- a/docs/csharp-migration-plan.md
+++ b/docs/csharp-migration-plan.md
@@ -11,9 +11,10 @@ open is recorded here rather than edited out, because the reasoning is what make
 remaining decisions reviewable.
 
 **Still open:** the path model in §3 — Phase 0 Spikes 1 and 2 need Windows with WSL2 and wslc
-present, so `Platform/WslPath.ForWslc` currently implements branch (a) of §3.2 as a
-provisional answer, isolated to that one function. §11 lists everything else awaiting a
-first-hand check.
+present. Reading wslc's source has since ruled branch (a) out (§3.2a), so
+`Platform/WslPath.ForWslc` now implements branch (b): the WSL filesystem is refused with an
+explanation instead of silently mistranslated, still isolated to that one function. §11 lists
+everything else awaiting a first-hand check.
 
 ---
 
@@ -117,6 +118,23 @@ Worth noting: the existing code already carries a workaround comment about `wslc
 | **(c) wslc handles UNC directly** | No translation needed, but I/O performance over 9p needs separate measurement before calling it usable |
 
 **Current expectation is (a) or (b).** Since wslc runs containers inside a WSL2 VM it presumably has some Linux path representation, which favors (a) — but **no implementation decision gets made without confirming this.**
+
+### 3.2a What wslc's source says (branch (a) is out)
+
+The expectation above was wrong, and wrong in the worst possible way. Reading wslc's own source:
+
+- a `-v` source is resolved with **`GetFullPathNameW`** — i.e. as a **Windows** path. `/home/u/proj` is not a Linux path to wslc, it is a rooted Windows path, and resolves against the current drive as `C:\home\u\proj`
+- a source that **does not exist is not an error**: wslc mounts an **empty directory** (`/mnt/<GUID>`) and the container starts normally
+
+Branch (a) therefore did not merely fail — it failed *silently*. A project on the WSL filesystem (where most Rails work lives) got `sync.source` and `volumes:` translated into paths that exist nowhere, and the container came up with none of the project in it and nothing printed to explain it. There is no error message to search for, so there is no way for the person hitting it to get out.
+
+**So the implementation is branch (b):**
+
+- `WslPath.ForWslc` refuses a WSL-side path with a message that names the setting, the path, and the fix ("move the project onto the Windows filesystem"), rather than translating it
+- `wip doctor` reports the project's location as a `[FAIL]` for the same reason, and `wip up` / `wip run` warn about `volumes:` — which wip passes through verbatim, so wslc resolves those itself and the refusal never sees them
+- the build context is **not** affected and is not run through `ForWslc` at all: §3.3 stages it into a Windows-local cache and hands wslc `"."`, so a WSL-side context works and must keep working
+
+This is source reading, not a measurement, so the other two branches stay reachable through the `WIP_WSL_PATH` environment variable — `unc` passes the UNC path through (branch (c)), `linux` restores the old translation (branch (a)) — and Spike 1 below still has to run. Whichever branch it confirms becomes the default, and `ForWslc` is still the only function that changes.
 
 ### 3.3 Stage the build context locally, always
 
@@ -455,9 +473,9 @@ Three files are required: version, installer, and locale manifests.
 **🔴 Spike 1: path model (highest priority — other decisions depend on it)**
 
 - [ ] Measure the working directory a Windows exe actually receives when launched from WSL2 bash (is it UNC, and in which form?)
-- [ ] Pass (a) Linux paths, (b) Windows-local paths, and (c) UNC paths to `wslc.exe run -v` and **measure which are accepted**
+- [ ] Pass (a) Linux paths, (b) Windows-local paths, and (c) UNC paths to `wslc.exe run -v` and **measure which are accepted** — including whether a non-existent source really does mount empty rather than fail (§3.2a)
 - [ ] Check `wslc.exe build` behavior with a UNC cwd
-- [ ] → Settle the approach via the §3.2 decision tree. **If (b), lock in the "projects live on the Windows filesystem" constraint and document it in the README and wiki**
+- [ ] → Settle the approach via the §3.2 decision tree. **(b) is what ships today on the strength of §3.2a; measuring it confirms the constraint or replaces the default in `WslPath.ForWslc`**
 
 **🔴 Spike 2: interactive terminal**
 
@@ -544,7 +562,7 @@ Close out what golden tests can't reach. Run **from both PowerShell and WSL2 bas
 
 | Risk | Impact | Mitigation |
 |---|---|---|
-| 🔴 **wslc rejects bind mounts of WSL-side paths** | **High** | Settle first in Phase 0 Spike 1. If (b), document "projects live on the Windows filesystem" as a constraint. **This outcome may require rethinking the purpose of `sync:` itself** |
+| 🔴 **wslc rejects bind mounts of WSL-side paths** | **High** | Per §3.2a this is what wslc's source says, and it *accepts* them into an empty mount rather than rejecting them — so wip refuses the WSL filesystem itself and documents "projects live on the Windows filesystem" as a constraint. Phase 0 Spike 1 still confirms it. **This outcome may require rethinking the purpose of `sync:` itself** |
 | **Walking files over UNC is too slow for large trees** | Medium | Take attributes from enumeration (§3.3). Measure in Phase 4; if inadequate, consider pushing the walk itself over to wslc/wsl.exe |
 | **An exe launched from WSL bash has no console fit for interaction** | Medium | Phase 0 Spike 2. Fall back to ConPTY (§4.2 option B) if needed |
 | **Some library doesn't work under AOT** | Medium | Phase 0 Spike 3 exercises every dependency up front. Fallbacks exist: hand-rolled YAML parser, hand-rolled CLI parser |
@@ -554,7 +572,7 @@ Close out what golden tests can't reach. Run **from both PowerShell and WSL2 bas
 
 ### To confirm from primary sources before starting
 
-1. **wslc.exe's path acceptance rules** — §3. Nothing in this repository answers it; it needs hands-on measurement
+1. **wslc.exe's path acceptance rules** — §3. wslc's source answers it (§3.2a: `GetFullPathNameW`, and an empty mount for a source that does not exist); it still needs hands-on measurement to confirm
 2. **.NET version** — net10.0 (LTS) is assumed; confirm support status at kickoff
 3. **System.CommandLine's current version and real AOT status** — particularly whether the unknown-command fallback is expressible cleanly
 4. **YamlDotNet's AOT track record** — zero reflection warnings via the representation model?
@@ -570,5 +588,5 @@ Close out what golden tests can't reach. Run **from both PowerShell and WSL2 bas
 
 - **Going Windows-only cut the port by roughly 20–30%.** The openpty, flock, and UnixFileMode P/Invokes, `/proc` parsing, the `Gem.win_platform?` branches, and the Linux RIDs with their separate distribution path all disappear.
 - **Accepting breaking changes and moving Ruby out avoids the largest liability: maintaining two implementations in parallel.** The one prerequisite is extracting the golden fixtures before it goes (Phase 1).
-- **One genuinely hard problem remains: the path model (§3).** Moving execution to the Windows side changes the meaning of all three places that hand wslc a host absolute path — `sync.source`, `volumes:`, and the build context. The build context is solved by staging locally at all times, but **the two bind-mount sites can't be settled until wslc's real behavior is measured.**
+- **One genuinely hard problem remains: the path model (§3).** Moving execution to the Windows side changes the meaning of all three places that hand wslc a host absolute path — `sync.source`, `volumes:`, and the build context. The build context is solved by staging locally at all times; for the two bind-mount sites, wslc's source (§3.2a) says WSL-side paths cannot work and fail without saying so, **so wip refuses them out loud pending a measurement rather than translating them into silence.**
 - **How to proceed:** settle the path model and get the distribution path working in Phase 0; extract the golden fixtures before Ruby leaves. With those two done, the rest is a mechanical port.

--- a/docs/csharp-migration-plan.md
+++ b/docs/csharp-migration-plan.md
@@ -128,13 +128,15 @@ The expectation above was wrong, and wrong in the worst possible way. Reading ws
 
 Branch (a) therefore did not merely fail — it failed *silently*. A project on the WSL filesystem (where most Rails work lives) got `sync.source` and `volumes:` translated into paths that exist nowhere, and the container came up with none of the project in it and nothing printed to explain it. There is no error message to search for, so there is no way for the person hitting it to get out.
 
-**So the implementation is branch (b):**
+**What this does and does not settle.** It disproves branch (a): a translated Linux path is a Windows path to wslc, and a wrong one. It says nothing about branch (c) — a UNC path *does* resolve through `GetFullPathNameW`, and *does* exist, so whether wslc can mount one into the VM is still unmeasured, and this section is not a finding that it cannot.
 
-- `WslPath.ForWslc` refuses a WSL-side path with a message that names the setting, the path, and the fix ("move the project onto the Windows filesystem"), rather than translating it
+**So the implementation is branch (b), as the safe default rather than as a verdict:**
+
+- `WslPath.ForWslc` refuses a WSL-side path with a message that names the setting, the path, the fix ("move the project onto the Windows filesystem"), and the fact that the direct-UNC route is unmeasured — rather than translating it into something known to be wrong
 - `wip doctor` reports the project's location as a `[FAIL]` for the same reason, and `wip up` / `wip run` warn about `volumes:` — which wip passes through verbatim, so wslc resolves those itself and the refusal never sees them
 - the build context is **not** affected and is not run through `ForWslc` at all: §3.3 stages it into a Windows-local cache and hands wslc `"."`, so a WSL-side context works and must keep working
 
-This is source reading, not a measurement, so the other two branches stay reachable through the `WIP_WSL_PATH` environment variable — `unc` passes the UNC path through (branch (c)), `linux` restores the old translation (branch (a)) — and Spike 1 below still has to run. Whichever branch it confirms becomes the default, and `ForWslc` is still the only function that changes.
+This is source reading, not a measurement, so the other two branches stay reachable through the `WIP_WSL_PATH` environment variable — `unc` passes the UNC path through (branch (c)), `linux` restores the old translation (branch (a)) — and Spike 1 below still has to run. `WIP_WSL_PATH` changes only what `sync.source` resolves to; it rewrites no `volumes:` entry, so the `wip up` / `wip run` warning stands whatever it is set to. Whichever branch the spike confirms becomes the default, and `ForWslc` is still the only function that changes.
 
 ### 3.3 Stage the build context locally, always
 
@@ -562,7 +564,7 @@ Close out what golden tests can't reach. Run **from both PowerShell and WSL2 bas
 
 | Risk | Impact | Mitigation |
 |---|---|---|
-| 🔴 **wslc rejects bind mounts of WSL-side paths** | **High** | Per §3.2a this is what wslc's source says, and it *accepts* them into an empty mount rather than rejecting them — so wip refuses the WSL filesystem itself and documents "projects live on the Windows filesystem" as a constraint. Phase 0 Spike 1 still confirms it. **This outcome may require rethinking the purpose of `sync:` itself** |
+| 🔴 **wslc cannot usefully bind-mount WSL-side paths** | **High** | wslc does not *reject* a bad source — per §3.2a it mounts an empty directory — so wip refuses the WSL filesystem itself and documents "projects live on the Windows filesystem" as a constraint. Whether the direct-UNC route works is still open, and Phase 0 Spike 1 decides it. **This outcome may require rethinking the purpose of `sync:` itself** |
 | **Walking files over UNC is too slow for large trees** | Medium | Take attributes from enumeration (§3.3). Measure in Phase 4; if inadequate, consider pushing the walk itself over to wslc/wsl.exe |
 | **An exe launched from WSL bash has no console fit for interaction** | Medium | Phase 0 Spike 2. Fall back to ConPTY (§4.2 option B) if needed |
 | **Some library doesn't work under AOT** | Medium | Phase 0 Spike 3 exercises every dependency up front. Fallbacks exist: hand-rolled YAML parser, hand-rolled CLI parser |
@@ -588,5 +590,5 @@ Close out what golden tests can't reach. Run **from both PowerShell and WSL2 bas
 
 - **Going Windows-only cut the port by roughly 20–30%.** The openpty, flock, and UnixFileMode P/Invokes, `/proc` parsing, the `Gem.win_platform?` branches, and the Linux RIDs with their separate distribution path all disappear.
 - **Accepting breaking changes and moving Ruby out avoids the largest liability: maintaining two implementations in parallel.** The one prerequisite is extracting the golden fixtures before it goes (Phase 1).
-- **One genuinely hard problem remains: the path model (§3).** Moving execution to the Windows side changes the meaning of all three places that hand wslc a host absolute path — `sync.source`, `volumes:`, and the build context. The build context is solved by staging locally at all times; for the two bind-mount sites, wslc's source (§3.2a) says WSL-side paths cannot work and fail without saying so, **so wip refuses them out loud pending a measurement rather than translating them into silence.**
+- **One genuinely hard problem remains: the path model (§3).** Moving execution to the Windows side changes the meaning of all three places that hand wslc a host absolute path — `sync.source`, `volumes:`, and the build context. The build context is solved by staging locally at all times; for the two bind-mount sites, wslc's source (§3.2a) shows that a bad source fails without saying so and that translating to Linux paths produces exactly that, **so wip refuses WSL-side paths out loud as a precaution while the direct-UNC route is measured, rather than translating them into silence.**
 - **How to proceed:** settle the path model and get the distribution path working in Phase 0; extract the golden fixtures before Ruby leaves. With those two done, the rest is a mechanical port.

--- a/docs/csharp-migration-plan.md
+++ b/docs/csharp-migration-plan.md
@@ -128,7 +128,7 @@ The expectation above was wrong, and wrong in the worst possible way. Reading ws
 
 Branch (a) therefore did not merely fail — it failed *silently*. A project on the WSL filesystem (where most Rails work lives) got `sync.source` and `volumes:` translated into paths that exist nowhere, and the container came up with none of the project in it and nothing printed to explain it. There is no error message to search for, so there is no way for the person hitting it to get out.
 
-**What this does and does not settle.** It disproves branch (a): a translated Linux path is a Windows path to wslc, and a wrong one. It says nothing about branch (c) — a UNC path *does* resolve through `GetFullPathNameW`, and *does* exist, so whether wslc can mount one into the VM is still unmeasured, and this section is not a finding that it cannot.
+**What this does and does not settle.** It disproves branch (a): a translated Linux path is a Windows path to wslc, and a wrong one. It says nothing about branch (c) — a UNC path resolves through `GetFullPathNameW` like any other Windows path (resolution alone proves nothing about existence, as the empty-mount case above shows), and the one wip is handed names a directory that *does* exist, so it never reaches the empty-mount path. Whether wslc can mount an existing UNC source into the VM is simply unmeasured, and this section is not a finding that it cannot.
 
 **So the implementation is branch (b), as the safe default rather than as a verdict:**
 

--- a/src/Wip.Cli/CliContext.cs
+++ b/src/Wip.Cli/CliContext.cs
@@ -623,11 +623,12 @@ internal sealed partial class CliContext
     /// <c>volumes:</c> entries reach wslc exactly as they were written — <c>.:/app</c>
     /// resolved against wip's own UNC working directory — so this warning is the only thing
     /// standing between such a project and a container that comes up empty in silence.
+    /// <c>WIP_WSL_PATH</c> deliberately does not silence it: that variable only changes what
+    /// <c>sync.source</c> resolves to, and rewrites no <c>volumes:</c> entry.
     /// </summary>
     private void WarnWslProject()
     {
-        if (!string.IsNullOrEmpty(System.Environment.GetEnvironmentVariable(WslPath.ModeVariable))
-            || Config.Path is null)
+        if (Config.Path is null)
         {
             return;
         }

--- a/src/Wip.Cli/CliContext.cs
+++ b/src/Wip.Cli/CliContext.cs
@@ -177,6 +177,8 @@ internal sealed partial class CliContext
 
     internal int Up(bool detach, bool sync, bool noCache, bool watch, double interval)
     {
+        WarnWslProject();
+
         if (Config.IsCompose)
         {
             return UpViaComposeBridge(detach, sync, watch);
@@ -274,6 +276,8 @@ internal sealed partial class CliContext
 
     internal int Run(IReadOnlyList<string> command, bool interactive)
     {
+        WarnWslProject();
+
         if (Config.IsCompose)
         {
             Console.Error.WriteLine(
@@ -610,6 +614,35 @@ internal sealed partial class CliContext
             $"from {context}");
 
         StageAndBuild(context, settings, WithNoCache(extra, noCache));
+    }
+
+    /// <summary>
+    /// A project on the WSL filesystem is a bind mount wslc cannot serve: it resolves a
+    /// <c>-v</c> source as a Windows path and mounts an empty directory rather than failing
+    /// when that path does not exist. <c>sync.source</c> refuses to resolve at all, but
+    /// <c>volumes:</c> entries reach wslc exactly as they were written — <c>.:/app</c>
+    /// resolved against wip's own UNC working directory — so this warning is the only thing
+    /// standing between such a project and a container that comes up empty in silence.
+    /// </summary>
+    private void WarnWslProject()
+    {
+        if (!string.IsNullOrEmpty(System.Environment.GetEnvironmentVariable(WslPath.ModeVariable))
+            || Config.Path is null)
+        {
+            return;
+        }
+
+        var directory = Path.GetDirectoryName(Path.GetFullPath(Config.Path));
+        if (directory is null || !WslPath.IsWslPath(directory))
+        {
+            return;
+        }
+
+        Console.Error.WriteLine(
+            $"wip: warning: this project is on the WSL filesystem ({directory}); wslc " +
+            "resolves bind-mount sources as Windows paths, so volumes: entries can mount " +
+            "empty instead of failing. Move the project onto the Windows filesystem " +
+            "(C:\\src\\myproject, say) if a container starts up without your files.");
     }
 
     private int StageAndBuild(string context, OrderedDictionary<string, object?> settings, IReadOnlyList<string> extra)

--- a/src/Wip.Core/Compose/ComposeFile.cs
+++ b/src/Wip.Core/Compose/ComposeFile.cs
@@ -1,4 +1,3 @@
-using Wip.Platform;
 using Wip.Yaml;
 
 namespace Wip.Compose;
@@ -239,10 +238,17 @@ public sealed class ComposeFile
     /// <c>build.context</c> is relative to compose.yml's own directory — Compose's own rule —
     /// not wherever wip happens to be invoked from.
     /// </summary>
+    /// <remarks>
+    /// This stays a host path in the host's own spelling, UNC included: wslc never sees it.
+    /// <c>BuildContext</c> reads the tree itself and stages it into a Windows-local cache,
+    /// and the build then runs from there with <c>context: "."</c> (§3.3 of the migration
+    /// plan). Putting it through <c>WslPath.ForWslc</c> would refuse — or, before that,
+    /// silently mistranslate — a WSL-side context that staging handles perfectly well.
+    /// </remarks>
     private string ResolveContext(string raw)
     {
         var baseDirectory = Path.GetDirectoryName(Path.GetFullPath(path)) ?? ".";
-        return WslPath.ForWslc(Path.GetFullPath(Path.Combine(baseDirectory, raw)));
+        return Path.GetFullPath(Path.Combine(baseDirectory, raw));
     }
 
     /// <summary>

--- a/src/Wip.Core/Compose/ComposeFile.cs
+++ b/src/Wip.Core/Compose/ComposeFile.cs
@@ -1,3 +1,4 @@
+using Wip.Platform;
 using Wip.Yaml;
 
 namespace Wip.Compose;

--- a/src/Wip.Core/Configuration/SyncSettings.cs
+++ b/src/Wip.Core/Configuration/SyncSettings.cs
@@ -104,7 +104,7 @@ public sealed class SyncSettings
     public string Source =>
         resolvedSource ??= basePath is null
             ? rawSource
-            : WslPath.ForWslc(Path.GetFullPath(Path.Combine(basePath, rawSource)));
+            : WslPath.ForWslc(Path.GetFullPath(Path.Combine(basePath, rawSource)), "sync.source");
 
     /// <summary>
     /// What <c>-v</c> specs the main container needs: the source read-only, and the named

--- a/src/Wip.Core/Diagnostics/Doctor.cs
+++ b/src/Wip.Core/Diagnostics/Doctor.cs
@@ -95,6 +95,7 @@ public sealed class Doctor
         }
 
         CheckWslc(config, results);
+        CheckProjectLocation(config, results);
 
         if (config.IsCompose)
         {
@@ -196,15 +197,55 @@ public sealed class Doctor
         }
     }
 
+    /// <summary>
+    /// A project on the WSL filesystem reaches wip as a UNC path, and wslc resolves a
+    /// bind-mount source as a Windows path — mounting an empty directory rather than
+    /// failing when it does not exist. <c>sync.source</c> says so itself by refusing to
+    /// resolve, but <c>volumes:</c> entries are passed to wslc verbatim, so nothing else
+    /// would report the one thing that explains an empty container.
+    /// </summary>
+    private static void CheckProjectLocation(Config config, List<Result> results)
+    {
+        if (config.Path is null)
+        {
+            return;
+        }
+
+        var directory = Path.GetDirectoryName(Path.GetFullPath(config.Path));
+        if (directory is null || !WslPath.IsWslPath(directory))
+        {
+            return;
+        }
+
+        results.Add(new Result(Level.Fail,
+            $"Project is on the WSL filesystem ({directory}): wslc bind mounts " +
+            "(volumes:, sync.source) cannot reach it, and mount empty rather than " +
+            "failing. Move the project onto the Windows filesystem, e.g. C:\\src\\myproject"));
+    }
+
     private static void CheckSync(Config config, List<Result> results)
     {
         var sync = config.Sync!;
-        var found = Directory.Exists(sync.Source);
+
+        // Resolving the source is what refuses a WSL-side path, and doctor is exactly where
+        // that has to read as a result rather than as wip falling over.
+        string source;
+        try
+        {
+            source = sync.Source;
+        }
+        catch (ConfigException exception)
+        {
+            results.Add(new Result(Level.Fail, exception.Message));
+            return;
+        }
+
+        var found = Directory.Exists(source);
         results.Add(new Result(
             found ? Level.Ok : Level.Fail,
             found
-                ? $"Sync source {sync.Source} mirrors into volume {sync.Volume} at {sync.Target}"
-                : $"Sync source not found: {sync.Source}"));
+                ? $"Sync source {source} mirrors into volume {sync.Volume} at {sync.Target}"
+                : $"Sync source not found: {source}"));
 
         if (!sync.IsExec || (sync.Image is null && sync.Build is null))
         {

--- a/src/Wip.Core/Diagnostics/Doctor.cs
+++ b/src/Wip.Core/Diagnostics/Doctor.cs
@@ -218,9 +218,10 @@ public sealed class Doctor
         }
 
         results.Add(new Result(Level.Fail,
-            $"Project is on the WSL filesystem ({directory}): wslc bind mounts " +
-            "(volumes:, sync.source) cannot reach it, and mount empty rather than " +
-            "failing. Move the project onto the Windows filesystem, e.g. C:\\src\\myproject"));
+            $"Project is on the WSL filesystem ({directory}): wslc resolves a bind-mount " +
+            "source as a Windows path and mounts an empty directory rather than failing, so " +
+            "sync.source is refused and volumes: entries can mount empty. Move the project " +
+            "onto the Windows filesystem, e.g. C:\\src\\myproject"));
     }
 
     private static void CheckSync(Config config, List<Result> results)

--- a/src/Wip.Core/Platform/WslPath.cs
+++ b/src/Wip.Core/Platform/WslPath.cs
@@ -3,23 +3,37 @@ using System.Text.RegularExpressions;
 namespace Wip.Platform;
 
 /// <summary>
-/// Translates host paths between the form Windows hands wip and the form wslc is given.
+/// Decides what wip is allowed to hand wslc as the host side of a bind mount.
 /// </summary>
 /// <remarks>
 /// <para>
-/// This is the single place the migration's open question lands, and it is deliberately one
-/// function so that answering the question is a local change. wip.exe runs on the Windows
-/// side, but is typically invoked from a WSL2 shell, so a project under <c>~/proj</c> gives
-/// the process a UNC working directory (<c>\\wsl.localhost\Ubuntu\home\u\proj</c>). Three
-/// call sites then hand that path to wslc: the <c>sync:</c> source mount, <c>volumes:</c>
-/// bind mounts, and the build context.
+/// wip.exe runs on the Windows side but is typically invoked from a WSL2 shell, so a project
+/// under <c>~/proj</c> gives the process a UNC working directory
+/// (<c>\\wsl.localhost\Ubuntu\home\u\proj</c>). That path reaches wslc through
+/// <c>sync.source</c> and <c>volumes:</c> — see docs/csharp-migration-plan.md §3.
 /// </para>
 /// <para>
-/// What wslc accepts has not been measured yet — see docs/csharp-migration-plan.md §3.2,
-/// Phase 0 Spike 1. This implements branch (a) of that decision tree, translating a UNC
-/// path back to the Linux path it denotes, on the reasoning that wslc runs containers inside
-/// a WSL2 VM and therefore speaks Linux paths. If the spike shows otherwise, this method is
-/// what changes; nothing else needs to know.
+/// This used to implement branch (a) of that section's decision tree, translating the UNC
+/// path back to the Linux path it denotes, on the assumption that wslc — which runs its
+/// containers inside a WSL2 VM — speaks Linux paths. Reading wslc's own source says
+/// otherwise: it resolves a <c>-v</c> source with <c>GetFullPathNameW</c>, i.e. as a Windows
+/// path, so <c>/home/u/proj</c> becomes <c>C:\home\u\proj</c>. Worse, a source that does not
+/// exist is not an error there: wslc mounts an empty directory (<c>/mnt/&lt;GUID&gt;</c>) and
+/// the container starts, so the translation turned "project on the WSL filesystem" into a
+/// silently empty mount — no message, nothing to search for.
+/// </para>
+/// <para>
+/// So this implements branch (b) instead: a WSL-side path is refused with an explanation
+/// rather than translated into something that fails quietly. The refusal is what a project
+/// on the WSL filesystem hits today; the constraint it states — bind mounts need the project
+/// on the Windows filesystem — is the one branch (b) says has to be documented.
+/// </para>
+/// <para>
+/// The finding is source reading, not a measurement on real hardware, so
+/// <c>WIP_WSL_PATH</c> keeps both other branches reachable without a rebuild:
+/// <c>unc</c> hands wslc the UNC path unchanged (branch (c)) and <c>linux</c> restores the
+/// old translation (branch (a)). Whichever the Phase 0 spike confirms becomes the default,
+/// and this is still the only function that changes.
 /// </para>
 /// <para>
 /// On non-Windows hosts every path passes through untouched, which is what keeps the golden
@@ -28,25 +42,23 @@ namespace Wip.Platform;
 /// </remarks>
 public static partial class WslPath
 {
+    /// <summary>Overrides the refusal, so the open question can be measured in place.</summary>
+    public const string ModeVariable = "WIP_WSL_PATH";
+
     /// <summary>
-    /// Converts a host path into the form handed to wslc on a command line.
+    /// Converts a host path into the form handed to wslc on a command line, or refuses it.
     /// </summary>
-    public static string ForWslc(string path)
-    {
-        if (!OperatingSystem.IsWindows())
-        {
-            return path;
-        }
-
-        var match = UncPattern().Match(path);
-        if (!match.Success)
-        {
-            return path;
-        }
-
-        var remainder = match.Groups[2].Value.Replace('\\', '/');
-        return remainder.Length == 0 ? "/" : $"/{remainder.TrimStart('/')}";
-    }
+    /// <param name="path">An absolute host path, as Windows handed it to wip.</param>
+    /// <param name="label">
+    /// What the path is, so a refusal names the setting to change rather than just a path.
+    /// </param>
+    /// <exception cref="ConfigException">
+    /// The path is inside a WSL distribution's filesystem, which wslc cannot bind-mount.
+    /// </exception>
+    public static string ForWslc(string path, string label = "the host path") =>
+        OperatingSystem.IsWindows()
+            ? ForWslc(path, label, System.Environment.GetEnvironmentVariable(ModeVariable))
+            : path;
 
     /// <summary>Whether <paramref name="path"/> points inside a WSL distribution's filesystem.</summary>
     public static bool IsWslPath(string path) => OperatingSystem.IsWindows() && UncPattern().IsMatch(path);
@@ -57,6 +69,56 @@ public static partial class WslPath
         var match = UncPattern().Match(path);
         return match.Success ? match.Groups[1].Value : null;
     }
+
+    /// <summary>
+    /// The decision itself, with the two host facts — the platform and the override — passed
+    /// in, so it can be exercised from a test run on any of them.
+    /// </summary>
+    internal static string ForWslc(string path, string label, string? mode)
+    {
+        var match = UncPattern().Match(path);
+        if (!match.Success)
+        {
+            return path;
+        }
+
+        if (string.IsNullOrEmpty(mode) || Is(mode, "refuse"))
+        {
+            throw new ConfigException(Refusal(label, path));
+        }
+
+        if (Is(mode, "unc"))
+        {
+            return path;
+        }
+
+        if (Is(mode, "linux"))
+        {
+            return ToLinuxPath(match);
+        }
+
+        throw new ConfigException(
+            $"{ModeVariable} must be one of refuse, unc, or linux — got ‘{mode}’");
+    }
+
+    private static bool Is(string mode, string name) =>
+        string.Equals(mode, name, StringComparison.OrdinalIgnoreCase);
+
+    private static string ToLinuxPath(Match match)
+    {
+        var remainder = match.Groups[2].Value.Replace('\\', '/');
+        return remainder.Length == 0 ? "/" : $"/{remainder.TrimStart('/')}";
+    }
+
+    private static string Refusal(string label, string path) =>
+        $"{label} is on the WSL filesystem ({path}), which wslc cannot bind-mount: it " +
+        "resolves a -v source as a Windows path, and mounts an empty directory instead of " +
+        "failing when that path does not exist — so the container would come up with none " +
+        "of your files in it and no error to explain why. Move the project onto the Windows " +
+        "filesystem (C:\\src\\myproject, say) and run wip from there. If you are measuring " +
+        $"what wslc really accepts: {ModeVariable}=unc hands it the UNC path unchanged and " +
+        $"{ModeVariable}=linux restores wip's old /home/... translation (see " +
+        "docs/csharp-migration-plan.md §3).";
 
     // Both spellings are in circulation: \\wsl$\ predates \\wsl.localhost\ and still
     // resolves, so a working directory can arrive as either.

--- a/src/Wip.Core/Platform/WslPath.cs
+++ b/src/Wip.Core/Platform/WslPath.cs
@@ -23,10 +23,10 @@ namespace Wip.Platform;
 /// silently empty mount — no message, nothing to search for.
 /// </para>
 /// <para>
-/// So this implements branch (b) instead: a WSL-side path is refused with an explanation
-/// rather than translated into something that fails quietly. The refusal is what a project
-/// on the WSL filesystem hits today; the constraint it states — bind mounts need the project
-/// on the Windows filesystem — is the one branch (b) says has to be documented.
+/// That rules branch (a) out. It does not establish branch (c): a UNC path does resolve, and
+/// does exist, so whether wslc can mount one into the VM is simply unmeasured. Refusing a
+/// WSL-side path with an explanation is therefore the safe default — it states the constraint
+/// branch (b) says has to be documented, and it fails in the open instead of quietly.
 /// </para>
 /// <para>
 /// The finding is source reading, not a measurement on real hardware, so
@@ -111,14 +111,15 @@ public static partial class WslPath
     }
 
     private static string Refusal(string label, string path) =>
-        $"{label} is on the WSL filesystem ({path}), which wslc cannot bind-mount: it " +
+        $"{label} is on the WSL filesystem ({path}), which wip will not hand to wslc: wslc " +
         "resolves a -v source as a Windows path, and mounts an empty directory instead of " +
-        "failing when that path does not exist — so the container would come up with none " +
-        "of your files in it and no error to explain why. Move the project onto the Windows " +
-        "filesystem (C:\\src\\myproject, say) and run wip from there. If you are measuring " +
-        $"what wslc really accepts: {ModeVariable}=unc hands it the UNC path unchanged and " +
-        $"{ModeVariable}=linux restores wip's old /home/... translation (see " +
-        "docs/csharp-migration-plan.md §3).";
+        "failing when that path does not exist — so wip's old translation of this to " +
+        "/home/... left the container with none of your files in it and nothing to explain " +
+        "why. Whether wslc can mount the UNC path itself has not been measured, so refusing " +
+        "is the safe default. Move the project onto the Windows filesystem " +
+        "(C:\\src\\myproject, say) and run wip from there — or, to measure it: " +
+        $"{ModeVariable}=unc hands wslc the UNC path unchanged and {ModeVariable}=linux " +
+        "restores the old translation (see docs/csharp-migration-plan.md §3).";
 
     // Both spellings are in circulation: \\wsl$\ predates \\wsl.localhost\ and still
     // resolves, so a working directory can arrive as either.

--- a/tests/Wip.Tests/WslPathTests.cs
+++ b/tests/Wip.Tests/WslPathTests.cs
@@ -1,0 +1,84 @@
+using Wip.Platform;
+
+namespace Wip.Tests;
+
+/// <summary>
+/// wslc resolves a <c>-v</c> source with <c>GetFullPathNameW</c> — as a Windows path — and
+/// mounts an empty directory instead of failing when the result does not exist. Translating
+/// a UNC working directory into <c>/home/u/proj</c> therefore produced a container with none
+/// of the project in it and no error, which is the one failure mode a user cannot diagnose.
+/// So the WSL filesystem is refused by name, and the two unmeasured alternatives stay
+/// reachable through <c>WIP_WSL_PATH</c> for whoever runs the spike.
+/// </summary>
+public class WslPathTests
+{
+    private const string Unc = @"\\wsl.localhost\Ubuntu\home\u\proj";
+
+    [Theory]
+    [InlineData(Unc)]
+    [InlineData(@"\\wsl$\Ubuntu\home\u\proj")]
+    [InlineData(@"\\WSL.LOCALHOST\Ubuntu\home\u\proj")]
+    public void WslPathsAreRefused(string path)
+    {
+        var exception = Assert.Throws<ConfigException>(() => WslPath.ForWslc(path, "sync.source", null));
+
+        Assert.Contains("sync.source", exception.Message);
+        Assert.Contains(path, exception.Message);
+        Assert.Contains(WslPath.ModeVariable, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(@"C:\src\proj")]
+    [InlineData(@"\\fileserver\share\proj")]
+    [InlineData("/home/u/proj")]
+    public void EveryOtherPathIsHandedOverUntouched(string path) =>
+        Assert.Equal(path, WslPath.ForWslc(path, "sync.source", null));
+
+    [Fact]
+    public void UncModeHandsWslcTheUncPathUnchanged() =>
+        Assert.Equal(Unc, WslPath.ForWslc(Unc, "sync.source", "unc"));
+
+    [Theory]
+    [InlineData(Unc, "/home/u/proj")]
+    [InlineData(@"\\wsl.localhost\Ubuntu", "/")]
+    [InlineData(@"\\wsl.localhost\Ubuntu\", "/")]
+    public void LinuxModeRestoresTheOldTranslation(string path, string expected) =>
+        Assert.Equal(expected, WslPath.ForWslc(path, "sync.source", "linux"));
+
+    [Fact]
+    public void ModeIsReadCaseInsensitively() =>
+        Assert.Equal(Unc, WslPath.ForWslc(Unc, "sync.source", "UNC"));
+
+    [Fact]
+    public void AnUnknownModeSaysWhatTheModesAre()
+    {
+        var exception = Assert.Throws<ConfigException>(() => WslPath.ForWslc(Unc, "sync.source", "windows"));
+
+        Assert.Contains(WslPath.ModeVariable, exception.Message);
+        Assert.Contains("unc", exception.Message);
+        Assert.Contains("linux", exception.Message);
+    }
+
+    /// <summary>
+    /// The rule is Windows-only: on Linux — where the golden corpus was generated, and where
+    /// wip runs against a native wslc — a path is already what wslc will be given.
+    /// </summary>
+    [Fact]
+    public void OnlyWindowsAppliesTheRule()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Throws<ConfigException>(() => WslPath.ForWslc(Unc, "sync.source"));
+            return;
+        }
+
+        Assert.Equal(Unc, WslPath.ForWslc(Unc, "sync.source"));
+    }
+
+    [Theory]
+    [InlineData(Unc, "Ubuntu")]
+    [InlineData(@"\\wsl$\Debian\home\u", "Debian")]
+    [InlineData(@"C:\src\proj", null)]
+    public void TheDistributionIsReadableFromTheUncPath(string path, string? expected) =>
+        Assert.Equal(expected, WslPath.DistributionOf(path));
+}


### PR DESCRIPTION
## The hole

`Platform/WslPath.ForWslc` implemented branch **(a)** of the migration plan's §3.2 decision tree: a UNC working directory (`\\wsl.localhost\Ubuntu\home\u\proj`) was translated back to the Linux path it denotes, on the assumption that wslc — which runs its containers inside a WSL2 VM — speaks Linux paths.

Reading wslc's source says otherwise:

- a `-v` source is resolved with **`GetFullPathNameW`**, i.e. as a **Windows** path, so `/home/u/proj` resolves against the current drive as `C:\home\u\proj`;
- a source that **does not exist is not an error** — wslc mounts an **empty directory** (`/mnt/<GUID>`) and the container starts normally.

So the translation did not merely fail, it failed *silently*. Anyone keeping a project on the WSL filesystem — where most Rails work lives — got `sync.source` and `volumes:` pointing at paths that exist nowhere, a container with none of their files in it, and nothing printed to explain why. There is no message to search for, so there is no way out of it. Worth closing before WinGet starts sending people here.

## What changed

Branch **(b)** instead — the constraint the plan says has to be documented, stated out loud rather than hidden:

- **`WslPath.ForWslc`** refuses a WSL-side path, naming the setting, the path, and the fix ("move the project onto the Windows filesystem"), instead of translating it into silence. Still the one function §3.2 says would change.
- **`wip doctor`** reports the project's location as a `[FAIL]`, and **`wip up` / `wip run`** warn about `volumes:` — which wip passes to wslc verbatim, so wslc resolves those itself and the refusal never sees them. `WIP_WSL_PATH` does not silence that warning: it changes only what `sync.source` resolves to.
- **The build context stops going through `ForWslc` altogether.** §3.3 stages it into a Windows-local cache and builds from there with `context: "."`, so a WSL-side context works today and must keep working; running it through the refusal (or, before this, the mistranslation) would have broken a case that is already handled correctly.

## What this settles, and what it does not

The source reading **disproves branch (a)**: a translated `/home/...` path is a Windows path to wslc, and a wrong one. It says nothing about **branch (c)** — a UNC path does resolve through `GetFullPathNameW`, and does exist, so whether wslc can mount one into the VM is still unmeasured. **The refusal is the safe default pending Phase 0 Spike 1, not a verdict on UNC**, and the refusal message, the doctor result, and the docs all say so.

Both other branches stay one environment variable away:

| `WIP_WSL_PATH` | Behaviour |
|---|---|
| unset / `refuse` | Refuse a WSL-side path with an explanation (default) |
| `unc` | Hand wslc the UNC path unchanged — branch (c) |
| `linux` | Restore the old `/home/...` translation — branch (a) |

Whichever the spike confirms becomes the default, and `ForWslc` is still all that changes.

## Tests

`tests/Wip.Tests/WslPathTests.cs` covers the decision itself — the platform and the override are passed in, so it runs on Linux and Windows alike: both UNC spellings refused, non-WSL paths untouched, `unc` and `linux` doing what they say, an unknown mode reporting the valid ones, and the Windows-only gate.

The golden corpus is unaffected: the rule is Windows-only, and its host-path cases are Linux paths that skip on Windows.

## Docs

- README's project-location note is now a stated constraint plus the escape hatch and the unmeasured-UNC caveat; the "known gaps" entry records what the source reading settled and what measuring still has to confirm.
- `docs/csharp-migration-plan.md` gains **§3.2a** with the finding, why branch (a) is out, and why branch (c) is untouched by it; §11's risk row, the Spike 1 checklist, and the summary follow it.

## Not verified here

wslc's actual behaviour — this is source reading. The spike (`wslc run -v` against a Linux path, a Windows-local path, and a UNC path, plus whether a non-existent source really does mount empty) is unchanged in scope and still needs a Windows machine with WSL2.

---
_Generated by [Claude Code](https://claude.ai/code/session_017EiokEsxW4UWCzLJeyygiP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diagnostics for projects stored in the WSL filesystem.
  * Added configurable handling for WSL paths, including refusal, UNC, and Linux path modes.
  * Improved resolution of sync sources and Compose build contexts across host and UNC paths.

* **Bug Fixes**
  * Prevented invalid translated paths from silently creating empty mounts.
  * Improved error reporting for invalid source configurations.
  * `wip up` and `wip run` now consistently warn about affected volume paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->