### PR TITLE
Colorize wip's own output and add a final outcome line to wip up

### DIFF
--- a/src/Wip.Cli/CliContext.cs
+++ b/src/Wip.Cli/CliContext.cs
@@ -305,6 +305,10 @@ internal sealed partial class CliContext
                 var code = UpViaComposeBridge(detach, sync, watch);
                 if (detach)
                 {
+                    // No container count here, unlike the non-compose branch below: under
+                    // mode: compose, wip delegates entirely to wslc-compose and deliberately
+                    // never parses compose.yml's service list (see the ConfigException in
+                    // UpViaComposeBridge for --watch), so it has nothing accurate to count.
                     Log.Info("up complete");
                 }
 

--- a/src/Wip.Cli/CliContext.cs
+++ b/src/Wip.Cli/CliContext.cs
@@ -356,8 +356,29 @@ internal sealed partial class CliContext
             // plus ErrorInterpreter's hint on top); this is only the missing "it's over, and
             // it did not work" marker the issue asked for, not a second explanation of why.
             Log.Error($"up failed (exit code {exit.Code})");
+            NoteIfDisplayLanguageIsNotEnglish();
             throw;
         }
+    }
+
+    /// <summary>
+    /// The output just streamed above came straight from wslc/docker/rsync, unlike everything
+    /// else wip printed around it — and unlike wip's own strings, it is not guaranteed to be in
+    /// English if Windows' display language isn't (issue #134's "Windows / locale angle"; see
+    /// <see cref="DisplayLanguage"/>). A quick note here is cheaper than the reader wondering
+    /// whether a paragraph in another language part-way up the scrollback was a wip message
+    /// they somehow can't parse.
+    /// </summary>
+    private static void NoteIfDisplayLanguageIsNotEnglish()
+    {
+        if (DisplayLanguage.IsEnglish())
+        {
+            return;
+        }
+
+        Log.Info(
+            "the output above came from the command that failed, not from wip, and may not " +
+            "be in English (your Windows display language isn't)");
     }
 
     internal int Sync(bool watch, double? interval)

--- a/src/Wip.Cli/CliContext.cs
+++ b/src/Wip.Cli/CliContext.cs
@@ -159,8 +159,7 @@ internal sealed partial class CliContext
 
         var initializer = new Initializer(Path.GetDirectoryName(path), template);
         File.WriteAllText(path, initializer.Call());
-        Console.Error.WriteLine(
-            $"wip: wrote {path} (mode: {(initializer.IsCompose ? "compose-native" : "container")})");
+        Log.Info($"wrote {path} (mode: {(initializer.IsCompose ? "compose-native" : "container")})");
         return 0;
     }
 
@@ -187,9 +186,9 @@ internal sealed partial class CliContext
         }
 
         var existing = File.Exists(path) ? File.ReadAllText(path) : null;
-        Console.Error.WriteLine($"wip: analyzing {directory}");
+        Log.Info($"analyzing {directory}");
         var project = new ProjectAnalyzer(directory).Analyze();
-        Console.Error.WriteLine($"wip: sending {project.Files.Count} selected project files to {model} at {baseUrl}");
+        Log.Info($"sending {project.Files.Count} selected project files to {model} at {baseUrl}");
         var candidate = new WipAiGenerator(new LocalAiProvider(baseUrl, model)).Generate(
             string.Join(System.Environment.NewLine, lines), project, existing, path);
 
@@ -201,12 +200,12 @@ internal sealed partial class CliContext
         if (!string.Equals(answer, "y", StringComparison.OrdinalIgnoreCase) &&
             !string.Equals(answer, "yes", StringComparison.OrdinalIgnoreCase))
         {
-            Console.Error.WriteLine("wip: not saved");
+            Log.Info("not saved");
             return 0;
         }
 
         File.WriteAllText(path, candidate);
-        Console.Error.WriteLine($"wip: wrote {path}");
+        Log.Info($"wrote {path}");
         return 0;
     }
 
@@ -226,7 +225,7 @@ internal sealed partial class CliContext
             throw new WipException("A question is required");
         }
 
-        Console.Error.WriteLine($"wip: asking {model} at {baseUrl}");
+        Log.Info($"asking {model} at {baseUrl}");
         var answer = new LocalAiProvider(baseUrl, model).Generate(HelpAiPrompt(asked));
         Console.WriteLine(answer);
         return 0;
@@ -285,49 +284,78 @@ internal sealed partial class CliContext
             Path.GetDirectoryName(Path.GetFullPath(Config.Path!))!,
             RubyValue.Presence(settings.GetValueOrDefault("context")) ?? "."));
 
-        Console.Error.WriteLine($"wip: staging build context ({context})");
+        Log.Info($"staging build context ({context})");
         return StageAndBuild(context, settings, arguments);
     }
 
+    /// <summary>
+    /// Gives <c>wip up</c> an explicit final outcome line (issue #134) instead of leaving
+    /// success or failure to be inferred from the tail of a build/boot log. The success line
+    /// only fires for a detached or --watch run: an attached run instead ends when the primary
+    /// container exits, and "up complete" printed after that would describe the wrong event.
+    /// </summary>
     internal int Up(bool detach, bool sync, bool noCache, bool watch, double interval)
     {
         WarnWslProject();
 
-        if (Config.IsCompose)
+        try
         {
-            return UpViaComposeBridge(detach, sync, watch);
-        }
+            if (Config.IsCompose)
+            {
+                var code = UpViaComposeBridge(detach, sync, watch);
+                if (detach)
+                {
+                    Log.Info("up complete");
+                }
 
-        // Validated up front, before any startup side effect (image build, network or
-        // container creation) — otherwise a bad --interval would only surface after
-        // everything was already running.
-        if (watch && interval <= 0)
+                return code;
+            }
+
+            // Validated up front, before any startup side effect (image build, network or
+            // container creation) — otherwise a bad --interval would only surface after
+            // everything was already running.
+            if (watch && interval <= 0)
+            {
+                throw new ConfigException("--interval must be a positive number");
+            }
+
+            EnsureComposeImages(noCache);
+            EnsureNetwork();
+            foreach (var name in SidecarNames())
+            {
+                EnsureDependency(name);
+            }
+
+            if (sync)
+            {
+                SyncBeforeBoot();
+            }
+
+            // --watch polls in a loop after boot, which cannot share this one thread with an
+            // attached primary container, so it forces the same behaviour -d gives.
+            EnsureContainer(detach || watch);
+
+            if (detach || watch)
+            {
+                var count = SidecarNames().Count + 1;
+                Log.Info($"up complete ({count} container(s) running)");
+            }
+
+            if (watch)
+            {
+                WatchRestarts(interval);
+            }
+
+            return 0;
+        }
+        catch (ExitException exit)
         {
-            throw new ConfigException("--interval must be a positive number");
+            // The failure itself was already streamed by CommandRunner (raw child output,
+            // plus ErrorInterpreter's hint on top); this is only the missing "it's over, and
+            // it did not work" marker the issue asked for, not a second explanation of why.
+            Log.Info($"up failed (exit code {exit.Code})");
+            throw;
         }
