### PR TITLE
feat: add dependency readiness checks (healthcheck:)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,14 +96,21 @@ flowchart TD
   `mode: container` does, one service at a time. See
   [Compose Native Mode](https://github.com/slidict/wip/wiki/Compose-Native-Mode).
 
-  Supported `services.<name>` keys: `image`, `build`, `command`, `environment`, `ports`
-  (short syntax only, e.g. `"3000:3000"`), `volumes`, `working_dir`, `user`, `restart`,
-  `depends_on` (`condition: service_started` or `service_healthy`), `profiles`, `healthcheck`.
+  `services.<name>` keys:
 
-  `tty`, `stdin_open`, `networks`, `cap_add`, and `dns` are accepted and silently ignored:
-  `wslc run`/`exec` has no flag to map any of them onto (TTY/stdin allocation is decided per
-  invocation instead, and every service already shares one project network). Anything else is
-  a `ConfigError` naming the unsupported key, rather than a silent no-op.
+  | Key | Status |
+  |---|---|
+  | `image`, `build`, `command`, `environment`, `volumes`, `working_dir`, `user`, `restart`, `profiles`, `healthcheck` | Supported |
+  | `ports` | Supported — short syntax only (e.g. `"3000:3000"`), not long-syntax mappings |
+  | `depends_on` | Supported — `condition: service_started` or `service_healthy` |
+  | `tty`, `stdin_open` | Ignored — TTY/stdin allocation is decided per invocation, not per service |
+  | `networks` | Ignored — every service already shares one project network |
+  | `cap_add` | Ignored — `wslc run`/`exec` has no capability flag to forward it to |
+  | `dns` | Ignored — `wslc run`/`exec` has no flag to set per-container DNS servers |
+  | anything else | `ConfigError` naming the key |
+
+  "Ignored" means accepted without error but with no effect — not a silent no-op passed off as
+  working, but a deliberate choice documented in [`ComposeFile.cs`](src/Wip.Core/Compose/ComposeFile.cs).
 - **`mode: compose`** — wip bridges to a separately-installed compose-for-wslc tool
   (`compose.command` in `wip.yml`), which does the orchestration and itself drives `wslc`. wip
   contributes no orchestration logic here, only argument forwarding.

--- a/README.md
+++ b/README.md
@@ -382,8 +382,10 @@ instead — see [Secret Masking](https://github.com/slidict/wip/wiki/Secret-Mask
 `healthcheck.test` accepts the same three shapes real Compose does: a bare string (shell form,
 run as `sh -c "..."`), an array starting with `CMD` (run exactly as written) or `CMD-SHELL`
 (shell form), or `NONE` (spelled either way) to explicitly disable one. `interval`, `timeout`,
-and `start_period` are plain seconds — not Compose's duration strings (`10s`, `1m30s`) — matching
-every other timing field in wip.yml (e.g. `sync.interval`). A dependency with no `healthcheck:`
+and `start_period` accept either a plain number of seconds (matching every other timing field in
+wip.yml, e.g. `sync.interval`) or a Compose duration string (`10s`, `1m30s`) — compose.yml
+healthchecks are almost always written the latter way, so `mode: compose-native` has to read them
+as they actually appear. `retries` is always a plain count. A dependency with no `healthcheck:`
 behaves exactly as before: `wip up` starts it and moves on without waiting. Under
 `mode: compose-native`, compose.yml's own `healthcheck:` is read the same way, and
 `depends_on: condition: service_healthy` is accepted as long as the named service declares one

--- a/README.md
+++ b/README.md
@@ -337,6 +337,12 @@ dependencies:
     env:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: development
+    healthcheck: # optional; `wip up` waits for this before starting whatever needs it
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 2 # seconds between checks (default 1)
+      timeout: 5 # seconds a single check may take before it counts as a failure (default 1)
+      retries: 10 # consecutive failures after start_period before giving up (default 3)
+      start_period: 10 # seconds of grace before failures start counting (default 0)
 interaction:
   rails:
     type: exec
@@ -373,6 +379,19 @@ sync: # optional; mirror the source into a named volume instead of bind-mounting
 credential, or auth. Keep real secrets out of the config file and in your runtime environment
 instead — see [Secret Masking](https://github.com/slidict/wip/wiki/Secret-Masking).
 
+`healthcheck.test` accepts the same three shapes real Compose does: a bare string (shell form,
+run as `sh -c "..."`), an array starting with `CMD` (run exactly as written) or `CMD-SHELL`
+(shell form), or `NONE` (spelled either way) to explicitly disable one. `interval`, `timeout`,
+and `start_period` are plain seconds — not Compose's duration strings (`10s`, `1m30s`) — matching
+every other timing field in wip.yml (e.g. `sync.interval`). A dependency with no `healthcheck:`
+behaves exactly as before: `wip up` starts it and moves on without waiting. Under
+`mode: compose-native`, compose.yml's own `healthcheck:` is read the same way, and
+`depends_on: condition: service_healthy` is accepted as long as the named service declares one
+(a `ConfigError` at load time otherwise) — but note that any `healthcheck:`, however it was
+declared, is waited on once its service starts, regardless of which condition (if any)
+named it. If the check never passes, `wip up` fails with a clear error once `retries` is
+exhausted instead of handing a not-yet-ready dependency to whatever depends on it.
+
 `interaction:` can also be spelled `commands:` — the same block under a different name, e.g. for
 projects that already use `commands:`. The two are aliases for the same feature; declaring both in
 the same `wip.yml` is a `ConfigError`. See [Interactions](https://github.com/slidict/wip/wiki/Interactions).
@@ -399,7 +418,7 @@ and examples — start at the
 | `wip doctor` | Diagnose WSL2, WSLC, config, architecture, Git, and the `--ai` host |
 | `wip config` | Print the effective configuration (secrets masked) |
 | `wip build [--no-cache] [-- OPTIONS]` | Build the image from the `build` definition |
-| `wip up [-d] [--no-sync] [--no-cache] [--watch] [--interval N]` | Start the configured stack, creating it if necessary |
+| `wip up [-d] [--no-sync] [--no-cache] [--watch] [--interval N]` | Start the configured stack, creating it if necessary (waits on any `healthcheck:` before starting whatever depends on it) |
 | `wip ps` / `wip status` | Show the current state of the configured container or stack |
 | `wip stop` | Stop the configured stack without removing it |
 | `wip down` | Stop and remove the configured stack |

--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ flowchart TD
 - **`mode: compose-native`** — wip parses `compose.yml` itself and drives `wslc` the same way
   `mode: container` does, one service at a time. See
   [Compose Native Mode](https://github.com/slidict/wip/wiki/Compose-Native-Mode).
+
+  Supported `services.<name>` keys: `image`, `build`, `command`, `environment`, `ports`
+  (short syntax only, e.g. `"3000:3000"`), `volumes`, `working_dir`, `user`, `restart`,
+  `depends_on` (`condition: service_started` or `service_healthy`), `profiles`, `healthcheck`.
+
+  `tty`, `stdin_open`, `networks`, `cap_add`, and `dns` are accepted and silently ignored:
+  `wslc run`/`exec` has no flag to map any of them onto (TTY/stdin allocation is decided per
+  invocation instead, and every service already shares one project network). Anything else is
+  a `ConfigError` naming the unsupported key, rather than a silent no-op.
 - **`mode: compose`** — wip bridges to a separately-installed compose-for-wslc tool
   (`compose.command` in `wip.yml`), which does the orchestration and itself drives `wslc`. wip
   contributes no orchestration logic here, only argument forwarding.

--- a/src/Wip.Cli/CliContext.cs
+++ b/src/Wip.Cli/CliContext.cs
@@ -555,15 +555,27 @@ internal sealed partial class CliContext
         return code;
     }
 
-    private (int Code, string Output) Probe(IReadOnlyList<string> command, TimeSpan? timeout = null)
+    /// <summary>
+    /// <paramref name="captureStderr"/> defaults to false because <see cref="ContainerEntry"/>
+    /// and <see cref="NetworkExists"/> parse this output as JSON — merging in stderr would risk
+    /// breaking that parse the moment wslc ever writes a warning there. A readiness check has
+    /// no such expectation and wants exactly the opposite: stderr is usually where the useful
+    /// diagnostic is, so <see cref="WaitForHealthy"/> opts in.
+    /// </summary>
+    private (int Code, string Output) Probe(
+        IReadOnlyList<string> command,
+        TimeSpan? timeout = null,
+        bool captureStderr = false)
     {
-        var output = new StringWriter();
-        var runner = new CommandRunner(Interpreter, output, new StringWriter(), Debug);
+        var captured = new StringWriter();
+        var output = captureStderr ? TextWriter.Synchronized(captured) : captured;
+        var error = captureStderr ? output : new StringWriter();
+        var runner = new CommandRunner(Interpreter, output, error, Debug);
         var code = Reporter.Step(
             $"checking: {CommandDisplay.ForDebug(command)}",
             () => runner.Run(command, timeout: timeout));
 
-        return (code, output.ToString());
+        return (code, captured.ToString());
     }
 
     /// <summary>
@@ -691,7 +703,8 @@ internal sealed partial class CliContext
 
         while (true)
         {
-            var (code, checkOutput) = Probe(Builder.DependencyExec(name, test), TimeSpan.FromSeconds(timeout));
+            var (code, checkOutput) =
+                Probe(Builder.DependencyExec(name, test), TimeSpan.FromSeconds(timeout), captureStderr: true);
             if (code == 0)
             {
                 Console.Error.WriteLine($"wip: dependency '{name}' is healthy");

--- a/src/Wip.Cli/CliContext.cs
+++ b/src/Wip.Cli/CliContext.cs
@@ -555,13 +555,13 @@ internal sealed partial class CliContext
         return code;
     }
 
-    private (int Code, string Output) Probe(IReadOnlyList<string> command)
+    private (int Code, string Output) Probe(IReadOnlyList<string> command, TimeSpan? timeout = null)
     {
         var output = new StringWriter();
         var runner = new CommandRunner(Interpreter, output, new StringWriter(), Debug);
         var code = Reporter.Step(
             $"checking: {CommandDisplay.ForDebug(command)}",
-            () => runner.Run(command));
+            () => runner.Run(command, timeout: timeout));
 
         return (code, output.ToString());
     }
@@ -654,7 +654,70 @@ internal sealed partial class CliContext
                 Execute(Builder.DependencyUp(name));
                 break;
         }
+
+        WaitForHealthy(name);
     }
+
+    /// <summary>
+    /// Polls <c>dependencies.&lt;name&gt;.healthcheck</c> — set directly under
+    /// <c>mode: container</c>, or read from compose.yml's own <c>healthcheck:</c> under
+    /// <c>mode: compose-native</c> — the way <c>docker compose up</c> blocks a
+    /// <c>depends_on: condition: service_healthy</c> dependent. A no-op when the dependency
+    /// declares no healthcheck at all, which keeps every project unaffected until it opts in.
+    /// </summary>
+    /// <remarks>
+    /// Waits on any healthcheck it finds, regardless of which depends_on condition (if any)
+    /// named it: <see cref="SidecarNames"/> already starts sidecars before the primary
+    /// container, and compose-native's dependency order already starts a dependency before
+    /// anything depends_on says depends on it, so there is no separate per-edge condition to
+    /// gate on selectively here.
+    /// </remarks>
+    private void WaitForHealthy(string name)
+    {
+        if (RubyValue.AsMapping(Config.Dependency(name)?.GetValueOrDefault("healthcheck")) is not { } healthcheck)
+        {
+            return;
+        }
+
+        var test = RubyValue.AsArray(healthcheck.GetValueOrDefault("test")).Select(RubyValue.ToStringValue).ToList();
+        var interval = Convert.ToDouble(healthcheck.GetValueOrDefault("interval"), CultureInfo.InvariantCulture);
+        var timeout = Convert.ToDouble(healthcheck.GetValueOrDefault("timeout"), CultureInfo.InvariantCulture);
+        var retries = Convert.ToInt32(healthcheck.GetValueOrDefault("retries"), CultureInfo.InvariantCulture);
+        var startPeriod = Convert.ToDouble(healthcheck.GetValueOrDefault("start_period"), CultureInfo.InvariantCulture);
+
+        Console.Error.WriteLine($"wip: waiting for dependency '{name}' to become healthy");
+        var startPeriodEnds = DateTime.UtcNow.AddSeconds(startPeriod);
+        var failures = 0;
+
+        while (true)
+        {
+            var (code, checkOutput) = Probe(Builder.DependencyExec(name, test), TimeSpan.FromSeconds(timeout));
+            if (code == 0)
+            {
+                Console.Error.WriteLine($"wip: dependency '{name}' is healthy");
+                return;
+            }
+
+            // Failures during start_period don't count against retries — the same grace real
+            // Compose gives a slow-booting service before it starts judging health at all.
+            if (DateTime.UtcNow >= startPeriodEnds && ++failures > retries)
+            {
+                throw new WipException(HealthCheckFailureMessage(name, failures, code, checkOutput));
+            }
+
+            Thread.Sleep(TimeSpan.FromSeconds(interval));
+        }
+    }
+
+    internal static string HealthCheckFailureMessage(string name, int failures, int code, string output)
+    {
+        var reason = code == CommandRunner.TimeoutExitCode ? "timed out" : $"exited {code}";
+        var detail = LastLine(output) is { } line ? $": {line}" : "";
+        return $"dependency '{name}' did not become healthy after {failures} attempt(s) (last check {reason}){detail}";
+    }
+
+    internal static string? LastLine(string output) =>
+        output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).LastOrDefault();
 
     private void EnsureContainer(bool detach)
     {

--- a/src/Wip.Core/Compose/ComposeFile.cs
+++ b/src/Wip.Core/Compose/ComposeFile.cs
@@ -1,3 +1,4 @@
+using Wip.Configuration;
 using Wip.Platform;
 using Wip.Yaml;
 
@@ -18,7 +19,7 @@ public sealed class ComposeFile
     private static readonly string[] ServiceKeys =
     [
         "image", "build", "command", "environment", "ports", "volumes", "working_dir", "user", "restart",
-        "depends_on", "profiles",
+        "depends_on", "profiles", "healthcheck",
     ];
 
     /// <summary>
@@ -32,7 +33,7 @@ public sealed class ComposeFile
     // shadow_context is deliberately absent: the build context is now always staged to a
     // local cache, so the key has no effect and falls through to the unsupported-key error.
     private static readonly string[] BuildKeys = ["context", "dockerfile", "args"];
-    private static readonly string[] SupportedConditions = ["service_started"];
+    private static readonly string[] SupportedConditions = ["service_started", "service_healthy"];
     private const string ListHint = "only supports short syntax (\"host:container\"), not long-syntax mappings";
 
     private readonly string path;
@@ -126,6 +127,7 @@ public sealed class ComposeFile
             entry["workdir"] = service.Workdir;
             entry["user"] = service.User;
             entry["restart"] = service.Restart;
+            entry["healthcheck"] = service.HealthCheck;
             result[name] = entry;
         }
 
@@ -175,7 +177,8 @@ public sealed class ComposeFile
             RubyValue.Presence(mapping.GetValueOrDefault("working_dir")),
             RubyValue.Presence(mapping.GetValueOrDefault("user")),
             NormalizeRestart(mapping.GetValueOrDefault("restart")),
-            NormalizeDependsOn(name, mapping.GetValueOrDefault("depends_on")));
+            NormalizeDependsOn(name, mapping.GetValueOrDefault("depends_on")),
+            HealthCheck.Normalize($"{path}: services.{name}.healthcheck", mapping.GetValueOrDefault("healthcheck")));
     }
 
     /// <summary>
