### PR TITLE
fix(scoop): parse Windows checksum line endings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,7 +290,9 @@ jobs:
           gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
             --pattern SHA256SUMS --dir scoop-release
 
-          digest=$(awk -v archive="$archive" '$2 == archive { print tolower($1) }' scoop-release/SHA256SUMS)
+          # SHA256SUMS is written by PowerShell on a Windows runner, so its filename field can
+          # retain a carriage return when awk reads the CRLF-terminated line on Linux.
+          digest=$(awk -v archive="$archive" '{ sub(/\r$/, "", $2); if ($2 == archive) print tolower($1) }' scoop-release/SHA256SUMS)
           if ! [[ "$digest" =~ ^[0-9a-f]{64}$ ]]; then
             echo "::error::SHA256SUMS has no valid digest for $archive"
             exit 1


### PR DESCRIPTION
### Motivation
- The Linux publish job failed to extract the archive digest from `SHA256SUMS` because PowerShell on Windows writes CRLF-terminated lines and the filename field retained a trailing `\r`, causing the archive lookup to miss and the Scoop manifest update to fail.

### Description
- Update `.github/workflows/release.yml` to strip a trailing carriage return from the filename field before matching in `awk` by using `sub(/\r$/, "", $2)` so the digest for `wip-<version>-win-x64.zip` is correctly extracted.

### Testing
- Ran `git diff --check` which passed. 
- Parsed `release.yml` with Ruby using `YAML.load_file` which succeeded. 
- Performed an `awk` regression check against a CRLF-terminated checksum line which reproduced and resolved the issue (digest matched expected value). 
- Attempted `dotnet test tests/Wip.Tests/Wip.Tests.csproj --configuration Release` but it was not run in this environment because `dotnet` is unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9257280294832283a162c1aa4a678a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed release checksum parsing for archives generated on Windows, ensuring downloads can be verified correctly on Linux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->