-
-        EnsureComposeImages(noCache);
-        EnsureNetwork();
-        foreach (var name in SidecarNames())
-        {
-            EnsureDependency(name);
-        }
-
-        if (sync)
-        {
-            SyncBeforeBoot();
-        }
-
-        // --watch polls in a loop after boot, which cannot share this one thread with an
-        // attached primary container, so it forces the same behaviour -d gives.
-        EnsureContainer(detach || watch);
-
-        if (watch)
-        {
-            WatchRestarts(interval);
-        }
-
-        return 0;
     }
 
     internal int Sync(bool watch, double? interval)
@@ -347,8 +375,8 @@ internal sealed partial class CliContext
             throw new ConfigException("--interval must be a positive number");
         }
 
-        Console.Error.WriteLine(string.Create(CultureInfo.InvariantCulture,
-            $"wip: syncing {settings.Source} -> {settings.Volume}:{settings.Target} every {seconds}s (Ctrl-C to stop)"));
+        Log.Info(string.Create(CultureInfo.InvariantCulture,
+            $"syncing {settings.Source} -> {settings.Volume}:{settings.Target} every {seconds}s (Ctrl-C to stop)"));
 
         return Loop(seconds, () => RunSync(exitOnFailure: false), "sync stopped");
     }
@@ -456,8 +484,8 @@ internal sealed partial class CliContext
 
         if (Config.IsCompose)
         {
-            Console.Error.WriteLine(
-                "wip: compose mode has no ephemeral 'run'; executing in the running " +
+            Log.Info(
+                "compose mode has no ephemeral 'run'; executing in the running " +
                 $"'{Config.ComposeService}' service instead");
             return Execute(ExecTarget(command, interactive), interactive: Tty(interactive));
         }
@@ -732,7 +760,7 @@ internal sealed partial class CliContext
             return;
         }
 
-        Console.Error.WriteLine($"wip: creating network '{network}'");
+        Log.Info($"creating network '{network}'");
         Execute(Builder.NetworkCreate(), exitOnFailure: false);
     }
 
@@ -761,16 +789,16 @@ internal sealed partial class CliContext
         switch (DecideContainerAction(exists, state))
         {
             case ContainerAction.AlreadyRunning:
-                Console.Error.WriteLine($"wip: dependency '{name}' is already running");
+                Log.Info($"dependency '{name}' is already running");
                 break;
 
             case ContainerAction.Start:
-                Console.Error.WriteLine($"wip: starting existing dependency '{name}'");
+                Log.Info($"starting existing dependency '{name}'");
                 Execute(Builder.DependencyStart(name));
                 break;
 
             default:
-                Console.Error.WriteLine($"wip: dependency '{name}' not found, creating it");
+                Log.Info($"dependency '{name}' not found, creating it");
                 Execute(Builder.DependencyUp(name));
                 break;
         }
@@ -805,7 +833,7 @@ internal sealed partial class CliContext
         var retries = Convert.ToInt32(healthcheck.GetValueOrDefault("retries"), CultureInfo.InvariantCulture);
         var startPeriod = Convert.ToDouble(healthcheck.GetValueOrDefault("start_period"), CultureInfo.InvariantCulture);
 
-        Console.Error.WriteLine($"wip: waiting for dependency '{name}' to become healthy");
+        Log.Info($"waiting for dependency '{name}' to become healthy");
         var startPeriodEnds = DateTime.UtcNow.AddSeconds(startPeriod);
         var failures = 0;
 
@@ -815,7 +843,7 @@ internal sealed partial class CliContext
                 Probe(Builder.DependencyExec(name, test), TimeSpan.FromSeconds(timeout), captureStderr: true);
             if (code == 0)
             {
-                Console.Error.WriteLine($"wip: dependency '{name}' is healthy");
+                Log.Info($"dependency '{name}' is healthy");
                 return;
             }
 
@@ -849,16 +877,16 @@ internal sealed partial class CliContext
         switch (DecideContainerAction(exists, state))
         {
             case ContainerAction.AlreadyRunning:
-                Console.Error.WriteLine($"wip: container '{Config.Container}' is already running");
+                Log.Info($"container '{Config.Container}' is already running");
                 break;
 
             case ContainerAction.Start:
-                Console.Error.WriteLine($"wip: starting existing container '{Config.Container}'");
+                Log.Info($"starting existing container '{Config.Container}'");
                 Execute(Builder.Start(detach), interactive);
                 break;
 
             default:
-                Console.Error.WriteLine($"wip: container '{Config.Container}' not found, creating it");
+                Log.Info($"container '{Config.Container}' not found, creating it");
                 Execute(Builder.Up(detach), interactive);
                 break;
         }
@@ -898,10 +926,9 @@ internal sealed partial class CliContext
         }
 
         EnsureSyncImage(settings);
-        Console.Error.WriteLine($"wip: syncing {settings.Source} -> {settings.Volume}:{settings.Target}");
+        Log.Info($"syncing {settings.Source} -> {settings.Volume}:{settings.Target}");
         Execute(Builder.SyncRun());
-        Console.Error.WriteLine(
-            $"wip: run `wip sync --watch` in another terminal to keep {settings.Target} up to date");
+        Log.Info($"run `wip sync --watch` in another terminal to keep {settings.Target} up to date");
     }
 
     /// <summary>
@@ -967,8 +994,8 @@ internal sealed partial class CliContext
         settings["tag"] = spec.GetValueOrDefault("tag");
 
         var context = RubyValue.ToStringValue(spec.GetValueOrDefault("context"));
