### PR TITLE
fix(ci): upload release artifacts before publishing immutable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release
 
 # Version-driven, the way the gem released: the version in the project file is the trigger,
-# not a tag anyone types. Every merge to main asks "is this version already out?", and only a
-# merge that changes it releases anything. release-drafter creates the tag when it publishes,
-# so there is no tag to push by hand and no way for a tag and a version to disagree.
+# not a tag anyone types. Every merge to main compares that file with the latest published
+# release, and only a merge that changes it creates a tag and releases anything.
 on:
   push:
     branches:
@@ -19,18 +18,22 @@ permissions:
 
 jobs:
   check:
-    name: Check whether this version is released
+    name: Check for a version change
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
 
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
-      needed: ${{ steps.released.outputs.needed }}
+      needed: ${{ steps.changed.outputs.needed }}
 
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       # Directory.Build.props is the single source of truth: the SDK stamps this into the
@@ -48,35 +51,43 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "tag=v$version" >> "$GITHUB_OUTPUT"
 
-      - name: Check for an existing release
-        id: released
+      # A version bump is deliberately just a file change. At release time, compare that file
+      # with the commit selected by the latest published release instead of treating the draft
+      # release (or a prematurely-created tag) as the source of truth.
+      - name: Check for a version change
+        id: changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          previous=$(gh release list --exclude-drafts --limit 1 --json tagName --jq '.[0].tagName // ""')
+          if [ -n "$previous" ] && git diff --quiet "$previous" HEAD -- Directory.Build.props; then
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+            echo "Directory.Build.props has not changed since $previous; nothing to release." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+            echo "Directory.Build.props changed since ${previous:-the repository began}; releasing the new version." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      # Tag only after the version comparison decides to release. Re-runs accept the same tag
+      # at the same commit, but reject a tag that already points somewhere else.
+      - name: Tag release commit
+        if: steps.changed.outputs.needed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.version.outputs.tag }}
         run: |
           set -euo pipefail
-
-          # changelog.yml keeps a draft release updated on every merge, and `gh release view`
-          # matches drafts too, so a draft does not count as released.
-          is_draft=$(gh release view "$TAG" --json isDraft --jq .isDraft 2>/dev/null || echo "")
-
-          # A completed release has both artifacts. With immutable releases a published release
-          # cannot be repaired, so detect that state explicitly instead of retrying an upload
-          # that GitHub must reject.
-          has_archive=$(gh release view "$TAG" --json assets \
-            --jq 'any(.assets[]; .name | endswith(".zip"))' 2>/dev/null || echo false)
-          has_checksums=$(gh release view "$TAG" --json assets \
-            --jq 'any(.assets[]; .name == "SHA256SUMS")' 2>/dev/null || echo false)
-
-          if [ "$is_draft" = "false" ] && [ "$has_archive" = "true" ] && [ "$has_checksums" = "true" ]; then
-            echo "needed=false" >> "$GITHUB_OUTPUT"
-            echo "$TAG is already published with its artifacts; nothing to do." >> "$GITHUB_STEP_SUMMARY"
-          elif [ "$is_draft" = "false" ]; then
-            echo "::error::$TAG is published but is missing release artifacts. Immutable releases cannot accept uploads; publish a corrected version instead."
+          tagged_sha=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" --jq .object.sha 2>/dev/null || true)
+          if [ -z "$tagged_sha" ]; then
+            gh api "repos/$GITHUB_REPOSITORY/git/refs" \
+              --method POST \
+              -f ref="refs/tags/$TAG" \
+              -f sha="$GITHUB_SHA"
+          elif [ "$tagged_sha" != "$GITHUB_SHA" ]; then
+            echo "::error::$TAG already points to $tagged_sha, not $GITHUB_SHA."
             exit 1
-          else
-            echo "needed=true" >> "$GITHUB_OUTPUT"
-            echo "Releasing $TAG." >> "$GITHUB_STEP_SUMMARY"
           fi
 
   # Windows only because Native AOT cannot cross-compile between operating systems. Nothing
@@ -173,39 +184,34 @@ jobs:
           name: release-dist
           path: dist
 