@@ -323,7 +326,7 @@ public sealed class ComposeFile
         return sequence.Select(RubyValue.ToStringValue).ToList();
     }
 
-    private List<string> NormalizeDependsOn(string name, object? value)
+    private List<DependsOnEntry> NormalizeDependsOn(string name, object? value)
     {
         if (value is null)
         {
@@ -332,7 +335,8 @@ public sealed class ComposeFile
 
         if (RubyValue.AsSequence(value) is { } sequence)
         {
-            return sequence.Select(RubyValue.ToStringValue).ToList();
+            return sequence.Select(item => new DependsOnEntry(RubyValue.ToStringValue(item), "service_started"))
+                .ToList();
         }
 
         if (RubyValue.AsMapping(value) is not { } mapping)
@@ -340,18 +344,21 @@ public sealed class ComposeFile
             throw new ConfigException($"{path}: services.{name}.depends_on must be an array or a mapping");
         }
 
+        var result = new List<DependsOnEntry>();
         foreach (var (dependency, options) in mapping)
         {
-            var condition = RubyValue.Presence(RubyValue.Dig(options, "condition"));
-            if (condition is not null && !SupportedConditions.Contains(condition))
+            var condition = RubyValue.Presence(RubyValue.Dig(options, "condition")) ?? "service_started";
+            if (!SupportedConditions.Contains(condition))
             {
                 throw new ConfigException(
                     $"{path}: services.{name}.depends_on.{dependency}: condition '{condition}' is not " +
-                    $"supported (only {string.Join(", ", SupportedConditions)} — no health checks)");
+                    $"supported (only {string.Join(", ", SupportedConditions)})");
             }
+
+            result.Add(new DependsOnEntry(dependency, condition));
         }
 
-        return mapping.Keys.ToList();
+        return result;
     }
 
     /// <summary>