-        Console.Error.WriteLine(
-            $"wip: building service '{name}' (tag: {RubyValue.ToStringValue(spec.GetValueOrDefault("tag"))}) " +
+        Log.Info(
+            $"building service '{name}' (tag: {RubyValue.ToStringValue(spec.GetValueOrDefault("tag"))}) " +
             $"from {context}");
 
         StageAndBuild(context, settings, WithNoCache(extra, noCache));
@@ -997,8 +1024,8 @@ internal sealed partial class CliContext
             return;
         }
 
-        Console.Error.WriteLine(
-            $"wip: warning: this project is on the WSL filesystem ({directory}); wslc " +
+        Log.Info(
+            $"warning: this project is on the WSL filesystem ({directory}); wslc " +
             "resolves bind-mount sources as Windows paths, so volumes: entries can mount " +
             "empty instead of failing. Move the project onto the Windows filesystem " +
             "(C:\\src\\myproject, say) if a container starts up without your files.");
@@ -1016,7 +1043,7 @@ internal sealed partial class CliContext
                 progress.Finish();
                 if (buildContext.UsesCache)
                 {
-                    Console.Error.WriteLine($"wip: using cached build context at {staged}");
+                    Log.Info($"using cached build context at {staged}");
                 }
 
                 // wslc build crashes when handed an absolute context path; running from
@@ -1057,8 +1084,8 @@ internal sealed partial class CliContext
             return;
         }
 
-        Console.Error.WriteLine(
-            $"wip: commands.{name} in wip.yml is shadowed by the built-in `wip {name}`; " +
+        Log.Info(
+            $"commands.{name} in wip.yml is shadowed by the built-in `wip {name}`; " +
             $"run it with `wip dispatch {name}`");
     }
 
@@ -1071,8 +1098,8 @@ internal sealed partial class CliContext
     {
         var names = Config.Dependencies.Keys.ToList();
         var joined = string.Join(", ", names);
-        Console.Error.WriteLine(string.Create(CultureInfo.InvariantCulture,
-            $"wip: watching {joined} for exited restart: containers every {interval}s (running detached; Ctrl-C to stop)"));
+        Log.Info(string.Create(CultureInfo.InvariantCulture,
+            $"watching {joined} for exited restart: containers every {interval}s (running detached; Ctrl-C to stop)"));
 
         Loop(interval, () =>
         {
@@ -1098,7 +1125,7 @@ internal sealed partial class CliContext
             return;
         }
 
-        Console.Error.WriteLine($"wip: '{name}' has exited, restarting it (restart: {policy})");
+        Log.Info($"'{name}' has exited, restarting it (restart: {policy})");
         Execute(Builder.DependencyStart(name), exitOnFailure: false);
     }
 
@@ -1189,7 +1216,7 @@ internal sealed partial class CliContext
         }
 
         Console.Error.WriteLine();
-        Console.Error.WriteLine($"wip: {stoppedMessage}");
+        Log.Info(stoppedMessage);
         return 0;
     }
 

--- a/src/Wip.Cli/CliContext.cs
+++ b/src/Wip.Cli/CliContext.cs
@@ -92,6 +92,8 @@ internal sealed partial class CliContext
     internal bool Debug =>
         options.Debug || !string.IsNullOrEmpty(System.Environment.GetEnvironmentVariable("WIP_DEBUG"));
 
+    internal bool Quiet => options.Quiet;
+
     internal ConfigLoader Loader => new(path: options.ConfigPath, envFile: options.EnvFile);
 
     internal Config Config => config ??= Loader.Load();
@@ -569,7 +571,7 @@ internal sealed partial class CliContext
         bool exitOnFailure = true,
         string? workingDirectory = null)
     {
-        var runner = new CommandRunner(Interpreter, debug: Debug);
+        var runner = new CommandRunner(Interpreter, debug: Debug, quiet: Quiet);
         var code = Reporter.Step(
             $"running: {CommandDisplay.ForDebug(command)}",
             () => runner.Run(command, interactive: interactive, workingDirectory: workingDirectory),
@@ -1225,4 +1227,4 @@ internal sealed partial class CliContext
 }
 
 /// <summary>The options every command shares, parsed once by <see cref="Program"/>.</summary>
-internal sealed record CliOptions(string? ConfigPath, string? EnvFile, bool Debug, string? DebugLog);
+internal sealed record CliOptions(string? ConfigPath, string? EnvFile, bool Debug, string? DebugLog, bool Quiet);

--- a/src/Wip.Cli/CliContext.cs
+++ b/src/Wip.Cli/CliContext.cs
@@ -353,7 +353,7 @@ internal sealed partial class CliContext
             // The failure itself was already streamed by CommandRunner (raw child output,
             // plus ErrorInterpreter's hint on top); this is only the missing "it's over, and
             // it did not work" marker the issue asked for, not a second explanation of why.
-            Log.Info($"up failed (exit code {exit.Code})");
+            Log.Error($"up failed (exit code {exit.Code})");
             throw;
         }
     }
@@ -1024,8 +1024,8 @@ internal sealed partial class CliContext
             return;
         }
 
-        Log.Info(
-            $"warning: this project is on the WSL filesystem ({directory}); wslc " +
+        Log.Warn(
+            $"this project is on the WSL filesystem ({directory}); wslc " +
             "resolves bind-mount sources as Windows paths, so volumes: entries can mount " +
             "empty instead of failing. Move the project onto the Windows filesystem " +
             "(C:\\src\\myproject, say) if a container starts up without your files.");
@@ -1084,7 +1084,7 @@ internal sealed partial class CliContext
             return;
         }
 
-        Log.Info(
+        Log.Warn(
             $"commands.{name} in wip.yml is shadowed by the built-in `wip {name}`; " +
             $"run it with `wip dispatch {name}`");
     }

--- a/src/Wip.Cli/Program.cs
+++ b/src/Wip.Cli/Program.cs
@@ -1,6 +1,7 @@
 using System.CommandLine;
 using Wip.Ai;
 using Wip.Configuration;
+using Wip.Diagnostics;
 
 namespace Wip.Cli;
 
@@ -25,7 +26,7 @@ internal static class Program
         }
         catch (WipException exception)
         {
-            Console.Error.WriteLine($"wip: {exception.Message}");
+            Log.Info(exception.Message);
             return 1;
         }
     }

--- a/src/Wip.Cli/Program.cs
+++ b/src/Wip.Cli/Program.cs
@@ -91,6 +91,13 @@ internal static class Program
             Description = "Where --debug snapshots go: a file path, or \"-\" for inline",
             Recursive = true,
         };