-      # Finalises the draft that changelog.yml has been accumulating on every merge. Keep it
-      # as a draft until its artifacts are attached: immutable releases reject every asset
-      # upload made after publication.
-      #
-      # Its own tag-template guesses the next version; the explicit tag and name override that
-      # with the version actually being released.
-      - name: Finalise draft release notes
+      # Attach artifacts to the running changelog draft before publishing it. Address the draft
+      # by the tag release-drafter currently proposes; the actual version tag was created by the
+      # check job and is supplied when the draft is published below.
+      - name: Upload release artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          draft_tag=$(gh release list --limit 100 --json tagName,isDraft \
+            --jq '[.[] | select(.isDraft)][0].tagName // ""')
+          if [ -z "$draft_tag" ]; then
+            echo "::error::No draft release exists for the accumulated release notes."
+            exit 1
+          fi
+
+          gh release upload "$draft_tag" dist/*.zip dist/SHA256SUMS --clobber
+
+      # Publish only after every artifact is attached. The explicit tag and name replace the
+      # draft's guessed next-patch values with the version read from Directory.Build.props.
+      - name: Publish release
         uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7
         with:
           config-name: release-drafter.yml
-          publish: false
+          publish: true
           tag: ${{ needs.check.outputs.tag }}
           name: ${{ needs.check.outputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Attach artifacts while the release is still mutable. If this fails, the release stays
-      # a draft and a re-run can safely overwrite any artifact uploaded before the failure.
-      - name: Upload release artifacts
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          tag_name: ${{ needs.check.outputs.tag }}
-          files: |
-            dist/*.zip
-            dist/SHA256SUMS
-
-      # Publishing is deliberately the final release mutation. It also creates the tag chosen
-      # above, preserving the version-driven flow while satisfying immutable releases.
-      - name: Publish release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ needs.check.outputs.tag }}
-        run: gh release edit "$TAG" --draft=false
 
   # Called rather than triggered: a release created with GITHUB_TOKEN does not raise
   # `release: published` for another workflow, so an event-based handoff would leave every

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,10 +60,9 @@ jobs:
           # matches drafts too, so a draft does not count as released.
           is_draft=$(gh release view "$TAG" --json isDraft --jq .isDraft 2>/dev/null || echo "")
 
-          # Notes are published before the artifacts are attached, so a failed upload leaves a
-          # release that exists but cannot be installed. "Published" alone would then read as
-          # done and skip the repair, so a release only counts as finished once its downloads
-          # are actually there -- which makes re-running this workflow fix it.
+          # A completed release has both artifacts. With immutable releases a published release
+          # cannot be repaired, so detect that state explicitly instead of retrying an upload
+          # that GitHub must reject.
           has_archive=$(gh release view "$TAG" --json assets \
             --jq 'any(.assets[]; .name | endswith(".zip"))' 2>/dev/null || echo false)
           has_checksums=$(gh release view "$TAG" --json assets \
@@ -72,13 +71,12 @@ jobs:
           if [ "$is_draft" = "false" ] && [ "$has_archive" = "true" ] && [ "$has_checksums" = "true" ]; then
             echo "needed=false" >> "$GITHUB_OUTPUT"
             echo "$TAG is already published with its artifacts; nothing to do." >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$is_draft" = "false" ]; then
+            echo "::error::$TAG is published but is missing release artifacts. Immutable releases cannot accept uploads; publish a corrected version instead."
+            exit 1
           else
             echo "needed=true" >> "$GITHUB_OUTPUT"
-            if [ "$is_draft" = "false" ]; then
-              echo "$TAG is published but missing artifacts; re-running the release." >> "$GITHUB_STEP_SUMMARY"
-            else
-              echo "Releasing $TAG." >> "$GITHUB_STEP_SUMMARY"
-            fi
+            echo "Releasing $TAG." >> "$GITHUB_STEP_SUMMARY"
           fi
 
   # Windows only because Native AOT cannot cross-compile between operating systems. Nothing
@@ -175,27 +173,24 @@ jobs:
           name: release-dist
           path: dist
 
-      # Publishes the draft that changelog.yml has been accumulating on every merge, and
-      # creates the tag while doing it. The draft is what the decision to release was made
-      # from, so the release says the same thing it did.
+      # Finalises the draft that changelog.yml has been accumulating on every merge. Keep it
+      # as a draft until its artifacts are attached: immutable releases reject every asset
+      # upload made after publication.
       #
       # Its own tag-template guesses the next version; the explicit tag and name override that
       # with the version actually being released.
-      - name: Publish release notes
+      - name: Finalise draft release notes
         uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7
         with:
           config-name: release-drafter.yml
-          publish: true
+          publish: false
           tag: ${{ needs.check.outputs.tag }}
           name: ${{ needs.check.outputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Attaches the artifacts to the release the step above just published. Publishing first
-      # means a failure here leaves a release without downloads; the check job treats that as
-      # unfinished rather than done, so re-running this workflow repairs it. Uploading before
-      # publishing instead would put two actions in charge of the same draft, which is a
-      # worse thing to get wrong.
+      # Attach artifacts while the release is still mutable. If this fails, the release stays
+      # a draft and a re-run can safely overwrite any artifact uploaded before the failure.
       - name: Upload release artifacts
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
@@ -203,6 +198,14 @@ jobs:
           files: |
             dist/*.zip
             dist/SHA256SUMS
+
+      # Publishing is deliberately the final release mutation. It also creates the tag chosen
+      # above, preserving the version-driven flow while satisfying immutable releases.
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.check.outputs.tag }}
+        run: gh release edit "$TAG" --draft=false
 
   # Called rather than triggered: a release created with GITHUB_TOKEN does not raise
   # `release: published` for another workflow, so an event-based handoff would leave every


### PR DESCRIPTION
### Motivation

- GitHub releases can be immutable, rejecting asset uploads after a release is published, so the previous publish-then-upload order could not recover from failed uploads.
- Ensure artifacts are attached while the release is still mutable to allow safe retries on failure.
- Fail fast and surface a clear error if an already-published release is missing artifacts so maintainers publish a corrected version instead of attempting impossible uploads.

### Description

- Update `.github/workflows/release.yml` to keep the release draft while attaching artifacts by setting `release-drafter` `publish: false` and uploading assets before publishing. 
- Add a final step that transitions the draft to published state with `gh release edit "$TAG" --draft=false` after artifacts are successfully uploaded. 
- Add a check that detects a non-draft release that lacks required artifacts and errors out with a clear message instead of trying to re-upload. 
- Adjust workflow log messages and summaries to reflect the new sequence (finalise draft → upload artifacts → publish).

### Testing

- Parsed the modified workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml')"`, which succeeded.
- Extracted and syntax-checked the shell portion with `bash -n` on the generated script fragment, which succeeded.
- Ran `git diff --check` to ensure no whitespace/patch issues, which reported no problems. 
- `actionlint` was not available in the environment so its linting was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a85c453f9808322b3e2e6830de60fc8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved release validation to ensure published releases include all required download artifacts.
  - Release artifacts are now uploaded before releases are finalized.
  - Version and tag consistency is validated when releases are created or rerun.
  - Releases with missing ZIP or checksum files are now flagged as incomplete instead of being treated as successful.
  - Unnecessary post-publication release updates have been removed for a more reliable release process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->