### PR TITLE
Add Scoop manifest and sync it in version bump workflow; document Scoop install

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -34,7 +34,8 @@ jobs:
 
       # Directory.Build.props is the single source of truth for the version: the SDK stamps
       # it into the assembly, and the release workflow releases whatever version it finds
-      # here, creating the tag itself.
+      # here, creating the tag itself. The update step below mirrors that version into the
+      # Scoop manifest so its concrete install URL follows the release.
       - name: Calculate next version
         id: version
         env:
@@ -58,14 +59,29 @@ jobs:
           echo "current=$current" >> "$GITHUB_OUTPUT"
           echo "next=$major.$minor.$patch" >> "$GITHUB_OUTPUT"
 
-      - name: Update version
+      - name: Update versions
         env:
           CURRENT: ${{ steps.version.outputs.current }}
           NEXT: ${{ steps.version.outputs.next }}
         run: |
           set -euo pipefail
+          test "$(jq -r '.version' wip.json)" = "$CURRENT"
+
           sed -i "s|<Version>${CURRENT}</Version>|<Version>${NEXT}</Version>|" Directory.Build.props
           grep -q "<Version>${NEXT}</Version>" Directory.Build.props
+
+          jq --arg version "$NEXT" '
+            .version = $version
+            | .architecture["64bit"].url = "https://github.com/slidict/wip/releases/download/v\($version)/wip-\($version)-win-x64.zip"
+            | .architecture["64bit"].hash = "https://github.com/slidict/wip/releases/download/v\($version)/SHA256SUMS"
+          ' wip.json > wip.json.tmp
+          mv wip.json.tmp wip.json
+
+          test "$(jq -r '.version' wip.json)" = "$NEXT"
+          jq -e --arg version "$NEXT" '
+            .architecture["64bit"].url == "https://github.com/slidict/wip/releases/download/v\($version)/wip-\($version)-win-x64.zip"
+            and .architecture["64bit"].hash == "https://github.com/slidict/wip/releases/download/v\($version)/SHA256SUMS"
+          ' wip.json > /dev/null
 
       - name: Commit version bump
         env:
@@ -76,7 +92,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -B "bump-version-v${NEXT}"
-          git add Directory.Build.props
+          git add Directory.Build.props wip.json
           git commit -m "chore: bump version to v${NEXT}"
 
           # Passed on the command line rather than written to .git/config, so the
@@ -96,4 +112,4 @@ jobs:
             --base "${GITHUB_REF_NAME}" \
             --head "bump-version-v${NEXT}" \
             --title "chore: bump version to v${NEXT}" \
-            --body "Bump wip version to v${NEXT}. Merging this publishes v${NEXT}: the release workflow reads the version from Directory.Build.props, and creates the tag itself."
+            --body "Bump wip and its Scoop manifest to v${NEXT}. Merging this publishes v${NEXT}: the release workflow reads the version from Directory.Build.props, and creates the tag itself."

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -34,8 +34,8 @@ jobs:
 
       # Directory.Build.props is the single source of truth for the version: the SDK stamps
       # it into the assembly, and the release workflow releases whatever version it finds
-      # here, creating the tag itself. The update step below mirrors that version into the
-      # Scoop manifest so its concrete install URL follows the release.
+      # here, creating the tag itself. The release workflow updates the Scoop manifest only
+      # after the corresponding archive exists and its digest can be verified.
       - name: Calculate next version
         id: version
         env:
@@ -59,29 +59,14 @@ jobs:
           echo "current=$current" >> "$GITHUB_OUTPUT"
           echo "next=$major.$minor.$patch" >> "$GITHUB_OUTPUT"
 
-      - name: Update versions
+      - name: Update version
         env:
           CURRENT: ${{ steps.version.outputs.current }}
           NEXT: ${{ steps.version.outputs.next }}
         run: |
           set -euo pipefail
-          test "$(jq -r '.version' wip.json)" = "$CURRENT"
-
           sed -i "s|<Version>${CURRENT}</Version>|<Version>${NEXT}</Version>|" Directory.Build.props
           grep -q "<Version>${NEXT}</Version>" Directory.Build.props
-
-          jq --arg version "$NEXT" '
-            .version = $version
-            | .architecture["64bit"].url = "https://github.com/slidict/wip/releases/download/v\($version)/wip-\($version)-win-x64.zip"
-            | .architecture["64bit"].hash = "https://github.com/slidict/wip/releases/download/v\($version)/SHA256SUMS"
-          ' wip.json > wip.json.tmp
-          mv wip.json.tmp wip.json
-
-          test "$(jq -r '.version' wip.json)" = "$NEXT"
-          jq -e --arg version "$NEXT" '
-            .architecture["64bit"].url == "https://github.com/slidict/wip/releases/download/v\($version)/wip-\($version)-win-x64.zip"
-            and .architecture["64bit"].hash == "https://github.com/slidict/wip/releases/download/v\($version)/SHA256SUMS"
-          ' wip.json > /dev/null
 
       - name: Commit version bump
         env:
@@ -92,7 +77,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -B "bump-version-v${NEXT}"
-          git add Directory.Build.props wip.json
+          git add Directory.Build.props
           git commit -m "chore: bump version to v${NEXT}"
 
           # Passed on the command line rather than written to .git/config, so the
@@ -112,4 +97,4 @@ jobs:
             --base "${GITHUB_REF_NAME}" \
             --head "bump-version-v${NEXT}" \
             --title "chore: bump version to v${NEXT}" \
-            --body "Bump wip and its Scoop manifest to v${NEXT}. Merging this publishes v${NEXT}: the release workflow reads the version from Directory.Build.props, and creates the tag itself."
+            --body "Bump wip version to v${NEXT}. Merging this publishes v${NEXT}: the release workflow reads the version from Directory.Build.props, creates the tag, and updates the Scoop manifest after uploading the release archive."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,25 +296,49 @@ jobs:
             exit 1
           fi
 
-          jq --arg version "$VERSION" --arg digest "$digest" '
-            .version = $version
-            | .architecture["64bit"].url = "https://github.com/slidict/wip/releases/download/v\($version)/wip-\($version)-win-x64.zip"
-            | .architecture["64bit"].hash = $digest
-          ' wip.json > wip.json.tmp
-          mv wip.json.tmp wip.json
-
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add wip.json
-          if git diff --cached --quiet; then
-            echo "Scoop manifest already describes v${VERSION}."
-            exit 0
-          fi
-          git commit -m "chore(scoop): update manifest for v${VERSION}"
 
           header=$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)
-          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${header}" \
-            push origin "HEAD:${GITHUB_REF_NAME}"
+          auth_header="AUTHORIZATION: basic ${header}"
+
+          # main can advance between the checkout above and the push below (another release,
+          # an unrelated merge). Retry against the latest tip rather than letting a stale push
+          # leave the manifest on the previous version: refetch, discard the rejected commit,
+          # and reapply the (idempotent) jq edit on top of the new tip.
+          pushed=false
+          for attempt in 1 2 3 4 5; do
+            jq --arg version "$VERSION" --arg digest "$digest" '
+              .version = $version
+              | .architecture["64bit"].url = "https://github.com/slidict/wip/releases/download/v\($version)/wip-\($version)-win-x64.zip"
+              | .architecture["64bit"].hash = $digest
+            ' wip.json > wip.json.tmp
+            mv wip.json.tmp wip.json
+
+            git add wip.json
+            if git diff --cached --quiet; then
+              echo "Scoop manifest already describes v${VERSION}."
+              pushed=true
+              break
+            fi
+            git commit -m "chore(scoop): update manifest for v${VERSION}"
+
+            if git -c "http.https://github.com/.extraheader=${auth_header}" \
+                push origin "HEAD:${GITHUB_REF_NAME}"; then
+              pushed=true
+              break
+            fi
+
+            echo "Push rejected on attempt ${attempt}; refetching ${GITHUB_REF_NAME} and retrying." >&2
+            git -c "http.https://github.com/.extraheader=${auth_header}" \
+              fetch origin "${GITHUB_REF_NAME}"
+            git reset --hard FETCH_HEAD
+          done
+
+          if [ "$pushed" != "true" ]; then
+            echo "::error::Could not push the Scoop manifest update after 5 attempts; ${GITHUB_REF_NAME} kept advancing." >&2
+            exit 1
+          fi
 
   # Called rather than triggered: a release created with GITHUB_TOKEN does not raise
   # `release: published` for another workflow, so an event-based handoff would leave every

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,6 +268,54 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # A Scoop manifest must contain the archive's digest, not a checksum-file URL. Keep
+      # the previous release installable until the new archive has been uploaded and
+      # published, then read back that release's checksum and update main atomically.
+      - name: Check out repository for Scoop manifest update
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.ref_name }}
+          persist-credentials: false
+
+      - name: Update Scoop manifest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.check.outputs.tag }}
+          VERSION: ${{ needs.check.outputs.version }}
+        run: |
+          set -euo pipefail
+          archive="wip-${VERSION}-win-x64.zip"
+          rm -rf scoop-release
+          mkdir scoop-release
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --pattern SHA256SUMS --dir scoop-release
+
+          digest=$(awk -v archive="$archive" '$2 == archive { print tolower($1) }' scoop-release/SHA256SUMS)
+          if ! [[ "$digest" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "::error::SHA256SUMS has no valid digest for $archive"
+            exit 1
+          fi
+
+          jq --arg version "$VERSION" --arg digest "$digest" '
+            .version = $version
+            | .architecture["64bit"].url = "https://github.com/slidict/wip/releases/download/v\($version)/wip-\($version)-win-x64.zip"
+            | .architecture["64bit"].hash = $digest
+          ' wip.json > wip.json.tmp
+          mv wip.json.tmp wip.json
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add wip.json
+          if git diff --cached --quiet; then
+            echo "Scoop manifest already describes v${VERSION}."
+            exit 0
+          fi
+          git commit -m "chore(scoop): update manifest for v${VERSION}"
+
+          header=$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${header}" \
+            push origin "HEAD:${GITHUB_REF_NAME}"
+
   # Called rather than triggered: a release created with GITHUB_TOKEN does not raise
   # `release: published` for another workflow, so an event-based handoff would leave every
   # automated release unsubmitted with nothing to show for it.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,15 @@ key, every command's flags, guides, and troubleshooting — see the **[wip Wiki]
 Windows with WSL2 and Microsoft WSLC. There is no runtime to install: `wip.exe` is a
 self-contained Native AOT binary.
 
-Download and extract `wip-<version>-win-x64.zip` from
+Install directly from this repository with [Scoop](https://scoop.sh/):
+
+```powershell
+scoop install https://raw.githubusercontent.com/slidict/wip/main/wip.json
+```
+
+Scoop puts `wip.exe` on your PATH and can update it later with `scoop update wip`.
+
+Alternatively, install it manually: download and extract `wip-<version>-win-x64.zip` from
 [Releases](https://github.com/slidict/wip/releases), then add the directory holding `wip.exe`
 to your PATH.
 

--- a/wip.json
+++ b/wip.json
@@ -17,7 +17,10 @@
     "architecture": {
       "64bit": {
         "url": "https://github.com/slidict/wip/releases/download/v$version/wip-$version-win-x64.zip",
-        "hash": "https://github.com/slidict/wip/releases/download/v$version/SHA256SUMS"
+        "hash": {
+          "url": "https://github.com/slidict/wip/releases/download/v$version/SHA256SUMS",
+          "regex": "$sha256\\s+$basename"
+        }
       }
     }
   }

--- a/wip.json
+++ b/wip.json
@@ -1,0 +1,24 @@
+{
+  "version": "2.0.6",
+  "description": "A developer-friendly CLI wrapper for Microsoft WSLC.",
+  "homepage": "https://github.com/slidict/wip",
+  "license": "MIT",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/slidict/wip/releases/download/v2.0.6/wip-2.0.6-win-x64.zip",
+      "hash": "https://github.com/slidict/wip/releases/download/v2.0.6/SHA256SUMS"
+    }
+  },
+  "bin": "wip.exe",
+  "checkver": {
+    "github": "https://github.com/slidict/wip"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/slidict/wip/releases/download/v$version/wip-$version-win-x64.zip",
+        "hash": "https://github.com/slidict/wip/releases/download/v$version/SHA256SUMS"
+      }
+    }
+  }
+}