+        var quietOption = new Option<bool>("--quiet", "-q")
+        {
+            Description =
+                "Hold back a shelled-out command's own output and print it only if that " +
+                "command fails (--debug's own lines are unaffected)",
+            Recursive = true,
+        };
 
         var root = new RootCommand("A developer-friendly CLI wrapper for Microsoft WSLC.")
         {
@@ -98,13 +105,15 @@ internal static class Program
             envFileOption,
             debugOption,
             debugLogOption,
+            quietOption,
         };
 
         CliContext Context(ParseResult parsed) => new(new CliOptions(
             parsed.GetValue(configOption),
             parsed.GetValue(envFileOption),
             parsed.GetValue(debugOption),
-            parsed.GetValue(debugLogOption)));
+            parsed.GetValue(debugLogOption),
+            parsed.GetValue(quietOption)));
 
         foreach (var command in BuildCommands(Context))
         {

--- a/src/Wip.Cli/Program.cs
+++ b/src/Wip.Cli/Program.cs
@@ -26,7 +26,7 @@ internal static class Program
         }
         catch (WipException exception)
         {
-            Log.Info(exception.Message);
+            Log.Error(exception.Message);
             return 1;
         }
     }

--- a/src/Wip.Core/Diagnostics/Doctor.cs
+++ b/src/Wip.Core/Diagnostics/Doctor.cs
@@ -36,13 +36,14 @@ public sealed class Doctor
                                new CommandResolver([], "compose command", ComposeBridge.InstallHint);
     }
 
-    public IReadOnlyList<Result> Call(string? aiBaseUrl = null)
+    public IReadOnlyList<Result> Call(string? aiBaseUrl = null, bool? englishDisplayLanguage = null)
     {
         var results = new List<Result>
         {
             new(environment.IsWsl2 ? Level.Ok : Level.Fail,
                 environment.IsWsl2 ? "WSL2 is available" : "WSL2 is not available"),
             new(Level.Ok, $"Architecture: {environment.Architecture}"),
+            DisplayLanguageResult(englishDisplayLanguage ?? DisplayLanguage.IsEnglish()),
         };
 
         var config = LoadConfig(results);
@@ -287,6 +288,17 @@ public sealed class Doctor
             "throwaway container) — sync.mode: exec’s `wip sync`/`wip sync --watch` run " +
             "rsync inside the primary container instead, so its image needs rsync too"));
     }
