### PR TITLE
Add wip ps/status/restart, and fix wip logs in mode: container

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ key, every command's flags, guides, and troubleshooting — see the **[wip Wiki]
 ## Contents
 
 - [Which mode should you use?](#which-mode-should-you-use)
+- [Architecture](#architecture)
 - [AI-assisted initialization](#ai-assisted-initialization)
 - [Requirements & installation](#requirements--installation)
 - [Quick start](#quick-start)
@@ -57,6 +58,75 @@ key, every command's flags, guides, and troubleshooting — see the **[wip Wiki]
 `docker-compose.yml`, or `docker-compose.yaml` next to it, and `container` otherwise — see
 [Commands](#commands). For the full breakdown and trade-offs, see
 [Choosing a Mode](https://github.com/slidict/wip/wiki/Choosing-a-Mode) on the wiki.
+
+## Architecture
+
+wip never talks to Docker: every mode ultimately shells out to `wslc.exe` / `wslc`, Microsoft's
+own container CLI, as a safe argv array. What differs between modes is *what sits between*
+`wip.yml` and `wslc` — today WSLC has no native Compose support, so `mode: compose` and
+`mode: compose-native` exist to cover that gap in two different ways:
+
+```mermaid
+flowchart TD
+    yml["wip.yml"] --> wip["wip.exe"]
+
+    subgraph m1["mode: container (default)"]
+        direction TB
+        wip -->|"run / exec / stop / logs / ps / restart"| wslc1["wslc.exe"]
+    end
+
+    subgraph m2["mode: compose-native"]
+        direction TB
+        wip -->|"parses compose.yml itself"| wslc2["wslc.exe"]
+    end
+
+    subgraph m3["mode: compose"]
+        direction TB
+        wip -->|"up / stop / down / exec / logs / ps"| bridge["compose-for-wslc<br/>(third-party, e.g. wslc-compose)"]
+        bridge --> wslc3["wslc.exe"]
+    end
+
+    compose["compose.yml"] -. "read by" .-> m2
+    compose -. "read by" .-> bridge
+```
+
+- **`mode: container`** — no `compose.yml` involved; wip drives `wslc` directly for one
+  container plus its `dependencies:`.
+- **`mode: compose-native`** — wip parses `compose.yml` itself and drives `wslc` the same way
+  `mode: container` does, one service at a time. See
+  [Compose Native Mode](https://github.com/slidict/wip/wiki/Compose-Native-Mode).
+- **`mode: compose`** — wip bridges to a separately-installed compose-for-wslc tool
+  (`compose.command` in `wip.yml`), which does the orchestration and itself drives `wslc`. wip
+  contributes no orchestration logic here, only argument forwarding.
+
+### If/when WSLC ships native Compose support
+
+`mode: compose-native` is a deliberate stopgap (see the `Modes` doc comment in
+[`Config.cs`](src/Wip.Core/Configuration/Config.cs)), not a permanent feature — it exists only
+because WSLC itself has no Compose command yet. Until that changes, wip keeps all three modes
+exactly as they are today. Once WSLC ships a complete native Compose command of its own (e.g.
+`wslc compose up`), `mode: compose-native` retires and `mode: compose` simply points at that
+native command instead of a third-party bridge:
+
+```mermaid
+flowchart TD
+    yml["wip.yml"] --> wip["wip.exe"]
+
+    subgraph m1["mode: container"]
+        direction TB
+        wip -->|"run / exec / stop / logs / ps / restart"| wslc1["wslc.exe"]
+    end
+
+    subgraph m3["mode: compose"]
+        direction TB
+        wip -->|"up / stop / down / exec / logs / ps"| wslc2["wslc.exe compose (native)"]
+    end
+
+    compose["compose.yml"] -. "read by wslc itself" .-> wslc2
+```
+
+Either way, wip stays a thin, safe-argv wrapper around `wip.yml` — it never grows an
+orchestration engine of its own; that job belongs to `wslc`.
 
 ## AI-assisted initialization
 

--- a/README.md
+++ b/README.md
@@ -330,12 +330,14 @@ and examples — start at the
 | `wip config` | Print the effective configuration (secrets masked) |
 | `wip build [--no-cache] [-- OPTIONS]` | Build the image from the `build` definition |
 | `wip up [-d] [--no-sync] [--no-cache] [--watch] [--interval N]` | Start the configured stack, creating it if necessary |
+| `wip ps` / `wip status` | Show the current state of the configured container or stack |
 | `wip stop` | Stop the configured stack without removing it |
 | `wip down` | Stop and remove the configured stack |
+| `wip restart` | Stop, then start the configured container or stack again — no rebuild, no `down`/`up` |
 | `wip exec [--no-interactive] COMMAND...` | Run a command in the existing container |
 | `wip run [--no-interactive] COMMAND...` | Run a command in a new `--rm` container (`mode: compose` has no ephemeral run — falls back to `exec` in the running service, with a warning) |
 | `wip shell` | Open the configured shell, falling back to `bash` then `sh` |
-| `wip logs [-f] [SERVICE...]` | Follow compose service logs (compose modes only; under `mode: compose-native`, at most one `SERVICE`) |
+| `wip logs [-f] [SERVICE...]` | Follow logs from the configured container (`mode: container` / `compose-native`, at most one `SERVICE`) or compose services (`mode: compose`) |
 | `wip sync [-w\|--watch] [--interval N]` | Mirror the source into the sync volume once, or keep re-syncing with `--watch` (needs `sync:`) |
 | `wip NAME ARGS...` | Run `interaction.NAME`, appending any extra arguments |
 

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ and examples — start at the
 | `wip ps` / `wip status` | Show the current state of the configured container or stack |
 | `wip stop` | Stop the configured stack without removing it |
 | `wip down` | Stop and remove the configured stack |
-| `wip restart` | Stop, then start the configured container or stack again — no rebuild, no `down`/`up` |
+| `wip restart` | Stop, then start the configured container or stack again — no rebuild (`mode: compose` runs `stop` then `up -d`; other modes run `stop` then `start`, never `down`) |
 | `wip exec [--no-interactive] COMMAND...` | Run a command in the existing container |
 | `wip run [--no-interactive] COMMAND...` | Run a command in a new `--rm` container (`mode: compose` has no ephemeral run — falls back to `exec` in the running service, with a warning) |
 | `wip shell` | Open the configured shell, falling back to `bash` then `sh` |

--- a/src/Wip.Cli/CliContext.cs
+++ b/src/Wip.Cli/CliContext.cs
@@ -396,11 +396,25 @@ internal sealed partial class CliContext
     {
         if (Config.IsCompose)
         {
-            Execute(Bridge.Stop(), exitOnFailure: false);
+            var stopCode = Execute(Bridge.Stop(), exitOnFailure: false);
+            if (stopCode != 0)
+            {
+                return stopCode;
+            }
+
             return Execute(Bridge.Up(detach: true), interactive: false);
         }
 
-        Execute(Builder.Stop(), exitOnFailure: false);
+        // A failed stop is not swallowed like the sidecar stops below are: if the primary
+        // container is still running afterwards, EnsureContainer sees AlreadyRunning and does
+        // nothing, so returning 0 unconditionally here would report success without the
+        // container having actually restarted.
+        var primaryStopCode = Execute(Builder.Stop(), exitOnFailure: false);
+        if (primaryStopCode != 0)
+        {
+            return primaryStopCode;
+        }
+
         foreach (var name in SidecarNames())
         {
             Execute(Builder.DependencyStop(name), exitOnFailure: false);

--- a/src/Wip.Cli/CliContext.cs
+++ b/src/Wip.Cli/CliContext.cs
@@ -35,6 +35,8 @@ internal sealed partial class CliContext
     /// "dead" state — only <c>exited</c> is a live, restartable exit; <c>deleted</c> means the
     /// container itself is gone and needs <c>wip up</c> to recreate it, not <c>start</c>.
     /// </summary>
+    private const int WslcContainerStateCreated = 1;
+
     private const int WslcContainerStateRunning = 2;
 
     private const int WslcContainerStateExited = 3;
@@ -383,6 +385,54 @@ internal sealed partial class CliContext
         return 0;
     }
 
+    /// <summary>
+    /// Restarts without a rebuild: stop, then let the same create-vs-start decision
+    /// <see cref="EnsureContainer"/> already makes for <c>wip up</c> bring it back — a freshly
+    /// stopped container is listed as <c>created</c>, not <c>deleted</c>, so it starts rather
+    /// than gets recreated. Always detached: this is a lifecycle operation, not a new
+    /// foreground attach.
+    /// </summary>
+    internal int Restart()
+    {
+        if (Config.IsCompose)
+        {
+            Execute(Bridge.Stop(), exitOnFailure: false);
+            return Execute(Bridge.Up(detach: true), interactive: false);
+        }
+
+        Execute(Builder.Stop(), exitOnFailure: false);
+        foreach (var name in SidecarNames())
+        {
+            Execute(Builder.DependencyStop(name), exitOnFailure: false);
+        }
+
+        foreach (var name in SidecarNames())
+        {
+            EnsureDependency(name);
+        }
+
+        EnsureContainer(detach: true);
+        return 0;
+    }
+
+    internal int Ps()
+    {
+        if (Config.IsCompose)
+        {
+            return Execute(Bridge.Ps(), interactive: true);
+        }
+
+        PrintStatusLine(
+            Config.Container ?? throw new ConfigException("container: must be set in wip.yml"),
+            Builder.Find());
+        foreach (var name in SidecarNames())
+        {
+            PrintStatusLine(name, Builder.DependencyFind(name));
+        }
+
+        return 0;
+    }
+
     internal int Exec(IReadOnlyList<string> command, bool interactive) =>
         Execute(ExecTarget(command, interactive), interactive: Tty(interactive));
 
@@ -414,28 +464,26 @@ internal sealed partial class CliContext
 
     internal int Logs(IReadOnlyList<string> services, bool follow)
     {
-        if (!Config.IsComposeMode)
-        {
-            throw new ConfigException("`wip logs` is only available in compose mode");
-        }
-
         if (Config.IsCompose)
         {
             return Execute(Bridge.Logs(services, follow), interactive: true);
         }
 
         // wslc has no compose-style multi-service log aggregation, so exactly one SERVICE is
-        // allowed, defaulting to compose.service when none is given.
+        // allowed, defaulting to the configured container (compose.service, under
+        // mode: compose-native) when none is given.
         if (services.Count > 1)
         {
             throw new ConfigException(
-                "`wip logs` under mode: compose-native takes at most one SERVICE " +
-                "(wslc logs, unlike a real compose tool, only follows one container at a time)");
+                "`wip logs` outside mode: compose takes at most one SERVICE " +
+                "(wslc, unlike a real compose tool, only follows one container at a time)");
         }
 
-        return Execute(
-            Builder.Logs(services.Count == 0 ? Config.ComposeService! : services[0], follow),
-            interactive: true);
+        var name = services.Count == 0
+            ? Config.Container ?? throw new ConfigException("container: must be set in wip.yml")
+            : services[0];
+
+        return Execute(Builder.Logs(name, follow), interactive: true);
     }
 
     internal int Dispatch(string name, IReadOnlyList<string> arguments)
@@ -865,6 +913,33 @@ internal sealed partial class CliContext
     /// visible instead of silently doing nothing forever.
     /// </summary>
     private int? ContainerStatus(string name) => ContainerEntry(Builder.DependencyFind(name), name).State;
+
+    /// <summary>
+    /// Prints one <c>wip ps</c>/<c>wip status</c> line. Image and ports come from the
+    /// configured <c>wip.yml</c> values rather than the wslc listing: only <c>Name</c> and
+    /// <c>State</c> are confirmed fields of that JSON anywhere else in this codebase.
+    /// </summary>
+    private void PrintStatusLine(string name, IReadOnlyList<string> findCommand)
+    {
+        var (exists, state) = ContainerEntry(findCommand, name);
+        var dependency = Config.Dependency(name);
+        var image = RubyValue.Presence(dependency?.GetValueOrDefault("image")) ?? "-";
+        var ports = RubyValue.AsArray(dependency?.GetValueOrDefault("ports"))
+            .Select(RubyValue.ToStringValue).ToList();
+
+        Console.WriteLine(string.Join('\t',
+            name, StatusLabel(exists, state), image, ports.Count > 0 ? string.Join(", ", ports) : "-"));
+    }
+
+    internal static string StatusLabel(bool exists, int? state) => (exists, state) switch
+    {
+        (false, _) => "not found",
+        (true, WslcContainerStateCreated) => "created",
+        (true, WslcContainerStateRunning) => "running",
+        (true, WslcContainerStateExited) => "exited",
+        (true, WslcContainerStateDeleted) => "deleted",
+        _ => "unknown",
+    };
 
     /// <summary>
     /// One probe answering both questions, because they come from the same listing. Splitting

--- a/src/Wip.Cli/Program.cs
+++ b/src/Wip.Cli/Program.cs
@@ -146,10 +146,16 @@ internal static class Program
         yield return UpCommand(context);
         yield return SyncCommand(context);
 
+        yield return Simple("ps", "Show the current state of the configured container or stack",
+            context, ctx => ctx.Ps());
+        yield return Simple("status", "Alias for `wip ps`", context, ctx => ctx.Ps());
+
         yield return Simple("stop", "Stop the configured container and its dependencies without removing them",
             context, ctx => ctx.Stop());
         yield return Simple("down", "Stop and remove the configured container and its dependencies",
             context, ctx => ctx.Down());
+        yield return Simple("restart", "Restart the configured container or stack (stop, then start — no rebuild)",
+            context, ctx => ctx.Restart());
 
         yield return ExecCommand(context);
         yield return RunCommand(context);
@@ -337,7 +343,7 @@ internal static class Program
         var noFollow = new Option<bool>("--no-follow") { Description = "Print current logs and exit" };
         var services = new Argument<string[]>("services") { Arity = ArgumentArity.ZeroOrMore };
 
-        var command = new Command("logs", "Follow logs from compose services (compose mode only)")
+        var command = new Command("logs", "Follow logs from the configured container or compose services")
         {
             follow, noFollow, services,
         };

--- a/src/Wip.Core/Compose/ComposeBridge.cs
+++ b/src/Wip.Core/Compose/ComposeBridge.cs
@@ -84,6 +84,13 @@ public sealed class ComposeBridge
         return command;
     }
 
+    public IReadOnlyList<string> Ps()
+    {
+        var command = Base();
+        command.Add("ps");
+        return command;
+    }
+
     public IReadOnlyList<string> Exec(string service, IEnumerable<string> arguments, bool interactive = true)
     {
         var command = Base();

--- a/tests/Wip.Tests/CommandRoutingTests.cs
+++ b/tests/Wip.Tests/CommandRoutingTests.cs
@@ -14,6 +14,9 @@ public class CommandRoutingTests
     [InlineData(new[] { "up", "-d" }, "up")]
     [InlineData(new[] { "--config", "x.yml", "up" }, "up")]
     [InlineData(new[] { "--debug", "doctor" }, "doctor")]
+    [InlineData(new[] { "ps" }, "ps")]
+    [InlineData(new[] { "status" }, "status")]
+    [InlineData(new[] { "restart" }, "restart")]
     // An unknown name is routed.
     [InlineData(new[] { "mycmd" }, "dispatch")]
     [InlineData(new[] { "--config", "x.yml", "mycmd" }, "dispatch")]

--- a/tests/Wip.Tests/ComposeBridgeTests.cs
+++ b/tests/Wip.Tests/ComposeBridgeTests.cs
@@ -1,0 +1,29 @@
+using Wip.Compose;
+
+namespace Wip.Tests;
+
+/// <summary>
+/// Covers <see cref="ComposeBridge.Ps"/>'s argv shape, added for <c>wip ps</c>/<c>wip status</c>
+/// under <c>mode: compose</c>. <c>compose ps</c> is close to universal across compose-for-wslc
+/// implementations, unlike <c>restart</c>/<c>pull</c>, which is why only this method got added.
+/// </summary>
+public class ComposeBridgeTests
+{
+    [Fact]
+    public void PsIncludesFileAndProject()
+    {
+        var bridge = new ComposeBridge("wslc-compose", "compose.yml", "myproject");
+
+        Assert.Equal(
+            new[] { "wslc-compose", "-f", "compose.yml", "-p", "myproject", "ps" },
+            bridge.Ps());
+    }
+
+    [Fact]
+    public void PsOmitsProjectWhenNotConfigured()
+    {
+        var bridge = new ComposeBridge("wslc-compose", "compose.yml");
+
+        Assert.Equal(new[] { "wslc-compose", "-f", "compose.yml", "ps" }, bridge.Ps());
+    }
+}

--- a/tests/Wip.Tests/StatusLabelTests.cs
+++ b/tests/Wip.Tests/StatusLabelTests.cs
@@ -1,0 +1,70 @@
+using Wip.Cli;
+
+namespace Wip.Tests;
+
+/// <summary>
+/// Covers <c>wip ps</c>/<c>wip status</c>'s state-to-label mapping. Pure function, mirroring
+/// the WSLC container states documented alongside <see cref="CliContext.DecideContainerAction"/>:
+/// 0 invalid, 1 created, 2 running, 3 exited, 4 deleted.
+/// </summary>
+public class StatusLabelTests
+{
+    private const int Invalid = 0;
+    private const int Created = 1;
+    private const int Running = 2;
+    private const int Exited = 3;
+    private const int Deleted = 4;
+
+    [Theory]
+    [InlineData(Running)]
+    [InlineData(Exited)]
+    [InlineData(Deleted)]
+    public void AbsenceOutranksState(int state)
+    {
+        Assert.Equal("not found", CliContext.StatusLabel(exists: false, state: state));
+    }
+
+    [Fact]
+    public void NotListedIsNotFound()
+    {
+        Assert.Equal("not found", CliContext.StatusLabel(exists: false, state: null));
+    }
+
+    [Fact]
+    public void CreatedIsReported()
+    {
+        Assert.Equal("created", CliContext.StatusLabel(exists: true, state: Created));
+    }
+
+    [Fact]
+    public void RunningIsReported()
+    {
+        Assert.Equal("running", CliContext.StatusLabel(exists: true, state: Running));
+    }
+
+    [Fact]
+    public void ExitedIsReported()
+    {
+        Assert.Equal("exited", CliContext.StatusLabel(exists: true, state: Exited));
+    }
+
+    [Fact]
+    public void DeletedIsReported()
+    {
+        Assert.Equal("deleted", CliContext.StatusLabel(exists: true, state: Deleted));
+    }
+
+    /// <summary>
+    /// A state wip cannot read, or one wslc does not actually use, falls back to "unknown"
+    /// rather than guessing — the same caution <see cref="CliContext.DecideContainerAction"/>
+    /// takes for an unreadable state.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData(Invalid)]
+    [InlineData(99)]
+    public void UnreadableStateIsUnknown(int? state)
+    {
+        Assert.Equal("unknown", CliContext.StatusLabel(exists: true, state: state));
+    }
+}


### PR DESCRIPTION
## Summary
- Refs #117 (not closing it — `wip pull` from that issue is out of scope for wip entirely, see below)
- `wip logs` no longer requires a compose mode: `CommandBuilder.Logs` already built a working single-container `wslc logs` command for `mode: compose-native`; the blanket `mode: container` gate is dropped so the same path now works there too (`--follow`/`-f` included)
- Added `wip ps` / `wip status`: reports each configured container's runtime state (name, running/created/exited/deleted/not found, plus the image and ports from `wip.yml`) via the existing `wslc list --filter` probe already used by `wip up`'s create-vs-start decision; delegates to `compose ps` under `mode: compose`
- Added `wip restart`: stop, then let the existing create-vs-start logic (`EnsureContainer`/`EnsureDependency`) bring it back up — no rebuild, no `down`+`up`

## Why not everything in #117
- `wip pull` is not implemented, and won't be: pulling an image is a standalone operation, not an orchestration step, so it falls outside what `wip` is for — it's not a "confirm the subcommand later" deferral, it's a scope decision
- `wip restart` and `wip ps` are built from primitives already proven in this codebase (`stop`, `start`, `list --filter`) instead of assuming wslc/compose-for-wslc ship native `restart`/`ps` subcommands, since only `compose ps` is safe to assume as near-universal

## Test plan
- [x] `dotnet build` (Wip.Cli) succeeds
- [x] `dotnet test` — 586 total, 570 passed, 16 skipped (pre-existing host-path skips), 0 failed
- [x] Added `StatusLabelTests.cs`, `ComposeBridgeTests.cs`, extended `CommandRoutingTests.cs` for the new subcommands
- [ ] Manual verification on a real WSLC host (`wip logs -f` under `mode: container`, `wip restart` on a running stack, `wip ps`/`wip status` under all three modes) — not possible in this environment, see README's existing "Needs verification on real hardware" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5Vwk7RmjtnXDCjRhunzbE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `wip ps` and `wip status` to view container and stack states.
  * Added `wip restart` for restarting services without rebuilding or taking them down.
  * Expanded `wip logs` to support configured containers and Compose services.
  * Added clear labels for created, running, exited, deleted, and unknown states.

* **Documentation**
  * Documented architecture modes, command behavior, restart workflows, and expanded logs support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->