@@ -365,19 +372,29 @@ public sealed class ComposeFile
         {
             foreach (var dependency in service.DependsOn)
             {
-                if (!services.ContainsKey(dependency))
+                if (!services.ContainsKey(dependency.Name))
                 {
-                    throw new ConfigException($"{path}: services.{name} depends_on unknown service '{dependency}'");
+                    throw new ConfigException(
+                        $"{path}: services.{name} depends_on unknown service '{dependency.Name}'");
                 }
 
-                if (service.Profiles.Count > 0 || !IsProfiled(dependency))
+                // Mirrors real Compose: a condition it cannot satisfy is a config error at
+                // load time, not a hang or a silent no-op the first time `wip up` runs.
+                if (dependency.Condition == "service_healthy" && services[dependency.Name].HealthCheck is null)
+                {
+                    throw new ConfigException(
+                        $"{path}: services.{name} depends_on '{dependency.Name}' with condition: " +
+                        "service_healthy, but that service has no healthcheck: configured");
+                }
+
+                if (service.Profiles.Count > 0 || !IsProfiled(dependency.Name))
                 {
                     continue;
                 }
 
                 throw new ConfigException(
-                    $"{path}: services.{name} depends_on '{dependency}', gated behind profiles: " +
-                    $"({string.Join(", ", services[dependency].Profiles)}) wip never activates " +
+                    $"{path}: services.{name} depends_on '{dependency.Name}', gated behind profiles: " +
+                    $"({string.Join(", ", services[dependency.Name].Profiles)}) wip never activates " +
                     "(no --profile flag)");
             }
         }
@@ -410,7 +427,7 @@ public sealed class ComposeFile
 
         foreach (var dependency in services[name].DependsOn)
         {
-            Visit(dependency, visited, visiting, result);
+            Visit(dependency.Name, visited, visiting, result);
         }
 
         visiting.Remove(name);
@@ -467,5 +484,8 @@ public sealed class ComposeFile
         string? Workdir,
         string? User,
         string Restart,
-        List<string> DependsOn);
+        List<DependsOnEntry> DependsOn,
+        OrderedDictionary<string, object?>? HealthCheck);
+
+    private sealed record DependsOnEntry(string Name, string Condition);
 }

--- a/src/Wip.Core/Compose/ComposeFile.cs
+++ b/src/Wip.Core/Compose/ComposeFile.cs
@@ -25,10 +25,10 @@ public sealed class ComposeFile
     /// <summary>
     /// Real Compose keys that read as meaningful here but have nothing to map onto: TTY and
     /// stdin allocation is decided per invocation, not per service; every service already
-    /// shares one project network; and <c>wslc run</c>/<c>exec</c> has no capability flag to
-    /// forward <c>cap_add:</c> to.
+    /// shares one project network; <c>wslc run</c>/<c>exec</c> has no capability flag to
+    /// forward <c>cap_add:</c> to; and it has no flag to set per-container DNS servers either.
     /// </summary>
-    private static readonly string[] IgnoredServiceKeys = ["tty", "stdin_open", "networks", "cap_add"];
+    private static readonly string[] IgnoredServiceKeys = ["tty", "stdin_open", "networks", "cap_add", "dns"];
 
     // shadow_context is deliberately absent: the build context is now always staged to a
     // local cache, so the key has no effect and falls through to the unsupported-key error.

--- a/src/Wip.Core/Configuration/Config.cs
+++ b/src/Wip.Core/Configuration/Config.cs
@@ -14,7 +14,7 @@ public sealed partial class Config
     private static readonly (string Key, object? Value)[] DependencyDefaults =
     [
         ("workdir", null), ("user", null), ("interactive", false), ("remove", true),
-        ("env", null), ("ports", null), ("volumes", null), ("restart", "no"),
+        ("env", null), ("ports", null), ("volumes", null), ("restart", "no"), ("healthcheck", null),
     ];
 
     /// <summary>
@@ -417,6 +417,7 @@ public sealed partial class Config
 
         StringifyEnvironment(mapping);
         NormalizeRestart(mapping);
+        NormalizeHealthCheck($"dependencies.{name}.healthcheck", mapping);
     }
 
     /// <summary>
@@ -436,6 +437,22 @@ public sealed partial class Config
         {
             entry["restart"] = "no";
         }
+    }
+
+    /// <summary>
+    /// Mutates <paramref name="entry"/> in place, mirroring <see cref="NormalizeRestart"/>: a
+    /// missing key stays missing (<see cref="Dependency"/> fills in the null default), while a
+    /// present one is replaced by its normalized form so every later reader — <c>wip up</c>,
+    /// <c>wip config</c> — sees the same shape regardless of what was written.
+    /// </summary>
+    private static void NormalizeHealthCheck(string errorPrefix, OrderedDictionary<string, object?> entry)
+    {
+        if (!entry.ContainsKey("healthcheck"))
+        {
+            return;
+        }
+
+        entry["healthcheck"] = HealthCheck.Normalize(errorPrefix, entry["healthcheck"]);
     }
 
     private static void StringifyEnvironment(OrderedDictionary<string, object?> entry)

--- a/src/Wip.Core/Configuration/HealthCheck.cs
+++ b/src/Wip.Core/Configuration/HealthCheck.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text.RegularExpressions;
 using Wip.Yaml;
 
 namespace Wip.Configuration;
@@ -10,12 +11,13 @@ namespace Wip.Configuration;
 /// a dependency's readiness wait behaves identically regardless of which mode produced it.
 /// </summary>
 /// <remarks>
-/// Real Compose accepts duration strings ("10s", "1m30s") for interval/timeout/start_period.
-/// wip.yml's own numeric config fields (<c>sync.interval</c>, this one included) are plain
-/// seconds instead — a compose.yml healthcheck already written with duration strings needs
-/// those fields rewritten as numbers to be understood here.
+/// <c>interval</c>/<c>timeout</c>/<c>start_period</c> accept either a plain number of seconds
+/// (wip.yml's own convention, matching <c>sync.interval</c>) or a real Compose duration string
+/// ("10s", "1m30s") — compose.yml healthchecks are near-universally written the latter way, so
+/// mode: compose-native has to read them as they actually appear. <c>retries</c> stays a plain
+/// count either way: Compose never accepts a duration there.
 /// </remarks>
-public static class HealthCheck
+public static partial class HealthCheck
 {
     public const double DefaultInterval = 1;
     public const double DefaultTimeout = 1;
@@ -23,6 +25,10 @@ public static class HealthCheck
     public const double DefaultStartPeriod = 0;
 
     private static readonly string[] Keys = ["test", "interval", "timeout", "retries", "start_period"];
+
+    /// <summary>Matches one "&lt;number&gt;&lt;unit&gt;" segment of a Compose duration string.</summary>
+    [GeneratedRegex(@"(\d+(?:\.\d+)?)(h|ms|us|m|s)")]
+    private static partial Regex DurationSegment();
 
     /// <summary>
     /// Null input, and a <c>test: NONE</c> (or <c>test: ["NONE"]</c>) disabling one, both mean
@@ -50,11 +56,11 @@ public static class HealthCheck
 
         var result = RubyValue.NewMapping();
         result["test"] = test.Cast<object?>().ToList();
-        result["interval"] = PositiveNumber(errorPrefix, "interval", mapping.GetValueOrDefault("interval"), DefaultInterval);
-        result["timeout"] = PositiveNumber(errorPrefix, "timeout", mapping.GetValueOrDefault("timeout"), DefaultTimeout);
-        result["retries"] = (long)PositiveNumber(errorPrefix, "retries", mapping.GetValueOrDefault("retries"), DefaultRetries);
+        result["interval"] = PositiveSeconds(errorPrefix, "interval", mapping.GetValueOrDefault("interval"), DefaultInterval);
+        result["timeout"] = PositiveSeconds(errorPrefix, "timeout", mapping.GetValueOrDefault("timeout"), DefaultTimeout);
+        result["retries"] = PositiveCount(errorPrefix, "retries", mapping.GetValueOrDefault("retries"), DefaultRetries);
         result["start_period"] =
-            NonNegativeNumber(errorPrefix, "start_period", mapping.GetValueOrDefault("start_period"), DefaultStartPeriod);
+            NonNegativeSeconds(errorPrefix, "start_period", mapping.GetValueOrDefault("start_period"), DefaultStartPeriod);
         return result;
     }
 
@@ -87,9 +93,9 @@ public static class HealthCheck
         };
     }
 