+
+    /// <summary>
+    /// Informational either way, never a <see cref="Level.Warn"/>: a non-English display
+    /// language is not itself a problem, just a fact worth surfacing so raw wslc/docker/rsync
+    /// text elsewhere in wip's output (or pasted into a bug report) has an explanation instead
+    /// of looking like garbage output.
+    /// </summary>
+    private static Result DisplayLanguageResult(bool isEnglish) => new(Level.Ok, isEnglish
+        ? "Display language: English"
+        : "Display language: not English (wslc/docker/rsync output may appear in a " +
+          "different language)");
 
     private static bool CommandAvailable(string name)
     {

--- a/src/Wip.Core/Diagnostics/Log.cs
+++ b/src/Wip.Core/Diagnostics/Log.cs
@@ -3,29 +3,62 @@ using Wip.Platform;
 namespace Wip.Diagnostics;
 
 /// <summary>
-/// Writes wip's own progress/status lines to stderr, tinting the "wip:" tag so they read apart
-/// at a glance from the raw, unprefixed passthrough output <see cref="Execution.CommandRunner"/>
-/// streams from whatever wip shells out to (docker, rsync, wslc, ...).
+/// Writes wip's own progress/status/warning/error lines to stderr, tinting the "wip:" tag so
+/// they read apart at a glance from the raw, unprefixed passthrough output
+/// <see cref="Execution.CommandRunner"/> streams from whatever wip shells out to (docker, rsync,
+/// wslc, ...), and tinting a "warning:"/"error:" label on top for the two lines actually mean.
 /// </summary>
 /// <remarks>
 /// Before this, every "wip: ..." line in <c>CliContext</c> was its own
 /// <c>Console.Error.WriteLine</c> call, indistinguishable in color or shape from a child
-/// process's raw output interleaved with it (issue #134). This does not touch <c>--debug</c>
-/// output: those "wip: [debug] ..." lines are a deliberately raw, uncolored channel already
-/// distinguished by their own tag, and stay on <see cref="DebugReporter"/>'s direct writes.
+/// process's raw output interleaved with it, and from each other regardless of whether the
+/// line was routine progress or something the user needed to notice (issue #134). Severity
+/// here covers only wip's own messages: a child process's raw output (a docker warning, an
+/// rsync error) is not parsed or reclassified, since guessing at arbitrary third-party output
+/// shapes is exactly the fragility the issue's design discussion ruled out. This also does not
+/// touch <c>--debug</c> output: those "wip: [debug] ..." lines are a deliberately raw,
+/// uncolored channel already distinguished by their own tag, and stay on
+/// <see cref="DebugReporter"/>'s direct writes.
 /// </remarks>
 public static class Log
 {
     private const string TagAccent = "\x1b[36m";
+    private const string WarnAccent = "\x1b[33m";
+    private const string ErrorAccent = "\x1b[31m";
     private const string Reset = "\x1b[0m";
 
     /// <summary>Writes "wip: message" to stderr, tinting the tag when the terminal supports it.</summary>
     public static void Info(string message) => Console.Error.WriteLine(Format(message, IsColorEnabled()));
 
+    /// <summary>Writes "wip: warning: message" -- something the user should notice but that
+    /// does not stop wip from continuing.</summary>
+    public static void Warn(string message) => Console.Error.WriteLine(FormatWarn(message, IsColorEnabled()));
+
+    /// <summary>Writes "wip: error: message" -- wip is about to stop, or a command it ran
+    /// already failed.</summary>
+    public static void Error(string message) => Console.Error.WriteLine(FormatError(message, IsColorEnabled()));
+
     /// <summary>Pure formatting, kept apart from <see cref="IsColorEnabled"/> so the tag's shape
     /// is testable without a real console or environment variables.</summary>
-    internal static string Format(string message, bool colorize) =>
-        colorize ? $"{TagAccent}wip:{Reset} {message}" : $"wip: {message}";
+    internal static string Format(string message, bool colorize) => FormatTagged(null, message, colorize);
+
+    internal static string FormatWarn(string message, bool colorize) =>
+        FormatTagged(("warning", WarnAccent), message, colorize);
+
+    internal static string FormatError(string message, bool colorize) =>
+        FormatTagged(("error", ErrorAccent), message, colorize);
+
+    private static string FormatTagged((string Label, string Accent)? severity, string message, bool colorize)
+    {
+        var tag = colorize ? $"{TagAccent}wip:{Reset}" : "wip:";
+        if (severity is not { } level)
+        {
+            return $"{tag} {message}";
+        }
+
+        var label = colorize ? $"{level.Accent}{level.Label}:{Reset}" : $"{level.Label}:";
+        return $"{tag} {label} {message}";
+    }
 
     /// <summary>
     /// NO_COLOR (https://no-color.org) always wins. Otherwise color only makes sense when

--- a/src/Wip.Core/Diagnostics/Log.cs
+++ b/src/Wip.Core/Diagnostics/Log.cs
@@ -1,0 +1,43 @@
+using Wip.Platform;
+
+namespace Wip.Diagnostics;
+
+/// <summary>
+/// Writes wip's own progress/status lines to stderr, tinting the "wip:" tag so they read apart
+/// at a glance from the raw, unprefixed passthrough output <see cref="Execution.CommandRunner"/>
+/// streams from whatever wip shells out to (docker, rsync, wslc, ...).
+/// </summary>
+/// <remarks>
+/// Before this, every "wip: ..." line in <c>CliContext</c> was its own
+/// <c>Console.Error.WriteLine</c> call, indistinguishable in color or shape from a child
+/// process's raw output interleaved with it (issue #134). This does not touch <c>--debug</c>
+/// output: those "wip: [debug] ..." lines are a deliberately raw, uncolored channel already
+/// distinguished by their own tag, and stay on <see cref="DebugReporter"/>'s direct writes.
+/// </remarks>
+public static class Log
+{
+    private const string TagAccent = "\x1b[36m";
+    private const string Reset = "\x1b[0m";
+
+    /// <summary>Writes "wip: message" to stderr, tinting the tag when the terminal supports it.</summary>
+    public static void Info(string message) => Console.Error.WriteLine(Format(message, IsColorEnabled()));
+
+    /// <summary>Pure formatting, kept apart from <see cref="IsColorEnabled"/> so the tag's shape
+    /// is testable without a real console or environment variables.</summary>
+    internal static string Format(string message, bool colorize) =>
+        colorize ? $"{TagAccent}wip:{Reset} {message}" : $"wip: {message}";
+
+    /// <summary>
+    /// NO_COLOR (https://no-color.org) always wins. Otherwise color only makes sense when
+    /// stderr is a real, VT100-capable console: a redirected/piped stderr should stay plain so
+    /// logs, CI output, and <c>wip up 2&gt;log</c> don't fill with escape codes, and a console
+    /// with no virtual-terminal support would otherwise print the escape bytes themselves
+    /// instead of color.
+    /// </summary>
+    internal static bool IsColorEnabled() => ShouldColorize(
+        noColorRequested: Environment.GetEnvironmentVariable("NO_COLOR") is not null,
+        isRealConsole: !Console.IsErrorRedirected && AnsiConsole.IsSupported);
+
+    internal static bool ShouldColorize(bool noColorRequested, bool isRealConsole) =>
+        !noColorRequested && isRealConsole;
+}

--- a/src/Wip.Core/Execution/CommandRunner.cs
+++ b/src/Wip.Core/Execution/CommandRunner.cs
@@ -36,17 +36,26 @@ public sealed class CommandRunner
     private readonly TextWriter error;
     private readonly ErrorInterpreter interpreter;
     private readonly bool debug;
+    private readonly bool quiet;
 
+    /// <summary>
+    /// <paramref name="quiet"/> holds back the captured (non-interactive) path's own stdout
+    /// and stderr until the command is known to have failed, instead of streaming it live — see
+    /// issue #134's point 4. It has no effect on the interactive path: a child that owns the
+    /// console writes straight to it, with nothing passing through here to hold back.
+    /// </summary>
     public CommandRunner(
         ErrorInterpreter interpreter,
         TextWriter? output = null,
         TextWriter? error = null,
-        bool debug = false)
+        bool debug = false,
+        bool quiet = false)
     {
         this.interpreter = interpreter;
         this.output = output ?? Console.Out;
         this.error = error ?? Console.Error;
         this.debug = debug;
+        this.quiet = quiet;
     }
 
     /// <summary>
@@ -94,6 +103,13 @@ public sealed class CommandRunner
 
         var captured = new StringBuilder();
 
+        // Holding each stream's own writer back, rather than buffering just one merged
+        // stream, is what keeps stdout and stderr from bleeding into each other once a quiet
+        // run's output is finally released -- `captured` above still merges both, same as
+        // always, but that copy is only ever read by ErrorInterpreter, never replayed verbatim.
+        var outputSink = quiet ? new BufferingWriter(output) : output;
+        var errorSink = quiet ? new BufferingWriter(error) : error;
+
         try
         {
             using var process = Process.Start(startInfo)
@@ -106,8 +122,8 @@ public sealed class CommandRunner
 
             var pumps = new[]
             {
-                Pump(process.StandardOutput, output, captured),
-                Pump(process.StandardError, error, captured),
+                Pump(process.StandardOutput, outputSink, captured),
+                Pump(process.StandardError, errorSink, captured),
             };
 
             var exited = timeout is null || process.WaitForExit((int)timeout.Value.TotalMilliseconds);
@@ -122,6 +138,11 @@ public sealed class CommandRunner
             var code = exited ? process.ExitCode : TimeoutExitCode;
             if (code != 0)
             {
+                // A held-back run only earns its silence by succeeding; a failure gets the
+                // full transcript released before the hint, in the same shape it would have
+                // printed in all along.
+                (outputSink as BufferingWriter)?.Release();
+                (errorSink as BufferingWriter)?.Release();
                 ReportHint(captured.ToString());
             }
 
@@ -234,5 +255,47 @@ public sealed class CommandRunner
         }
 
         public void Dispose() => Console.CancelKeyPress -= handler;
+    }
+
+    /// <summary>
+    /// Accumulates everything written to it instead of forwarding it, until <see cref="Release"/>
+    /// says the run turned out to need it after all.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Pump"/> calls <see cref="TextWriter.Flush"/> after every chunk so a live run
+    /// echoes immediately; overriding it to do nothing here is exactly what makes a quiet run
+    /// quiet; without that override the base class default would still eagerly forward each
+    /// write.
+    /// </remarks>
+    private sealed class BufferingWriter(TextWriter inner) : TextWriter
+    {
+        private readonly StringBuilder buffer = new();
+
+        public override Encoding Encoding => inner.Encoding;
+
+        public override void Write(char value) => buffer.Append(value);
+
+        public override void Write(string? value)
+        {
+            if (value is not null)
+            {
+                buffer.Append(value);
+            }
+        }
+
+        public override void Flush()
+        {
+        }
+
+        internal void Release()
+        {
+            if (buffer.Length == 0)
+            {
+                return;
+            }
+
+            inner.Write(buffer.ToString());
+            inner.Flush();
+        }
     }
 }