--- a/wip.json
+++ b/wip.json
@@ -6,7 +6,7 @@
   "architecture": {
     "64bit": {
       "url": "https://github.com/slidict/wip/releases/download/v2.0.6/wip-2.0.6-win-x64.zip",
-      "hash": "https://github.com/slidict/wip/releases/download/v2.0.6/SHA256SUMS"
+      "hash": "97e7320e4a28264ed2034ea6f0db3f814f3a89ee3d2ac0e89f50c2c0a07e7f5c"
     }
   },
   "bin": "wip.exe",


### PR DESCRIPTION
### Motivation
- Provide a Scoop manifest so Windows users can install `wip` easily and receive updates via Scoop.
- Ensure the Scoop manifest's concrete download URL and hash are kept in sync with the project version during automated bumps.
- Add installation instructions to the README so users know how to install via Scoop.

### Description
- Add `wip.json` Scoop manifest containing `version`, `architecture`, `bin`, `checkver`, and `autoupdate` entries for `win-x64` builds.
- Update `.github/workflows/bump-version.yml` to update `wip.json` with `jq`, verify the `version`, `architecture["64bit"].url`, and `architecture["64bit"].hash`, and include `wip.json` in the commit pushed by the workflow.
- Rename the workflow step to `Update versions` and adjust the PR body text to mention bumping the Scoop manifest as well.
- Update `README.md` to document installing `wip` via Scoop with a `scoop install` example and mention how Scoop updates are performed.

### Testing
- No automated unit tests were added or modified as part of this change.
- The CI workflow includes `jq`-based assertions in the bump job to validate that `wip.json` is updated correctly, but no external CI run results are included in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a919ac4166483228416d29a19274425)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Scoop support for installing and updating `wip` on Windows.
  - Added automatic version checking and update configuration for Scoop installations.
  - Added verified download checksums for Scoop packages.
  - Improved release publishing reliability for package updates.

- **Documentation**
  - Documented Scoop installation, repository setup, and update commands.
  - Retained manual ZIP installation instructions as an alternative.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->