-    private static double PositiveNumber(string errorPrefix, string key, object? value, double defaultValue)
+    private static double PositiveSeconds(string errorPrefix, string key, object? value, double defaultValue)
     {
-        var seconds = ToDouble(errorPrefix, key, value, defaultValue);
+        var seconds = ToSeconds(errorPrefix, key, value, defaultValue);
         if (seconds <= 0)
         {
             throw new ConfigException($"{errorPrefix}.{key} must be a positive number");
@@ -98,9 +104,9 @@ public static class HealthCheck
         return seconds;
     }
 
-    private static double NonNegativeNumber(string errorPrefix, string key, object? value, double defaultValue)
+    private static double NonNegativeSeconds(string errorPrefix, string key, object? value, double defaultValue)
     {
-        var seconds = ToDouble(errorPrefix, key, value, defaultValue);
+        var seconds = ToSeconds(errorPrefix, key, value, defaultValue);
         if (seconds < 0)
         {
             throw new ConfigException($"{errorPrefix}.{key} must not be negative");
@@ -109,10 +115,67 @@ public static class HealthCheck
         return seconds;
     }
 
-    private static double ToDouble(string errorPrefix, string key, object? value, double defaultValue) => value switch
+    private static double ToSeconds(string errorPrefix, string key, object? value, double defaultValue) => value switch
     {
         null => defaultValue,
         long or int or double => Convert.ToDouble(value, CultureInfo.InvariantCulture),
-        _ => throw new ConfigException($"{errorPrefix}.{key} must be a number of seconds"),
+        string text => ParseDuration(errorPrefix, key, text),
+        _ => throw new ConfigException($"{errorPrefix}.{key} must be a number of seconds or a duration string"),
     };
+
+    /// <summary>
+    /// A whole count of consecutive failures, never a duration: Compose itself never accepts
+    /// one for <c>retries</c>, so "10s" here is a mistake to reject, not 10 seconds to guess at.
+    /// </summary>
+    private static long PositiveCount(string errorPrefix, string key, object? value, long defaultValue)
+    {
+        var count = value switch
+        {
+            null => defaultValue,
+            long number => number,
+            int number => number,
+            double number => (long)number,
+            _ => throw new ConfigException($"{errorPrefix}.{key} must be a whole number"),
+        };
+
+        if (count <= 0)
+        {
+            throw new ConfigException($"{errorPrefix}.{key} must be a positive number");
+        }
+
+        return count;
+    }
+
+    /// <summary>
+    /// Compose's own duration syntax: one or more "&lt;number&gt;&lt;unit&gt;" segments —
+    /// h/m/s/ms/us — concatenated with no separator (<c>1h30m</c>, <c>1m30s</c>). Rejects
+    /// anything the segments don't fully account for, so a typo fails loudly instead of
+    /// silently parsing a prefix and ignoring the rest.
+    /// </summary>
+    private static double ParseDuration(string errorPrefix, string key, string text)
+    {
+        var matches = DurationSegment().Matches(text);
+        if (matches.Count == 0 || matches.Sum(match => match.Length) != text.Length)
+        {
+            throw new ConfigException(
+                $"{errorPrefix}.{key} must be a number of seconds or a duration string (e.g. \"10s\", \"1m30s\")");
+        }
+
+        double seconds = 0;
+        foreach (Match match in matches)
+        {
+            var amount = double.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
+            seconds += match.Groups[2].Value switch
+            {
+                "h" => amount * 3600,
+                "m" => amount * 60,
+                "s" => amount,
+                "ms" => amount / 1_000,
+                "us" => amount / 1_000_000,
+                _ => 0,
+            };
+        }
+
+        return seconds;
+    }
 }

--- a/src/Wip.Core/Configuration/HealthCheck.cs
+++ b/src/Wip.Core/Configuration/HealthCheck.cs
@@ -1,0 +1,118 @@
+using System.Globalization;
+using Wip.Yaml;
+
+namespace Wip.Configuration;
+
+/// <summary>
+/// Parses a <c>healthcheck:</c> block — <c>dependencies.&lt;name&gt;.healthcheck:</c> under
+/// <c>mode: container</c>, or a compose.yml service's own <c>healthcheck:</c> under
+/// <c>mode: compose-native</c> — into the shape <c>wip up</c> polls against. Shared by both so
+/// a dependency's readiness wait behaves identically regardless of which mode produced it.
+/// </summary>
+/// <remarks>
+/// Real Compose accepts duration strings ("10s", "1m30s") for interval/timeout/start_period.
+/// wip.yml's own numeric config fields (<c>sync.interval</c>, this one included) are plain
+/// seconds instead — a compose.yml healthcheck already written with duration strings needs
+/// those fields rewritten as numbers to be understood here.
+/// </remarks>
+public static class HealthCheck
+{
+    public const double DefaultInterval = 1;
+    public const double DefaultTimeout = 1;
+    public const long DefaultRetries = 3;
+    public const double DefaultStartPeriod = 0;
+
+    private static readonly string[] Keys = ["test", "interval", "timeout", "retries", "start_period"];
+
+    /// <summary>
+    /// Null input, and a <c>test: NONE</c> (or <c>test: ["NONE"]</c>) disabling one, both mean
+    /// "no healthcheck" — the same as the key being absent entirely.
+    /// </summary>
+    public static OrderedDictionary<string, object?>? Normalize(string errorPrefix, object? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        var mapping = RubyValue.AsMapping(value) ?? throw new ConfigException($"{errorPrefix} must be a mapping");
+        var unknown = mapping.Keys.Where(key => !Keys.Contains(key)).ToList();
+        if (unknown.Count > 0)
+        {
+            throw new ConfigException($"{errorPrefix} has unsupported key(s): {string.Join(", ", unknown)}");
+        }
+
+        var test = NormalizeTest(errorPrefix, mapping.GetValueOrDefault("test"));
+        if (test is null)
+        {
+            return null;
+        }
+
+        var result = RubyValue.NewMapping();
+        result["test"] = test.Cast<object?>().ToList();
+        result["interval"] = PositiveNumber(errorPrefix, "interval", mapping.GetValueOrDefault("interval"), DefaultInterval);
+        result["timeout"] = PositiveNumber(errorPrefix, "timeout", mapping.GetValueOrDefault("timeout"), DefaultTimeout);
+        result["retries"] = (long)PositiveNumber(errorPrefix, "retries", mapping.GetValueOrDefault("retries"), DefaultRetries);
+        result["start_period"] =
+            NonNegativeNumber(errorPrefix, "start_period", mapping.GetValueOrDefault("start_period"), DefaultStartPeriod);
+        return result;
+    }
+
+    /// <summary>
+    /// Mirrors real Compose's three test shapes: a bare string is shell form, an array leads
+    /// with <c>CMD</c> (exec form, run exactly as written) or <c>CMD-SHELL</c> (shell form),
+    /// and <c>NONE</c> — spelled either way — disables the healthcheck.
+    /// </summary>
+    private static List<string>? NormalizeTest(string errorPrefix, object? value)
+    {
+        if (value is string text)
+        {
+            return text == "NONE" ? null : ["sh", "-c", text];
+        }
+
+        if (RubyValue.AsSequence(value) is not { } sequence || sequence.Count == 0)
+        {
+            throw new ConfigException($"{errorPrefix}.test must be a string or a non-empty array");
+        }
+
+        var items = sequence.Select(RubyValue.ToStringValue).ToList();
+        return items[0] switch
+        {
+            "NONE" => null,
+            "CMD" when items.Count > 1 => items[1..],
+            "CMD" => throw new ConfigException($"{errorPrefix}.test: CMD needs at least one argument"),
+            "CMD-SHELL" when items.Count == 2 => ["sh", "-c", items[1]],
+            "CMD-SHELL" => throw new ConfigException($"{errorPrefix}.test: CMD-SHELL takes exactly one command"),
+            _ => throw new ConfigException($"{errorPrefix}.test array must start with CMD, CMD-SHELL, or NONE"),
+        };
+    }
+
+    private static double PositiveNumber(string errorPrefix, string key, object? value, double defaultValue)
+    {
+        var seconds = ToDouble(errorPrefix, key, value, defaultValue);
+        if (seconds <= 0)
+        {
+            throw new ConfigException($"{errorPrefix}.{key} must be a positive number");
+        }
+
+        return seconds;
+    }
+
+    private static double NonNegativeNumber(string errorPrefix, string key, object? value, double defaultValue)
+    {
+        var seconds = ToDouble(errorPrefix, key, value, defaultValue);
+        if (seconds < 0)
+        {
+            throw new ConfigException($"{errorPrefix}.{key} must not be negative");
+        }
+
+        return seconds;
+    }
+
+    private static double ToDouble(string errorPrefix, string key, object? value, double defaultValue) => value switch
+    {
+        null => defaultValue,
+        long or int or double => Convert.ToDouble(value, CultureInfo.InvariantCulture),
+        _ => throw new ConfigException($"{errorPrefix}.{key} must be a number of seconds"),
+    };
+}

--- a/src/Wip.Core/Execution/CommandBuilder.cs
+++ b/src/Wip.Core/Execution/CommandBuilder.cs
@@ -218,6 +218,18 @@ public sealed class CommandBuilder
 
     public IReadOnlyList<string> DependencyStart(string name) => [wslc, "start", name];
 
+    /// <summary>
+    /// Runs a healthcheck's <c>test</c> inside a sidecar. Unlike <see cref="Exec"/>, this
+    /// targets <paramref name="name"/> directly rather than <c>config.Container</c>, since a
+    /// readiness check runs against whichever dependency it belongs to, not the primary.
+    /// </summary>
+    public IReadOnlyList<string> DependencyExec(string name, IEnumerable<string> arguments)
+    {
+        var command = new List<string> { wslc, "exec", name };
+        command.AddRange(arguments);
+        return command;
+    }
+
     public IReadOnlyList<string> DependencyFind(string name) => Listing(name);
 
     public IReadOnlyList<string> DependencyStop(string name) => [wslc, "stop", name];

--- a/src/Wip.Core/Execution/CommandRunner.cs
+++ b/src/Wip.Core/Execution/CommandRunner.cs
@@ -29,6 +29,9 @@ public sealed class CommandRunner
     // already being streamed to the user's terminal.
     private const int MaxCapturedCharacters = 1024 * 1024;
 
+    /// <summary>Reported for a command killed by <c>timeout</c> — coreutils' own convention.</summary>
+    public const int TimeoutExitCode = 124;
+
     private readonly TextWriter output;
     private readonly TextWriter error;
     private readonly ErrorInterpreter interpreter;
@@ -46,11 +49,18 @@ public sealed class CommandRunner
         this.debug = debug;
     }
 