--- a/src/Wip.Core/Platform/AnsiConsole.cs
+++ b/src/Wip.Core/Platform/AnsiConsole.cs
@@ -1,0 +1,61 @@
+using System.Runtime.InteropServices;
+
+namespace Wip.Platform;
+
+/// <summary>
+/// Enables ANSI/VT100 escape-sequence processing on the process's stderr handle, and reports
+/// whether that succeeded.
+/// </summary>
+/// <remarks>
+/// Unlike a Unix terminal, a Windows console does not render <c>\x1b[...</c> sequences until
+/// <c>ENABLE_VIRTUAL_TERMINAL_PROCESSING</c> is set on its handle, and that is not guaranteed
+/// to already be on — an older conhost window, for one. Writing color codes without this
+/// first would print the literal escape bytes instead of color, which is worse than no color
+/// at all. The check runs once and is cached: the mode cannot meaningfully change mid-process,
+/// and repeating two syscalls on every log line would be wasted work.
+/// </remarks>
+internal static partial class AnsiConsole
+{
+    private const int StdErrorHandle = -12;
+    private const uint EnableVirtualTerminalProcessing = 0x0004;
+
+    private static readonly Lazy<bool> Supported = new(TryEnable);
+
+    internal static bool IsSupported => Supported.Value;
+
+    private static bool TryEnable()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return false;
+        }
+
+        var handle = GetStdHandle(StdErrorHandle);
+        if (handle == IntPtr.Zero || handle == new IntPtr(-1))
+        {
+            return false;
+        }
+
+        // GetConsoleMode fails outright when the handle is not a console at all (redirected to
+        // a file or pipe). Log already checks Console.IsErrorRedirected before trusting this,
+        // but there is no reason to assume that here too.
+        if (!GetConsoleMode(handle, out var mode))
+        {
+            return false;
+        }
+
+        return (mode & EnableVirtualTerminalProcessing) != 0 ||
+               SetConsoleMode(handle, mode | EnableVirtualTerminalProcessing);
+    }
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    private static partial IntPtr GetStdHandle(int handle);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool GetConsoleMode(IntPtr handle, out uint mode);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool SetConsoleMode(IntPtr handle, uint mode);
+}

--- a/src/Wip.Core/Platform/AnsiConsole.cs
+++ b/src/Wip.Core/Platform/AnsiConsole.cs
@@ -3,16 +3,21 @@ using System.Runtime.InteropServices;
 namespace Wip.Platform;
 
 /// <summary>
-/// Enables ANSI/VT100 escape-sequence processing on the process's stderr handle, and reports
-/// whether that succeeded.
+/// Whether the process's stderr handle will render ANSI/VT100 escape sequences, enabling that
+/// support on Windows first if it isn't already on.
 /// </summary>
 /// <remarks>
 /// Unlike a Unix terminal, a Windows console does not render <c>\x1b[...</c> sequences until
 /// <c>ENABLE_VIRTUAL_TERMINAL_PROCESSING</c> is set on its handle, and that is not guaranteed
 /// to already be on — an older conhost window, for one. Writing color codes without this
 /// first would print the literal escape bytes instead of color, which is worse than no color
