### PR TITLE
fix(test): select Microsoft.Testing.Platform runner

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.0.7</Version>
+    <Version>2.0.6</Version>
     <Authors>wip contributors</Authors>
     <Product>wip</Product>
     <Description>A developer-friendly CLI wrapper for Microsoft WSLC.</Description>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.0.6</Version>
+    <Version>2.0.7</Version>
     <Authors>wip contributors</Authors>
     <Product>wip</Product>
     <Description>A developer-friendly CLI wrapper for Microsoft WSLC.</Description>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/tests/Wip.Tests/Wip.Tests.csproj
+++ b/tests/Wip.Tests/Wip.Tests.csproj
@@ -9,13 +9,6 @@
       reflection dependency would actually matter.
     -->
     <IsAotCompatible>false</IsAotCompatible>
-    <!--
-      xunit.v3 runs on Microsoft.Testing.Platform. Starting with the .NET 10 SDK, `dotnet
-      test` no longer bridges MTP projects through VSTest automatically, so this opts the
-      project in to the native MTP-based `dotnet test` experience instead.
-      https://aka.ms/dotnet-test-mtp-error
-    -->
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Motivation

- CI and local `dotnet test` behavior on .NET 10 requires the Microsoft Testing Platform as the test runner rather than relying on the legacy VSTest bridge. 
- The project-level compatibility opt-in was ineffective or obsolete for the current SDK behavior and should be replaced by a repository-wide runner selection. 
- The change is a test-related bugfix, so the patch version is bumped to follow Semantic Versioning.

### Description

- Add a repository-level `global.json` with `"test": { "runner": "Microsoft.Testing.Platform" }` to select the MTP runner. 
- Remove the obsolete `TestingPlatformDotnetTestSupport` property from `tests/Wip.Tests/Wip.Tests.csproj`. 
- Bump the patch version from `2.0.6` to `2.0.7` in `Directory.Build.props`.

### Testing

- `python3 -m json.tool global.json` succeeded, validating the new `global.json` is valid JSON. 
- `git diff --check` succeeded with no whitespace or merge-marker problems. 
- `dotnet test tests/Wip.Tests/Wip.Tests.csproj --configuration Release --no-build` was not run in this environment because the .NET SDK is not installed, so runtime test execution was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a91b1a5a318832298dff248afe1420e)