+    /// <summary>
+    /// <paramref name="timeout"/> only applies to the captured (non-interactive) path: a
+    /// command that runs past it is killed and reported as <see cref="TimeoutExitCode"/>,
+    /// with whatever it had already written still captured for a hint. Used by readiness
+    /// checks, which poll on a schedule and must never let one slow probe hang <c>wip up</c>.
+    /// </summary>
     public int Run(
         IReadOnlyList<string> command,
         IReadOnlyDictionary<string, string>? environment = null,
         bool interactive = false,
-        string? workingDirectory = null)
+        string? workingDirectory = null,
+        TimeSpan? timeout = null)
     {
         if (debug)
         {
@@ -73,10 +83,10 @@ public sealed class CommandRunner
             startInfo.WorkingDirectory = workingDirectory;
         }
 
-        return interactive ? RunInherited(startInfo) : RunCaptured(startInfo);
+        return interactive ? RunInherited(startInfo) : RunCaptured(startInfo, timeout);
     }
 
-    private int RunCaptured(ProcessStartInfo startInfo)
+    private int RunCaptured(ProcessStartInfo startInfo, TimeSpan? timeout)
     {
         startInfo.RedirectStandardOutput = true;
         startInfo.RedirectStandardError = true;
@@ -100,20 +110,42 @@ public sealed class CommandRunner
                 Pump(process.StandardError, error, captured),
             };
 
+            var exited = timeout is null || process.WaitForExit((int)timeout.Value.TotalMilliseconds);
+            if (!exited)
+            {
+                KillTree(process);
+            }
+
             Task.WaitAll(pumps);
             process.WaitForExit();
 
-            if (process.ExitCode != 0)
+            var code = exited ? process.ExitCode : TimeoutExitCode;
+            if (code != 0)
             {
                 ReportHint(captured.ToString());
             }
 
-            return process.ExitCode;
+            return code;
         }
         catch (System.ComponentModel.Win32Exception exception)
         {
             error.WriteLine(exception.Message);
             return 127;
+        }
+    }
+
+    /// <summary>
+    /// Best-effort: the process may have exited on its own between the timeout check and
+    /// here, in which case <see cref="Process.Kill(bool)"/> throwing is not a real failure.
+    /// </summary>
+    private static void KillTree(Process process)
+    {
+        try
+        {
+            process.Kill(entireProcessTree: true);
+        }
+        catch (InvalidOperationException)
+        {
         }
     }
 

--- a/tests/Wip.Tests/CommandBuilderHealthCheckTests.cs
+++ b/tests/Wip.Tests/CommandBuilderHealthCheckTests.cs
@@ -1,0 +1,44 @@
+using Wip.Configuration;
+using Wip.Execution;
+using Wip.Platform;
+using Wip.Yaml;
+
+namespace Wip.Tests;
+
+/// <summary>
+/// Covers <see cref="CommandBuilder.DependencyExec"/>, added so a readiness check can run its
+/// <c>test</c> inside a sidecar directly rather than through <see cref="CommandBuilder.Exec"/>,
+/// which always targets the primary container.
+/// </summary>
+public class CommandBuilderHealthCheckTests
+{
+    [Fact]
+    public void TargetsTheNamedDependencyRatherThanThePrimaryContainer()
+    {
+        var config = new Config(YamlLoader.LoadText("""
+            version: 1
+            mode: container
+            container: app
+            dependencies:
+              app:
+                image: example
+              db:
+                image: mysql:8.0
+            """, allowAliases: false));
+
+        var builder = new CommandBuilder("wslc.exe", config, new FakeEnvironment());
+
+        Assert.Equal(
+            new[] { "wslc.exe", "exec", "db", "mysqladmin", "ping" },
+            builder.DependencyExec("db", ["mysqladmin", "ping"]));
+    }
+
+    private sealed class FakeEnvironment : IEnvironment
+    {
+        public bool IsInteractive => false;
+
+        public bool IsWsl2 => true;
+
+        public string Architecture => "linux/amd64";
+    }
+}

--- a/tests/Wip.Tests/ComposeFileHealthCheckTests.cs
+++ b/tests/Wip.Tests/ComposeFileHealthCheckTests.cs
@@ -1,0 +1,149 @@
+using Wip.Compose;
+using Wip.Yaml;
+
+namespace Wip.Tests;
+
+/// <summary>
+/// Covers <c>healthcheck:</c> parsing and <c>depends_on: condition: service_healthy</c> on a
+/// real compose.yml, both new to <see cref="ComposeFile"/> alongside the readiness-check
+/// feature. <see cref="HealthCheckTests"/> already covers the shared normalizer in isolation.
+/// </summary>
+public class ComposeFileHealthCheckTests
+{
+    [Fact]
+    public void HealthCheckFlowsIntoTheDependenciesMapping()
+    {
+        using var directory = new TemporaryDirectory();
+        var path = WriteCompose(directory.Path, """
+            services:
+              db:
+                image: mysql:8.0
+                healthcheck:
+                  test: ["CMD", "mysqladmin", "ping"]
+                  interval: 2
+                  retries: 5
+            """);
+
+        var compose = ComposeFile.Load(path);
+        var db = (OrderedDictionary<string, object?>)compose.ToDependenciesMapping()["db"]!;
+        var healthcheck = (OrderedDictionary<string, object?>)db["healthcheck"]!;
+
+        Assert.Equal(["mysqladmin", "ping"], ((List<object?>)healthcheck["test"]!).Cast<string>());
+        Assert.Equal(2.0, healthcheck["interval"]);
+        Assert.Equal(5L, healthcheck["retries"]);
+    }
+
+    [Fact]
+    public void ServiceWithNoHealthCheckHasANullEntry()
+    {
+        using var directory = new TemporaryDirectory();
+        var path = WriteCompose(directory.Path, """
+            services:
+              app:
+                image: myapp:dev
+            """);
+
+        var compose = ComposeFile.Load(path);
+        var app = (OrderedDictionary<string, object?>)compose.ToDependenciesMapping()["app"]!;
+
+        Assert.Null(app["healthcheck"]);
+    }
+
+    [Fact]
+    public void ServiceHealthyConditionIsAcceptedWhenTheDependencyHasAHealthCheck()
+    {
+        using var directory = new TemporaryDirectory();
+        var path = WriteCompose(directory.Path, """
+            services:
+              db:
+                image: mysql:8.0
+                healthcheck:
+                  test: ["CMD", "mysqladmin", "ping"]
+              web:
+                image: myapp:dev
+                depends_on:
+                  db:
+                    condition: service_healthy
+            """);
+
+        var compose = ComposeFile.Load(path);
+
+        Assert.Equal(["db", "web"], compose.ServiceNamesInDependencyOrder);
+    }
+
+    [Fact]
+    public void ServiceHealthyConditionIsRejectedWithoutAHealthCheck()
+    {
+        using var directory = new TemporaryDirectory();
+        var path = WriteCompose(directory.Path, """
+            services:
+              db:
+                image: mysql:8.0
+              web:
+                image: myapp:dev
+                depends_on:
+                  db:
+                    condition: service_healthy
+            """);
+
+        var exception = Assert.Throws<ConfigException>(() => ComposeFile.Load(path));
+
+        Assert.Contains("service_healthy", exception.Message);
+        Assert.Contains("no healthcheck", exception.Message);
+    }
+
+    [Fact]
+    public void UnsupportedConditionIsStillRejected()
+    {
+        using var directory = new TemporaryDirectory();
+        var path = WriteCompose(directory.Path, """
+            services:
+              db:
+                image: mysql:8.0
+              web:
+                image: myapp:dev
+                depends_on:
+                  db:
+                    condition: service_completed_successfully
+            """);
+
+        var exception = Assert.Throws<ConfigException>(() => ComposeFile.Load(path));
+
+        Assert.Contains("condition 'service_completed_successfully' is not supported", exception.Message);
+    }
+
+    [Fact]
+    public void ArrayFormDependsOnDefaultsToServiceStarted()
+    {
+        using var directory = new TemporaryDirectory();
+        var path = WriteCompose(directory.Path, """
+            services:
+              db:
+                image: mysql:8.0
+              web:
+                image: myapp:dev
+                depends_on:
+                  - db
+            """);
+
+        var compose = ComposeFile.Load(path);
+
+        Assert.Equal(["db", "web"], compose.ServiceNamesInDependencyOrder);
+    }
+
+    private static string WriteCompose(string directory, string contents)
+    {
+        var path = Path.Combine(directory, "compose.yml");
+        File.WriteAllText(path, contents);
+        return path;
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        internal TemporaryDirectory() => Path = Directory.CreateTempSubdirectory("wip-test-").FullName;
+
+        internal string Path { get; }
+
+        public void Dispose() => Directory.Delete(Path, recursive: true);
+    }
+}