-/// at all. The check runs once and is cached: the mode cannot meaningfully change mid-process,
-/// and repeating two syscalls on every log line would be wasted work.
+/// at all. wip only ships for Windows, but the solution also builds and runs on a Linux dev
+/// box (see the RID comment in Wip.Cli.csproj) and CI's own Ubuntu leg — there, a real
+/// terminal already renders ANSI without any enabling step, so gating this on
+/// <c>OperatingSystem.IsWindows()</c> the same way as the syscalls below would needlessly
+/// disable color on every non-Windows terminal. The check runs once and is cached: the mode
+/// cannot meaningfully change mid-process, and repeating two syscalls on every log line would
+/// be wasted work.
 /// </remarks>
 internal static partial class AnsiConsole
 {
@@ -27,7 +32,9 @@ internal static partial class AnsiConsole
     {
         if (!OperatingSystem.IsWindows())
         {
-            return false;
+            // No handle to enable anything on outside Windows -- and none needed, since a
+            // real Unix terminal already understands ANSI on its own.
+            return true;
         }
 
         var handle = GetStdHandle(StdErrorHandle);

--- a/src/Wip.Core/Platform/DisplayLanguage.cs
+++ b/src/Wip.Core/Platform/DisplayLanguage.cs
@@ -1,0 +1,34 @@
+using System.Runtime.InteropServices;
+
+namespace Wip.Platform;
+
+/// <summary>Whether Windows' own UI language is English.</summary>
+/// <remarks>
+/// wip builds with <c>InvariantGlobalization</c> (see <c>Directory.Build.props</c>) —
+/// deliberately, since that is exactly what keeps wip's own strings simple to hold
+/// culture-invariant (see <see cref="Diagnostics.Log"/>) — but the same setting also means
+/// <c>CultureInfo.CurrentUICulture</c> never reflects the real OS language: every culture
+/// collapses to the invariant one under it. Reading the language straight from Win32 instead
+/// (<c>GetUserDefaultUILanguage</c>, the same LANGID <c>FormatMessage</c> itself consults to
+/// render an HRESULT like <c>WSLC_E_IMAGE_NOT_FOUND</c>) is what still lets issue #134's locale
+/// note tell an English desktop apart from one where a shelled-out command's raw output is not
+/// in English.
+/// </remarks>
+public static partial class DisplayLanguage
+{
+    // The low 10 bits of a LANGID are its primary language, independent of sublanguage
+    // (en-US, en-GB, ...); 0x09 is LANG_ENGLISH, per the language identifier constants in
+    // the Windows SDK's winnt.h.
+    private const ushort PrimaryLanguageMask = 0x3FF;
+    private const ushort EnglishPrimaryLanguageId = 0x09;
+
+    public static bool IsEnglish() => IsEnglish(CurrentUiLanguageId());
+
+    internal static bool IsEnglish(ushort languageId) => (languageId & PrimaryLanguageMask) == EnglishPrimaryLanguageId;
+
+    private static ushort CurrentUiLanguageId() =>
+        OperatingSystem.IsWindows() ? GetUserDefaultUILanguage() : EnglishPrimaryLanguageId;
+
+    [LibraryImport("kernel32.dll")]
+    private static partial ushort GetUserDefaultUILanguage();
+}

--- a/tests/Wip.Tests/CommandRunnerQuietTests.cs
+++ b/tests/Wip.Tests/CommandRunnerQuietTests.cs
@@ -1,0 +1,63 @@
+using Wip.Diagnostics;
+using Wip.Execution;
+
+namespace Wip.Tests;
+
+/// <summary>
+/// Exercises quiet mode (issue #134's point 4) against a real child process rather than a
+/// fake: the behaviour under test is exactly the difference between what
+/// <see cref="CommandRunner.Run"/> streams live versus holds back, which a mock of the process
+/// I/O would define away rather than verify.
+/// </summary>
+public class CommandRunnerQuietTests
+{
+    private static readonly ErrorInterpreter Interpreter = new("linux/amd64");
+
+    [Fact]
+    public void QuietSuccessPrintsNothing()
+    {
+        Assert.SkipWhen(!OperatingSystem.IsWindows(), "cmd.exe is Windows-only");
+
+        var output = new StringWriter();
+        var error = new StringWriter();
+        var runner = new CommandRunner(Interpreter, output, error, quiet: true);
+
+        var code = runner.Run(Cmd("echo hello & exit /b 0"));
+
+        Assert.Equal(0, code);
+        Assert.Equal("", output.ToString());
+        Assert.Equal("", error.ToString());
+    }
+
+    [Fact]
+    public void QuietFailureReleasesTheHeldOutput()
+    {
+        Assert.SkipWhen(!OperatingSystem.IsWindows(), "cmd.exe is Windows-only");
+
+        var output = new StringWriter();
+        var error = new StringWriter();
+        var runner = new CommandRunner(Interpreter, output, error, quiet: true);
+
+        var code = runner.Run(Cmd("echo hello & exit /b 3"));
+
+        Assert.Equal(3, code);
+        Assert.Contains("hello", output.ToString());
+    }
+
+    [Fact]
+    public void NonQuietSuccessStillStreamsLive()
+    {
+        Assert.SkipWhen(!OperatingSystem.IsWindows(), "cmd.exe is Windows-only");
+
+        var output = new StringWriter();
+        var error = new StringWriter();
+        var runner = new CommandRunner(Interpreter, output, error);
+
+        var code = runner.Run(Cmd("echo hello & exit /b 0"));
+
+        Assert.Equal(0, code);
+        Assert.Contains("hello", output.ToString());
+    }
+
+    private static IReadOnlyList<string> Cmd(string script) => ["cmd.exe", "/c", script];
+}

--- a/tests/Wip.Tests/DisplayLanguageTests.cs
+++ b/tests/Wip.Tests/DisplayLanguageTests.cs
@@ -1,0 +1,31 @@
+using Wip.Platform;
+
+namespace Wip.Tests;
+
+/// <summary>
+/// Exercises against real Windows LANGID values rather than <c>CultureInfo</c>: wip builds
+/// with <c>InvariantGlobalization</c>, under which <c>CultureInfo.GetCultureInfo</c> throws for
+/// every name but the invariant one, so a test built on it would not even compile a case for
+/// "ja-JP" -- exactly the gap <see cref="DisplayLanguage"/> exists to work around.
+/// </summary>
+public class DisplayLanguageTests
+{
+    private const ushort EnglishUS = 0x0409;
+    private const ushort EnglishUK = 0x0809;
+    private const ushort JapaneseJP = 0x0411;
+    private const ushort GermanDE = 0x0407;
+    private const ushort FrenchFR = 0x040C;
+
+    [Theory]
+    [InlineData(EnglishUS, true)]
+    [InlineData(EnglishUK, true)]
+    [InlineData(JapaneseJP, false)]
+    [InlineData(GermanDE, false)]
+    [InlineData(FrenchFR, false)]
+    public void MatchesOnlyTheEnglishPrimaryLanguageId(ushort languageId, bool expected)
+    {
+        var actual = DisplayLanguage.IsEnglish(languageId);
+
+        Assert.Equal(expected, actual);
+    }
+}

--- a/tests/Wip.Tests/DoctorTests.cs
+++ b/tests/Wip.Tests/DoctorTests.cs
@@ -9,6 +9,31 @@ namespace Wip.Tests;
 public class DoctorTests
 {
     [Fact]
+    public void ReportsEnglishDisplayLanguageWithNoQualifier()
+    {
+        using var directory = new TemporaryDirectory();
+        var results = new Doctor(new ConfigLoader(directory.Path), new FakeEnvironment())
+            .Call(englishDisplayLanguage: true);
+
+        var language = Assert.Single(results, result => result.Message.StartsWith("Display language:"));
+        Assert.Equal(Doctor.Level.Ok, language.Level);
+        Assert.Equal("Display language: English", language.Message);
+    }
+
+    [Fact]
+    public void FlagsANonEnglishDisplayLanguageAsPossiblyAffectingToolOutput()
+    {
+        using var directory = new TemporaryDirectory();
+        var results = new Doctor(new ConfigLoader(directory.Path), new FakeEnvironment())
+            .Call(englishDisplayLanguage: false);
+
+        var language = Assert.Single(results, result => result.Message.StartsWith("Display language:"));
+        Assert.Equal(Doctor.Level.Ok, language.Level);
+        Assert.Contains("not English", language.Message);
+        Assert.Contains("may appear in a different language", language.Message);
+    }
+
+    [Fact]
     public void ReportsMissingAiServerAsWarnWithFixHint()
     {
         using var baseUrl = new TemporaryEnvironmentVariable(LocalAiProvider.BaseUrlEnvironmentVariable, "http://127.0.0.1:1");

--- a/tests/Wip.Tests/LogTests.cs
+++ b/tests/Wip.Tests/LogTests.cs
@@ -1,0 +1,34 @@
+using Wip.Diagnostics;
+
+namespace Wip.Tests;
+
+public class LogTests
+{
+    [Fact]
+    public void FormatsPlainWhenColorDisabled()
+    {
+        var actual = Log.Format("container 'app' not found, creating it", colorize: false);
+
+        Assert.Equal("wip: container 'app' not found, creating it", actual);
+    }
+
+    [Fact]
+    public void TintsOnlyTheTagWhenColorEnabled()
+    {
+        var actual = Log.Format("container 'app' not found, creating it", colorize: true);
+
+        Assert.Equal("\x1b[36mwip:\x1b[0m container 'app' not found, creating it", actual);
+    }
+
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(false, true, true)]
+    [InlineData(true, false, false)]
+    [InlineData(true, true, false)]
+    public void NoColorEnvironmentVariableAlwaysWins(bool noColorRequested, bool isRealConsole, bool expected)
+    {
+        var actual = Log.ShouldColorize(noColorRequested, isRealConsole);
+
+        Assert.Equal(expected, actual);
+    }
+}

--- a/tests/Wip.Tests/LogTests.cs
+++ b/tests/Wip.Tests/LogTests.cs
@@ -20,6 +20,40 @@ public class LogTests
         Assert.Equal("\x1b[36mwip:\x1b[0m container 'app' not found, creating it", actual);
     }
 
+    [Fact]
+    public void WarnAddsAPlainWarningLabelWhenColorDisabled()
+    {
+        var actual = Log.FormatWarn("this project is on the WSL filesystem", colorize: false);
+
+        Assert.Equal("wip: warning: this project is on the WSL filesystem", actual);
+    }
+
+    [Fact]
+    public void WarnTintsTheTagAndTheLabelSeparatelyWhenColorEnabled()
+    {
+        var actual = Log.FormatWarn("this project is on the WSL filesystem", colorize: true);
+
+        Assert.Equal(
+            "\x1b[36mwip:\x1b[0m \x1b[33mwarning:\x1b[0m this project is on the WSL filesystem",
+            actual);
+    }
+
+    [Fact]
+    public void ErrorAddsAPlainErrorLabelWhenColorDisabled()
+    {
+        var actual = Log.FormatError("up failed (exit code 1)", colorize: false);
+
+        Assert.Equal("wip: error: up failed (exit code 1)", actual);
+    }
+
+    [Fact]
+    public void ErrorTintsTheTagAndTheLabelSeparatelyWhenColorEnabled()
+    {
+        var actual = Log.FormatError("up failed (exit code 1)", colorize: true);
+
+        Assert.Equal("\x1b[36mwip:\x1b[0m \x1b[31merror:\x1b[0m up failed (exit code 1)", actual);
+    }
+
     [Theory]
     [InlineData(false, false, false)]
     [InlineData(false, true, true)]


### PR DESCRIPTION
## Summary

Implements all 5 items scoped in #134 ("Rethink logging/output design across the whole CLI"). Originally opened covering just items 1+3, with items 2/4/5 as separate stacked PRs (#137, #138, #139); those have since been merged into this branch, so this PR now carries the whole stack.

- **Source attribution** (item 1): `Wip.Diagnostics.Log` tints the `wip:` tag on every line wip writes itself, so it reads apart at a glance from the raw, uncolored passthrough output `CommandRunner` streams from docker/rsync/wslc. Every `Console.Error.WriteLine("wip: ...")` call site in `CliContext`/`Program` goes through it.
- **Final outcome line** (item 3): `wip up` prints `wip: up complete (N container(s) running)` after a detached or `--watch` run finishes starting things, and `wip: error: up failed (exit code N)` when a child command it ran exits non-zero. An attached (foreground) run is left alone — it already ends when the primary container exits.
- **Severity** (item 2): `Log.Warn`/`Log.Error` join `Log.Info`, each with their own colored label (`warning:` yellow, `error:` red) on top of the shared cyan `wip:` tag. Scoped to wip's own messages only — a child process's raw output is not parsed or reclassified.
- **Verbosity control** (item 4): opt-in `--quiet`/`-q` (recursive) holds back a captured command's stdout/stderr until it's known to have failed, instead of streaming it live. Deliberately opt-in rather than the issue's literal "quiet by default" — flipping the default risked hiding real-time progress on a slow build with no way back short of a flag.
- **Locale-awareness** (item 5): `wip up`'s failure path and `wip doctor` both flag when the current Windows UI language isn't English, since a shelled-out command's raw output (wslc's own Win32 error text, in particular) follows the OS language, not wip's. Uses `GetUserDefaultUILanguage` directly rather than `CultureInfo`, since this repo builds with `InvariantGlobalization` and `CultureInfo.CurrentUICulture` never reflects the real OS setting under it.

`--debug` output (`wip: [debug] ...`) and raw child passthrough are untouched throughout — both deliberately out of scope, per the design discussion on #134.

### Review fixes (CodeRabbit)

- `AnsiConsole.IsSupported` unconditionally returned `false` on non-Windows, silently disabling color on a real Unix terminal too (not just a Windows console lacking VT processing) — the solution also builds/tests on a Linux dev box and CI's Ubuntu leg. Fixed: non-Windows now reports supported without touching the Windows-only syscalls.
- Compose-mode (`mode: compose`)'s `up complete` line has no container count, unlike the container/compose-native path — flagged as a possible inconsistency. It's intentional: under `mode: compose`, wip delegates entirely to `wslc-compose` and deliberately never parses `compose.yml`'s service list, so there's no accurate count to report. Added a comment explaining why rather than fabricating a number.

## Test plan

- [x] `dotnet build` — 0 warnings
- [x] `dotnet test` — 640 passed, 16 pre-existing skips (host-path fixtures, unrelated), 0 failed
- [x] `LogTests`, `DisplayLanguageTests`, `DoctorTests`, `CommandRunnerQuietTests` cover the new logic
- [x] Manual smoke tests against a real `wslc.exe` (including on this session's Japanese-locale Windows machine) for: colored/plain output fallback, `wip up` success/failure outcome lines, `--quiet` suppressing successful-run output while leaving failures untouched, and the locale note/`wip doctor` display-language line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rodvc77pcR2cbR3Z1VRkVG