### PR TITLE
feat(cli): add wip help --ai [--url]

### DIFF
--- a/src/Wip.Cli/CliContext.cs
+++ b/src/Wip.Cli/CliContext.cs
@@ -208,6 +208,56 @@ internal sealed partial class CliContext
         return 0;
     }
 
+    internal int HelpAi(string? url, IReadOnlyList<string> question)
+    {
+        var baseUrl = LocalAiProvider.ResolveBaseUrl(url);
+        if (!LocalAiProvider.IsAvailable(baseUrl))
+        {
+            throw new WipException(
+                $"{LocalAiProvider.NotFoundMessage(baseUrl)} Run `wip doctor` to check again.");
+        }
+
+        var model = LocalAiProvider.ResolveModel() ?? LocalAiProvider.DiscoverModel(baseUrl);
+        var asked = question.Count > 0 ? string.Join(' ', question) : ReadQuestion();
+        if (string.IsNullOrWhiteSpace(asked))
+        {
+            throw new WipException("A question is required");
+        }
+
+        Console.Error.WriteLine($"wip: asking {model} at {baseUrl}");
+        var answer = new LocalAiProvider(baseUrl, model).Generate(HelpAiPrompt(asked));
+        Console.WriteLine(answer);
+        return 0;
+    }
+
+    private static string ReadQuestion()
+    {
+        Console.Error.WriteLine(
+            "Ask wip how to do something, then press Enter twice (once after your question, " +
+            "once more on a blank line) to finish:");
+        var lines = new List<string>();
+        string? line;
+        while ((line = Console.ReadLine()) is not null && line.Length > 0)
+        {
+            lines.Add(line);
+        }
+
+        return string.Join(System.Environment.NewLine, lines);
+    }
+
+    private static string HelpAiPrompt(string question) => $$"""
+        You answer questions about how to use the wip CLI, a developer-friendly wrapper around
+        Microsoft WSLC. Answer only from the reference below; say plainly that it is not covered
+        there rather than guessing.
+
+        <wip-help>
+        {{Program.HelpText()}}
+        </wip-help>
+
+        Question:
+        {{question}}
+        """;
+
     internal int Doctor(string? url = null)
     {
         var results = new Doctor(Loader, Environment).Call(url);

--- a/src/Wip.Cli/Program.cs
+++ b/src/Wip.Cli/Program.cs
@@ -139,6 +139,7 @@ internal static class Program
         yield return init;
 
         yield return DoctorCommand(context);
+        yield return HelpCommand(context);
         yield return Simple("config", "Print the effective configuration", context, ctx => ctx.ShowConfig());
 
         yield return BuildCommand(context);
@@ -168,6 +169,60 @@ internal static class Program
         var command = new Command("doctor", "Diagnose the development environment") { url };
         command.SetAction(parsed => context(parsed).Doctor(parsed.GetValue(url)));
         return command;
+    }
+
+    private static Command HelpCommand(Func<ParseResult, CliContext> context)
+    {
+        var ai = new Option<bool>("--ai")
+        {
+            Description = "Ask a local AI server how to use wip instead of printing --help",
+        };
+        var url = AiUrlOption();
+        var question = new Argument<string[]>("question") { Arity = ArgumentArity.ZeroOrMore };
+        var command = new Command("help", "Show usage help (add --ai to ask a local AI server instead)")
+        {
+            ai, url, question,
+        };
+
+        command.SetAction(parsed =>
+        {
+            if (!parsed.GetValue(ai))
+            {
+                if (parsed.GetValue(url) is not null)
+                {
+                    throw new WipException("--url requires --ai");
+                }
+
+                if ((parsed.GetValue(question) ?? []).Length > 0)
+                {
+                    throw new WipException("a question requires --ai");
+                }
+
+                return ShowHelp();
+            }
+
+            return context(parsed).HelpAi(parsed.GetValue(url), parsed.GetValue(question) ?? []);
+        });
+
+        return command;
+    }
+
+    /// <summary>Prints the same text as <c>wip --help</c>, so <c>wip help</c> needs no text of
+    /// its own to keep in sync with the real command tree.</summary>
+    private static int ShowHelp()
+    {
+        var invocation = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
+        return BuildRoot().Parse(["--help"]).Invoke(invocation);
+    }
+
+    /// <summary>The same output as <see cref="ShowHelp"/>, captured as text instead of printed,
+    /// so <c>wip help --ai</c> can hand it to the local AI server as grounding context.</summary>
+    internal static string HelpText()
+    {
+        var writer = new StringWriter();
+        var invocation = new InvocationConfiguration { EnableDefaultExceptionHandler = false, Output = writer };
+        BuildRoot().Parse(["--help"]).Invoke(invocation);
+        return writer.ToString();
     }
 
     private static Command Simple(

--- a/src/Wip.Core/Ai/LocalAiProvider.cs
+++ b/src/Wip.Core/Ai/LocalAiProvider.cs
@@ -62,8 +62,11 @@ public sealed class LocalAiProvider : IWipAiProvider
             using var client = new TcpClient();
             return client.ConnectAsync(uri.Host, uri.Port).Wait(ProbeTimeout);
         }