--- a/tests/Wip.Tests/ComposeFileHealthCheckTests.cs
+++ b/tests/Wip.Tests/ComposeFileHealthCheckTests.cs
@@ -34,6 +34,30 @@ public class ComposeFileHealthCheckTests
     }
 
     [Fact]
+    public void HealthCheckWithComposeDurationStringsLoads()
+    {
+        using var directory = new TemporaryDirectory();
+        var path = WriteCompose(directory.Path, """
+            services:
+              db:
+                image: mysql:8.0
+                healthcheck:
+                  test: ["CMD", "mysqladmin", "ping"]
+                  interval: 1m30s
+                  timeout: 10s
+                  start_period: 40s
+            """);
+
+        var compose = ComposeFile.Load(path);
+        var db = (OrderedDictionary<string, object?>)compose.ToDependenciesMapping()["db"]!;
+        var healthcheck = (OrderedDictionary<string, object?>)db["healthcheck"]!;
+
+        Assert.Equal(90.0, healthcheck["interval"]);
+        Assert.Equal(10.0, healthcheck["timeout"]);
+        Assert.Equal(40.0, healthcheck["start_period"]);
+    }
+
+    [Fact]
     public void ServiceWithNoHealthCheckHasANullEntry()
     {
         using var directory = new TemporaryDirectory();

--- a/tests/Wip.Tests/ComposeFileIgnoredKeysTests.cs
+++ b/tests/Wip.Tests/ComposeFileIgnoredKeysTests.cs
@@ -1,0 +1,40 @@
+using Wip.Compose;
+using Wip.Yaml;
+
+namespace Wip.Tests;
+
+/// <summary>
+/// Covers <c>dns:</c> — accepted and ignored like <c>cap_add</c>/<c>networks</c>/<c>tty</c>,
+/// since <c>wslc run</c>/<c>exec</c> has no flag to set per-container DNS servers.
+/// </summary>
+public class ComposeFileIgnoredKeysTests
+{
+    [Fact]
+    public void DnsIsAcceptedAndIgnored()
+    {
+        using var directory = new TemporaryDirectory();
+        var path = Path.Combine(directory.Path, "compose.yml");
+        File.WriteAllText(path, """
+            services:
+              app:
+                image: myapp:dev
+                dns:
+                  - 8.8.8.8
+                  - 1.1.1.1
+            """);
+
+        var compose = ComposeFile.Load(path);
+        var app = (OrderedDictionary<string, object?>)compose.ToDependenciesMapping()["app"]!;
+
+        Assert.False(app.ContainsKey("dns"));
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        internal TemporaryDirectory() => Path = Directory.CreateTempSubdirectory("wip-test-").FullName;
+
+        internal string Path { get; }
+
+        public void Dispose() => Directory.Delete(Path, recursive: true);
+    }
+}

--- a/tests/Wip.Tests/ConfigHealthCheckTests.cs
+++ b/tests/Wip.Tests/ConfigHealthCheckTests.cs
@@ -1,0 +1,94 @@
+using Wip.Configuration;
+using Wip.Yaml;
+
+namespace Wip.Tests;
+
+/// <summary>
+/// Covers <c>dependencies.&lt;name&gt;.healthcheck:</c> under <c>mode: container</c>, where
+/// <see cref="Config"/> normalizes it eagerly at load time via <see cref="HealthCheck"/> —
+/// the same normalizer compose-native's own healthcheck: goes through (see
+/// <see cref="ComposeFileHealthCheckTests"/>).
+/// </summary>
+public class ConfigHealthCheckTests
+{
+    [Fact]
+    public void NormalizedHealthCheckIsReachableFromDependency()
+    {
+        var config = LoadConfig("""
+            version: 1
+            mode: container
+            container: app
+            dependencies:
+              app:
+                image: example
+              db:
+                image: mysql:8.0
+                healthcheck:
+                  test: ["CMD", "mysqladmin", "ping"]
+                  interval: 2
+                  retries: 5
+            """);
+
+        var healthcheck = (OrderedDictionary<string, object?>)config.Dependency("db")!["healthcheck"]!;
+
+        Assert.Equal(["mysqladmin", "ping"], ((List<object?>)healthcheck["test"]!).Cast<string>());
+        Assert.Equal(2.0, healthcheck["interval"]);
+        Assert.Equal(5L, healthcheck["retries"]);
+    }
+
+    [Fact]
+    public void DependencyWithNoHealthCheckDefaultsToNull()
+    {
+        var config = LoadConfig("""
+            version: 1
+            mode: container
+            container: app
+            dependencies:
+              app:
+                image: example
+            """);
+
+        Assert.Null(config.Dependency("app")!["healthcheck"]);
+    }
+
+    [Fact]
+    public void InvalidHealthCheckFailsAtConfigLoadTime()
+    {
+        var exception = Assert.Throws<ConfigException>(() => LoadConfig("""
+            version: 1
+            mode: container
+            container: app
+            dependencies:
+              app:
+                image: example
+              db:
+                image: mysql:8.0
+                healthcheck:
+                  interval: 2
+            """));
+
+        Assert.Contains("dependencies.db.healthcheck.test", exception.Message);
+    }
+
+    [Fact]
+    public void NoneTestDisablesTheHealthCheck()
+    {
+        var config = LoadConfig("""
+            version: 1
+            mode: container
+            container: app
+            dependencies:
+              app:
+                image: example
+              db:
+                image: mysql:8.0
+                healthcheck:
+                  test: NONE
+            """);
+
+        Assert.Null(config.Dependency("db")!["healthcheck"]);
+    }
+
+    private static Config LoadConfig(string yaml) =>
+        new(YamlLoader.LoadText(yaml, allowAliases: false));
+}

--- a/tests/Wip.Tests/HealthCheckFailureMessageTests.cs
+++ b/tests/Wip.Tests/HealthCheckFailureMessageTests.cs
@@ -1,0 +1,38 @@
+using Wip.Cli;
+using Wip.Execution;
+
+namespace Wip.Tests;
+
+/// <summary>
+/// Covers the pure formatting <see cref="CliContext.WaitForHealthy"/> falls back on once a
+/// dependency's healthcheck exhausts its retries — the message a user actually sees when
+/// <c>wip up</c> gives up, per issue #118's "fail with a clear error" requirement.
+/// </summary>
+public class HealthCheckFailureMessageTests
+{
+    [Fact]
+    public void ReportsANonZeroExitCode()
+    {
+        var message = CliContext.HealthCheckFailureMessage("db", failures: 4, code: 1, output: "mysqladmin: connect failed\n");
+
+        Assert.Equal("dependency 'db' did not become healthy after 4 attempt(s) (last check exited 1): mysqladmin: connect failed", message);
+    }
+
+    [Fact]
+    public void ReportsATimeout()
+    {
+        var message = CliContext.HealthCheckFailureMessage("db", failures: 3, code: CommandRunner.TimeoutExitCode, output: "");
+
+        Assert.Equal("dependency 'db' did not become healthy after 3 attempt(s) (last check timed out)", message);
+    }
+
+    [Fact]
+    public void LastLineIgnoresTrailingBlankLines()
+    {
+        Assert.Equal("connect failed", CliContext.LastLine("connecting...\nconnect failed\n\n"));
+    }
+
+    [Fact]
+    public void LastLineIsNullForEmptyOutput() =>
+        Assert.Null(CliContext.LastLine(""));
+}

--- a/tests/Wip.Tests/HealthCheckTests.cs
+++ b/tests/Wip.Tests/HealthCheckTests.cs
@@ -1,0 +1,169 @@
+using Wip.Configuration;
+using Wip.Yaml;
+
+namespace Wip.Tests;
+
+/// <summary>
+/// Covers <see cref="HealthCheck.Normalize"/> directly — the parsing and validation shared by
+/// <c>dependencies.&lt;name&gt;.healthcheck:</c> (mode: container) and a compose.yml service's
+/// own <c>healthcheck:</c> (mode: compose-native).
+/// </summary>
+public class HealthCheckTests
+{
+    [Fact]
+    public void NullIsNoHealthCheck() =>
+        Assert.Null(HealthCheck.Normalize("dependencies.db.healthcheck", null));
+
+    [Fact]
+    public void StringTestIsShellForm()
+    {
+        var result = HealthCheck.Normalize("dependencies.db.healthcheck", Load("""
+            test: mysqladmin ping -h localhost
+            """));
+
+        Assert.Equal(["sh", "-c", "mysqladmin ping -h localhost"], Argv(result));
+    }
+
+    [Fact]
+    public void CmdArrayIsUsedAsIs()
+    {
+        var result = HealthCheck.Normalize("dependencies.db.healthcheck", Load("""
+            test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+            """));
+
+        Assert.Equal(["mysqladmin", "ping", "-h", "localhost"], Argv(result));
+    }
+
+    [Fact]
+    public void CmdShellArrayBecomesAShellInvocation()
+    {
+        var result = HealthCheck.Normalize("dependencies.db.healthcheck", Load("""
+            test: ["CMD-SHELL", "mysqladmin ping || exit 1"]
+            """));
+
+        Assert.Equal(["sh", "-c", "mysqladmin ping || exit 1"], Argv(result));
+    }
+
+    [Theory]
+    [InlineData("test: NONE")]
+    [InlineData("""test: ["NONE"]""")]
+    public void NoneDisablesTheHealthCheck(string yaml) =>
+        Assert.Null(HealthCheck.Normalize("dependencies.db.healthcheck", Load(yaml)));
+
+    [Fact]
+    public void DefaultsAreApplied()
+    {
+        var result = HealthCheck.Normalize("dependencies.db.healthcheck", Load("""
+            test: ["CMD", "true"]
+            """));
+
+        Assert.Equal(HealthCheck.DefaultInterval, result!["interval"]);
+        Assert.Equal(HealthCheck.DefaultTimeout, result["timeout"]);
+        Assert.Equal(HealthCheck.DefaultRetries, result["retries"]);
+        Assert.Equal(HealthCheck.DefaultStartPeriod, result["start_period"]);
+    }
+
+    [Fact]
+    public void ExplicitTimingOverridesDefaults()
+    {
+        var result = HealthCheck.Normalize("dependencies.db.healthcheck", Load("""
+            test: ["CMD", "true"]
+            interval: 2
+            timeout: 5
+            retries: 10
+            start_period: 30
+            """));
+
+        Assert.Equal(2.0, result!["interval"]);
+        Assert.Equal(5.0, result["timeout"]);
+        Assert.Equal(10L, result["retries"]);
+        Assert.Equal(30.0, result["start_period"]);
+    }
+
+    [Fact]
+    public void MissingTestIsRejected()
+    {
+        var exception = Assert.Throws<ConfigException>(() =>
+            HealthCheck.Normalize("dependencies.db.healthcheck", Load("interval: 2")));
+
+        Assert.Contains("test", exception.Message);
+    }
+
+    [Fact]
+    public void UnsupportedKeyIsRejected()
+    {
+        var exception = Assert.Throws<ConfigException>(() => HealthCheck.Normalize("dependencies.db.healthcheck", Load("""
+            test: ["CMD", "true"]
+            disable: true
+            """)));
+
+        Assert.Contains("disable", exception.Message);
+    }
+
+    [Fact]
+    public void CmdWithNoArgumentsIsRejected()
+    {
+        var exception = Assert.Throws<ConfigException>(() =>
+            HealthCheck.Normalize("dependencies.db.healthcheck", Load("""test: ["CMD"]""")));
+
+        Assert.Contains("CMD needs at least one argument", exception.Message);
+    }
+
+    [Fact]
+    public void CmdShellWithExtraArgumentsIsRejected()
+    {
+        var exception = Assert.Throws<ConfigException>(() => HealthCheck.Normalize(
+            "dependencies.db.healthcheck", Load("""test: ["CMD-SHELL", "one", "two"]""")));
+
+        Assert.Contains("CMD-SHELL takes exactly one command", exception.Message);
+    }
+
+    [Fact]
+    public void UnknownArrayLeaderIsRejected()
+    {
+        var exception = Assert.Throws<ConfigException>(() =>
+            HealthCheck.Normalize("dependencies.db.healthcheck", Load("""test: ["EXEC", "true"]""")));
+
+        Assert.Contains("must start with CMD, CMD-SHELL, or NONE", exception.Message);
+    }
+
+    [Theory]
+    [InlineData("interval: 0")]
+    [InlineData("interval: -1")]
+    public void NonPositiveIntervalIsRejected(string yaml)
+    {
+        var exception = Assert.Throws<ConfigException>(() => HealthCheck.Normalize(
+            "dependencies.db.healthcheck", Load($"test: [\"CMD\", \"true\"]\n{yaml}")));
+
+        Assert.Contains("interval must be a positive number", exception.Message);
+    }
+
+    [Fact]
+    public void NegativeStartPeriodIsRejected()
+    {
+        var exception = Assert.Throws<ConfigException>(() => HealthCheck.Normalize(
+            "dependencies.db.healthcheck", Load("""
+            test: ["CMD", "true"]
+            start_period: -1
+            """)));
+
+        Assert.Contains("start_period must not be negative", exception.Message);
+    }
+
+    [Fact]
+    public void NonNumericIntervalIsRejected()
+    {
+        var exception = Assert.Throws<ConfigException>(() => HealthCheck.Normalize(
+            "dependencies.db.healthcheck", Load("""
+            test: ["CMD", "true"]
+            interval: "10s"
+            """)));
+
+        Assert.Contains("interval must be a number of seconds", exception.Message);
+    }
+
+    private static object? Load(string yaml) => YamlLoader.LoadText(yaml, allowAliases: false);
+
+    private static List<string> Argv(OrderedDictionary<string, object?>? result) =>
+        ((List<object?>)result!["test"]!).Select(item => (string)item!).ToList();
+}

--- a/tests/Wip.Tests/HealthCheckTests.cs
+++ b/tests/Wip.Tests/HealthCheckTests.cs
@@ -150,16 +150,44 @@ public class HealthCheckTests
         Assert.Contains("start_period must not be negative", exception.Message);
     }
 
