### PR TITLE
docs: add rails and node example projects

### DIFF
--- a/examples/node/Dockerfile.dev
+++ b/examples/node/Dockerfile.dev
@@ -2,12 +2,16 @@
 # Replace with your app's real Dockerfile — this only exists so `wip build` has something to run.
 FROM node:20-slim
 
+# The image already ships a `node` user at UID/GID 1000; run as it so `npm install` and the
+# dev command don't leave root-owned files in the bind-mounted /app tree.
 WORKDIR /app
+RUN chown node:node /app
+USER node
 
-COPY package.json package-lock.json ./
+COPY --chown=node:node package.json package-lock.json ./
 RUN npm install
 
-COPY . .
+COPY --chown=node:node . .
 
 EXPOSE 3000
 CMD ["npm", "run", "dev"]

--- a/examples/node/README.md
+++ b/examples/node/README.md
@@ -11,7 +11,12 @@ differs from `mode: compose`.
   `healthcheck:` on `db` that `wip up` waits on before starting `web`
 - [`wip.yml`](wip.yml) — points at the `web` service and adds a few day-to-day commands
 - [`Dockerfile.dev`](Dockerfile.dev) — a minimal placeholder image so `wip build` has something
-  to run; replace it with your app's real Dockerfile
+  to run; replace it with your app's real Dockerfile. It runs as the image's non-root `node`
+  user so `npm install` doesn't leave root-owned files in the bind-mounted `/app`.
+
+> **The `root` / `password` MySQL credential here is for local development only.** `db` publishes
+> `127.0.0.1:3306` so it stays on the loopback interface rather than every host interface. Swap in
+> a real secret (and a non-root database user) before running this anywhere shared or reachable.
 
 ## Setup
 

--- a/examples/node/compose.yml
+++ b/examples/node/compose.yml
@@ -7,7 +7,7 @@ services:
     command: ["npm", "run", "dev"]
     environment:
       NODE_ENV: development
-      DATABASE_URL: mysql://root:password@db:3306/myapp_development
+      DATABASE_URL: mysql://root:password@db:3306/myapp_development # matches MYSQL_ROOT_PASSWORD below
       REDIS_URL: redis://cache:6379
     ports:
       - "3000:3000"
@@ -23,10 +23,10 @@ services:
   db:
     image: mysql:8.0
     environment:
-      MYSQL_ROOT_PASSWORD: password
+      MYSQL_ROOT_PASSWORD: password # local development only — pick a real secret before this leaves your machine
       MYSQL_DATABASE: myapp_development
     ports:
-      - "3306:3306"
+      - "127.0.0.1:3306:3306" # loopback only, so the sample credential isn't reachable from the network
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
       interval: 2s

--- a/examples/node/wip.yml
+++ b/examples/node/wip.yml
@@ -9,7 +9,7 @@ commands:
   test:
     command: npm test
   mysql:
-    command: mysql -uroot -ppassword myapp_development
+    command: mysql -uroot -ppassword myapp_development # the local-development-only password from compose.yml
     container: db # redirects this one command to the db service instead of web
     interactive: true
   redis-cli:

--- a/examples/rails/README.md
+++ b/examples/rails/README.md
@@ -11,6 +11,10 @@ this mode fits.
 - [`Dockerfile`](Dockerfile) — a minimal placeholder image so `wip build` has something to run;
   replace it with your app's real Dockerfile
 
+> **The `postgres` / `password` credential here is for local development only.** `db` publishes
+> `127.0.0.1:5432` so it stays on the loopback interface rather than every host interface. Swap in
+> a real secret before running this anywhere shared or reachable.
+
 ## Setup
 
 1. Copy `wip.yml` (and `Dockerfile`, if you don't have one yet) into the root of your Rails app.

--- a/examples/rails/wip.yml
+++ b/examples/rails/wip.yml
@@ -6,10 +6,10 @@ dependencies:
   app:
     image: myapp/rails:development # built by the `build` command below
     workdir: /app
-    command: server -b 0.0.0.0 # appended to the image's CMD when `wip up` creates the container
+    command: bin/rails server -b 0.0.0.0 # replaces the image's CMD when `wip up` creates the container
     env:
       RAILS_ENV: development
-      DATABASE_URL: postgres://postgres:password@db:5432/myapp_development
+      DATABASE_URL: postgres://postgres:password@db:5432/myapp_development # matches POSTGRES_PASSWORD below
       REDIS_URL: redis://redis:6379/0
     ports:
       - "3000:3000"
@@ -20,10 +20,10 @@ dependencies:
     image: postgres:16
     restart: unless-stopped
     env:
-      POSTGRES_PASSWORD: password
+      POSTGRES_PASSWORD: password # local development only — pick a real secret before this leaves your machine
       POSTGRES_DB: myapp_development
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432" # loopback only, so the sample credential isn't reachable from the network
     healthcheck: # `wip up` waits for this before starting `app`
       test: ["CMD", "pg_isready", "-U", "postgres"]
       interval: 2


### PR DESCRIPTION
Closes #119. Each example pairs a working wip.yml (and compose.yml for
the node one) with a minimal setup README, covering both mode: container
and mode: compose-native with realistic sidecars (Postgres/Redis,
MySQL/Redis) and healthchecks. Both configs are verified against `wip
config` to parse and resolve correctly.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016o6acN1vC5dXndgb9DQ4aq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ready-to-use Rails and Node.js example application stacks.
  * Added development environments with databases, caching services, health checks, and common application commands.
  * Added support for running, testing, migrating, debugging, and managing example services locally.

* **Documentation**
  * Added setup instructions, daily workflows, configuration references, and troubleshooting guidance for both examples.
  * Added the Examples section to the project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->