-        catch (AggregateException)
+        catch (Exception exception) when (exception is AggregateException or ArgumentException)
         {
+            // ArgumentException covers a URI with no host or no default port for its scheme
+            // (e.g. file:///tmp), which TcpClient rejects synchronously before ConnectAsync
+            // ever returns a Task — too early for the AggregateException catch above to see it.
             return false;
         }
     }

--- a/tests/Wip.Tests/HelpCommandTests.cs
+++ b/tests/Wip.Tests/HelpCommandTests.cs
@@ -1,0 +1,51 @@
+using System.CommandLine;
+using Wip.Cli;
+
+namespace Wip.Tests;
+
+/// <summary>Covers <c>wip help</c>'s own argument validation and its reuse of <c>--help</c>'s
+/// text. The AI round trip itself is covered by <see cref="LocalAiProvider"/>'s tests; wiring it
+/// up here would mean either a real local AI server or duplicating those tests for no benefit.</summary>
+public class HelpCommandTests
+{
+    [Fact]
+    public void HelpTextMatchesRootHelpAndListsEveryCommand()
+    {
+        var text = Program.HelpText();
+
+        Assert.Contains("Usage:", text);
+        Assert.Contains("help", text);
+        Assert.Contains("doctor", text);
+        Assert.Contains("--ai", text);
+    }
+
+    [Fact]
+    public void UrlWithoutAiIsRejected()
+    {
+        var parsed = Program.BuildRoot().Parse(["help", "--url", "http://localhost:1"]);
+        var invocation = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
+
+        var exception = Assert.Throws<WipException>(() => parsed.Invoke(invocation));
+        Assert.Equal("--url requires --ai", exception.Message);
+    }
+
+    [Fact]
+    public void QuestionWithoutAiIsRejected()
+    {
+        var parsed = Program.BuildRoot().Parse(["help", "how", "do", "I", "sync"]);
+        var invocation = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
+
+        var exception = Assert.Throws<WipException>(() => parsed.Invoke(invocation));
+        Assert.Equal("a question requires --ai", exception.Message);
+    }
+
+    [Fact]
+    public void PlainHelpRoutesToTheHelpCommandWithAiOff()
+    {
+        var parsed = Program.Parse(Program.BuildRoot(), ["help"]);
+
+        Assert.Equal("help", parsed.CommandResult.Command.Name);
+        var ai = parsed.CommandResult.Command.Options.OfType<Option<bool>>().Single(option => option.Name == "--ai");
+        Assert.False(parsed.GetValue(ai));
+    }
+}

--- a/tests/Wip.Tests/WipAiTests.cs
+++ b/tests/Wip.Tests/WipAiTests.cs
@@ -107,6 +107,19 @@ public class WipAiTests
         Assert.False(LocalAiProvider.IsAvailable("http://127.0.0.1:1"));
     }
 
+    /// <summary>
+    /// A URI whose scheme has no default port and no explicit one either (file:///tmp parses to
+    /// an empty host and Port -1) makes TcpClient.ConnectAsync throw ArgumentException
+    /// synchronously, before it ever returns a Task — too early for a catch around
+    /// AggregateException alone to see it, so it used to escape IsAvailable and crash the CLI
+    /// instead of being reported as "no server found".
+    /// </summary>
+    [Fact]
+    public void IsAvailableRejectsAUriWithNoHostOrPortInsteadOfThrowing()
+    {
+        Assert.False(LocalAiProvider.IsAvailable("file:///tmp"));
+    }
+
     [Fact]
     public void GenerateSendsOpenAiCompatibleChatCompletionsRequest()
     {


### PR DESCRIPTION
## Summary
- Add `wip help`, which prints the same output as `wip --help` (generated from the same command tree, so the two can't drift apart).
- Add `wip help --ai [--url URL] [QUESTION...]`, which sends a natural-language question plus the `--help` text to a local AI server (same `LocalAiProvider` as `wip init --ai` / `wip doctor`) and prints the answer. The question can be passed inline or typed interactively (blank-line terminated, matching `wip init --ai`).
- `--url` alone (without `--ai`) and a question alone (without `--ai`) are both rejected up front, mirroring `wip init`'s `--template`/`--ai` validation.
- Wiki: added [wip-help](https://github.com/slidict/wip/wiki/wip-help) with examples, and cross-linked it from `wip-doctor`, `AI-Assisted-Initialization`, `CLI-Command-Reference`, and the sidebar.

## Test plan
- [x] `dotnet build wip.slnx`
- [x] `dotnet test tests/Wip.Tests/Wip.Tests.csproj` (569 tests, 553 passed, 16 pre-existing skips, 0 failures)
- [x] Manually verified `wip help`, `wip help --url <url>` (rejected), `wip help --ai` (rejected without a server)
- [x] Manually verified `wip help --ai --url ...` end-to-end against a real LM Studio server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzKtR25kpU6J7DueJcGuLN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `help` command to display available commands and usage information.
  * Added optional AI-assisted help for answering command-related questions.
  * Supports questions provided directly or entered interactively.
  * Added validation for AI-only options and empty questions.

* **Bug Fixes**
  * Improved handling of invalid local AI connection details so availability checks fail gracefully.

* **Tests**
  * Added coverage for help output, option validation, standard help behavior, and invalid AI connection details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->