+    [Theory]
+    [InlineData("10s", 10.0)]
+    [InlineData("1m30s", 90.0)]
+    [InlineData("1h", 3600.0)]
+    [InlineData("1h5m30s", 3930.0)]
+    [InlineData("500ms", 0.5)]
+    public void ComposeDurationStringsAreParsedAsSeconds(string duration, double seconds)
+    {
+        var result = HealthCheck.Normalize("dependencies.db.healthcheck", Load($"""
+            test: ["CMD", "true"]
+            interval: "{duration}"
+            """));
+
+        Assert.Equal(seconds, result!["interval"]);
+    }
+
     [Fact]
-    public void NonNumericIntervalIsRejected()
+    public void UnparseableIntervalIsRejected()
     {
         var exception = Assert.Throws<ConfigException>(() => HealthCheck.Normalize(
             "dependencies.db.healthcheck", Load("""
             test: ["CMD", "true"]
-            interval: "10s"
+            interval: "10 seconds"
             """)));
 
-        Assert.Contains("interval must be a number of seconds", exception.Message);
+        Assert.Contains("interval must be a number of seconds or a duration string", exception.Message);
+    }
+
+    [Fact]
+    public void RetriesRejectsADurationString()
+    {
+        var exception = Assert.Throws<ConfigException>(() => HealthCheck.Normalize(
+            "dependencies.db.healthcheck", Load("""
+            test: ["CMD", "true"]
+            retries: "10s"
+            """)));
+
+        Assert.Contains("retries must be a whole number", exception.Message);
     }
 
     private static object? Load(string yaml) => YamlLoader.LoadText(yaml, allowAliases: false);

--- a/tests/golden/cases/001-container-basic/cases.json
+++ b/tests/golden/cases/001-container-basic/cases.json
@@ -67,6 +67,7 @@
             "bundle:/usr/local/bundle"
           ],
           "restart": "no",
+          "healthcheck": null,
           "image": "slidict/slidict:development",
           "command": "bin/rails",
           "type": "exec"
@@ -90,6 +91,7 @@
             "bundle:/usr/local/bundle"
           ],
           "restart": "no",
+          "healthcheck": null,
           "image": "slidict/slidict:development",
           "command": "bundle exec rspec",
           "type": "exec"
@@ -113,6 +115,7 @@
             "bundle:/usr/local/bundle"
           ],
           "restart": "no",
+          "healthcheck": null,
           "image": "slidict/slidict:development",
           "command": "psql -U postgres",
           "type": "exec",
@@ -137,6 +140,7 @@
             "bundle:/usr/local/bundle"
           ],
           "restart": "no",
+          "healthcheck": null,
           "image": "slidict/slidict:development",
           "command": "server -p 3000",
           "type": "build",
@@ -214,6 +218,7 @@
             "bundle:/usr/local/bundle"
           ],
           "restart": "no",
+          "healthcheck": null,
           "image": "slidict/slidict:development",
           "command": "bin/rails",
           "type": "exec"
@@ -237,6 +242,7 @@
             "bundle:/usr/local/bundle"
           ],
           "restart": "no",
+          "healthcheck": null,
           "image": "slidict/slidict:development",
           "command": "bundle exec rspec",
           "type": "exec"
@@ -260,6 +266,7 @@
             "bundle:/usr/local/bundle"
           ],
           "restart": "no",
+          "healthcheck": null,
           "image": "slidict/slidict:development",
           "command": "psql -U postgres",
           "type": "exec",
@@ -284,6 +291,7 @@
             "bundle:/usr/local/bundle"
           ],
           "restart": "no",
+          "healthcheck": null,
           "image": "slidict/slidict:development",
           "command": "server -p 3000",
           "type": "build",
