### PR TITLE
fix(ci): address repository when uploading release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,7 +236,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          drafts=$(gh release list --limit 100 --json tagName,name,isDraft \
+          # This job intentionally has no checkout, so gh cannot infer the repository from
+          # a local .git directory. Address it explicitly for every `gh release` command.
+          drafts=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 100 --json tagName,name,isDraft \
             --jq '[.[] | select(.isDraft and .name == "Unreleased") | .tagName]')
           count=$(echo "$drafts" | jq 'length')
 
@@ -251,7 +253,8 @@ jobs:
           fi
 
           draft_tag=$(echo "$drafts" | jq -r '.[0]')
-          gh release upload "$draft_tag" dist/*.zip dist/SHA256SUMS --clobber
+          gh release upload "$draft_tag" dist/*.zip dist/SHA256SUMS \
+            --repo "$GITHUB_REPOSITORY" --clobber
 
       # Publish only after every artifact is attached. The explicit tag and name replace the
       # draft's guessed next-patch values with the version read from Directory.Build.props.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.0.5</Version>
+    <Version>2.0.6</Version>
     <Authors>wip contributors</Authors>
     <Product>wip</Product>
     <Description>A developer-friendly CLI wrapper for Microsoft WSLC.</Description>


### PR DESCRIPTION
### Motivation

- The publish job runs without a checkout so `gh` could not infer the target repository, causing release artifact upload/list commands to fail.
- The change also prepares a corrected release by bumping the patch version so the release workflow will publish the updated artifacts.

### Description

- Added `--repo "$GITHUB_REPOSITORY"` to `gh release list` in `.github/workflows/release.yml` so the command works without a local checkout. 
- Added `--repo "$GITHUB_REPOSITORY"` to `gh release upload` in `.github/workflows/release.yml` so uploads target the correct repository when no checkout is present. 
- Updated `Directory.Build.props` `Version` from `2.0.5` to `2.0.6` to allow publishing the corrected release. 
- Added an explanatory comment in the workflow to clarify why the explicit `--repo` argument is necessary.

### Testing

- Validated `.github/workflows/release.yml` is parseable with `ruby -e "require 'yaml'; YAML.parse_file('.github/workflows/release.yml')"`, which succeeded. 
- Ran `git diff --check` and `git status --short` to ensure no whitespace or obvious diff issues, which reported clean results. 
- Confirmed the edited workflow fragment appears as intended via `git diff` output inspection. 
- Attempted to run `dotnet test` and `dotnet --version` but the .NET SDK is not available in the execution environment, so the full test suite could not be executed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a86ea9078ac8322b0981a55d11c81f8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the project version to 2.0.6.

- **Bug Fixes**
  - Improved release publishing reliability when repository checkout is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->