@@ -925,6 +933,7 @@
         "bundle:/usr/local/bundle"
       ],
       "restart": "no",
+      "healthcheck": null,
       "image": "slidict/slidict:development",
       "command": "bin/rails",
       "type": "exec"
@@ -992,6 +1001,7 @@
         "bundle:/usr/local/bundle"
       ],
       "restart": "no",
+      "healthcheck": null,
       "image": "slidict/slidict:development",
       "command": "bundle exec rspec",
       "type": "exec"
@@ -1061,6 +1071,7 @@
         "bundle:/usr/local/bundle"
       ],
       "restart": "no",
+      "healthcheck": null,
       "image": "slidict/slidict:development",
       "command": "psql -U postgres",
       "type": "exec",
@@ -1107,6 +1118,7 @@
         "bundle:/usr/local/bundle"
       ],
       "restart": "no",
+      "healthcheck": null,
       "image": "slidict/slidict:development",
       "command": "server -p 3000",
       "type": "build",

--- a/tests/golden/cases/002-container-sync/cases.json
+++ b/tests/golden/cases/002-container-sync/cases.json
@@ -52,6 +52,7 @@
             "node_modules:/srv/app/node_modules"
           ],
           "restart": "no",
+          "healthcheck": null,
           "image": "myapp:dev",
           "type": "exec",
           "command": "bin/console"
@@ -112,6 +113,7 @@
             "node_modules:/srv/app/node_modules"
           ],
           "restart": "no",
+          "healthcheck": null,
           "image": "myapp:dev",
           "type": "exec",
           "command": "bin/console"

--- a/tests/golden/cases/002-container-sync/cases.json
+++ b/tests/golden/cases/002-container-sync/cases.json
@@ -533,6 +533,7 @@
         "node_modules:/srv/app/node_modules"
       ],
       "restart": "no",
+      "healthcheck": null,
       "image": "myapp:dev",
       "type": "exec",
       "command": "bin/console"

--- a/tests/golden/cases/003-compose-native/cases.json
+++ b/tests/golden/cases/003-compose-native/cases.json
@@ -19,7 +19,8 @@
           "volumes": [],
           "workdir": null,
           "user": null,
-          "restart": "no"
+          "restart": "no",
+          "healthcheck": null
         },
         "cache": {
           "image": "redis:7",
@@ -29,7 +30,8 @@
           "volumes": [],
           "workdir": null,
           "user": null,
-          "restart": "on-failure:3"
+          "restart": "on-failure:3",
+          "healthcheck": null
         },
         "web": {
           "image": "wip-compose-web:latest",
@@ -46,7 +48,8 @@
           ],
           "workdir": "/app",
           "user": null,
-          "restart": "unless-stopped"
+          "restart": "unless-stopped",
+          "healthcheck": null
         }
       },
       "compose": {
@@ -71,6 +74,7 @@
             ".:/app"
           ],
           "restart": "unless-stopped",
+          "healthcheck": null,
           "image": "wip-compose-web:latest",
           "command": "bin/rails",
           "type": "exec"
@@ -98,7 +102,8 @@
           "volumes": [],
           "workdir": null,
           "user": null,
-          "restart": "no"
+          "restart": "no",
+          "healthcheck": null
         },
         "cache": {
           "image": "redis:7",
@@ -108,7 +113,8 @@
           "volumes": [],
           "workdir": null,
           "user": null,
-          "restart": "on-failure:3"
+          "restart": "on-failure:3",
+          "healthcheck": null
         },
         "web": {
           "image": "wip-compose-web:latest",
@@ -125,7 +131,8 @@
           ],
           "workdir": "/app",
           "user": null,
-          "restart": "unless-stopped"
+          "restart": "unless-stopped",
+          "healthcheck": null
         }
       },
       "compose": {
@@ -150,6 +157,7 @@
             ".:/app"
           ],
           "restart": "unless-stopped",
+          "healthcheck": null,
           "image": "wip-compose-web:latest",
           "command": "bin/rails",
           "type": "exec"
@@ -717,6 +725,7 @@
         ".:/app"
       ],
       "restart": "unless-stopped",
+      "healthcheck": null,
       "image": "wip-compose-web:latest",
       "command": "bin/rails",
       "type": "exec"

--- a/tests/golden/cases/005-dotenv/cases.json
+++ b/tests/golden/cases/005-dotenv/cases.json
@@ -33,6 +33,7 @@
           "ports": [],
           "volumes": [],
           "restart": "no",
+          "healthcheck": null,
           "image": "myapp:dev",
           "type": "exec",
           "command": "env"
@@ -74,6 +75,7 @@
           "ports": [],
           "volumes": [],
           "restart": "no",
+          "healthcheck": null,
           "image": "myapp:dev",
           "type": "exec",
           "command": "env"
@@ -647,6 +649,7 @@
       "ports": [],
       "volumes": [],
       "restart": "no",
+      "healthcheck": null,
       "image": "myapp:dev",
       "type": "exec",
       "command": "env"

--- a/tests/golden/cases/007-interaction-alias/cases.json
+++ b/tests/golden/cases/007-interaction-alias/cases.json
@@ -32,6 +32,7 @@
           "ports": [],
           "volumes": [],
           "restart": "no",
+          "healthcheck": null,
           "image": "legacy:dev",
           "type": "exec",
           "command": "bash"
@@ -47,6 +48,7 @@
           "ports": [],
           "volumes": [],
           "restart": "no",
+          "healthcheck": null,
           "image": "legacy:dev",
           "type": "run",
           "command": "bin/rails db:migrate"
@@ -87,6 +89,7 @@
           "ports": [],
           "volumes": [],
           "restart": "no",
+          "healthcheck": null,
           "image": "legacy:dev",
           "type": "exec",
           "command": "bash"
@@ -102,6 +105,7 @@
           "ports": [],
           "volumes": [],
           "restart": "no",
+          "healthcheck": null,
           "image": "legacy:dev",
           "type": "run",
           "command": "bin/rails db:migrate"
@@ -464,6 +468,7 @@
       "ports": [],
       "volumes": [],
       "restart": "no",
+      "healthcheck": null,
       "image": "legacy:dev",
       "type": "exec",
       "command": "bash"
@@ -509,6 +514,7 @@
       "ports": [],
       "volumes": [],
       "restart": "no",
+      "healthcheck": null,
       "image": "legacy:dev",
       "type": "run",
       "command": "bin/rails db:migrate"


### PR DESCRIPTION
## Summary
- `wip up` used to treat a dependency as "ready" the moment `wslc` reported its container running — well before a MySQL/Redis-style service is actually accepting connections. This adds `dependencies.<name>.healthcheck:` (mode: container) and reads a compose.yml service's own `healthcheck:` under mode: compose-native, both normalized through one shared `Wip.Configuration.HealthCheck` so both modes behave identically.
- `wip up`/`wip restart` now poll a dependency's `healthcheck.test` via `wslc exec` after starting it, honoring `interval`/`timeout`/`retries`/`start_period` the same way Compose's own healthcheck does, and fail with a clear error once retries are exhausted instead of handing a not-yet-ready dependency to whatever needs it.
- `mode: compose-native` also now accepts `depends_on: condition: service_healthy`, rejected at config-load time (like real Compose) if the named service has no `healthcheck:`.
- `CommandRunner` gained an optional per-command timeout (kills the process, reports exit 124) so one slow health probe can't hang `wip up`.
- A dependency with no `healthcheck:` behaves exactly as before — this is opt-in.

Closes #118.

## Test plan
- [x] `dotnet build wip.slnx` — clean, no warnings
- [x] `dotnet test tests/Wip.Tests/Wip.Tests.csproj` — 618 passed, 0 failed, 16 skipped (pre-existing host-path skips)
- [x] Added unit tests for the shared `HealthCheck` normalizer (shell/CMD/CMD-SHELL/NONE test forms, defaults, validation errors)
- [x] Added tests for compose-native `healthcheck:` parsing and `depends_on: condition: service_healthy` (accepted/rejected)
- [x] Added tests for `Config`'s container-mode `dependencies.<name>.healthcheck:` validation
- [x] Added tests for the new `CommandBuilder.DependencyExec` and the readiness-timeout failure message
- [x] Updated `tests/golden/*/cases.json` for the new `healthcheck: null` default key (verified via a byte-for-byte JSON round-trip check that only the intended field was added)
- [x] Updated README with the new config shape and behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UU2mezoQaK2tLuHHAF1y3q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable dependency health checks with commands, timeouts, intervals, startup delays, and retries.
  * Added Compose `healthcheck` settings and `service_healthy` dependency conditions.
  * `wip up` now waits for dependencies to become healthy before starting dependent services.
  * Health-check timing supports numeric seconds and Compose duration strings.
  * Compose parsing now accepts supported `ports`, `depends_on`, and ignored `dns` settings.
  * Improved failure reporting with diagnostic output and timeout details.
* **Bug Fixes**
  * Timed-out commands now terminate reliably, including child processes.
* **Documentation**
  * Documented health-check configuration, timing formats, startup behavior, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->