### PR TITLE
Add warning/error severity levels to Log

### DIFF
--- a/src/Wip.Cli/CliContext.cs
+++ b/src/Wip.Cli/CliContext.cs
@@ -353,7 +353,7 @@ internal sealed partial class CliContext
             // The failure itself was already streamed by CommandRunner (raw child output,
             // plus ErrorInterpreter's hint on top); this is only the missing "it's over, and
             // it did not work" marker the issue asked for, not a second explanation of why.
-            Log.Info($"up failed (exit code {exit.Code})");
+            Log.Error($"up failed (exit code {exit.Code})");
             throw;
         }
     }
@@ -1024,8 +1024,8 @@ internal sealed partial class CliContext
             return;
         }
 
-        Log.Info(
-            $"warning: this project is on the WSL filesystem ({directory}); wslc " +
+        Log.Warn(
+            $"this project is on the WSL filesystem ({directory}); wslc " +
             "resolves bind-mount sources as Windows paths, so volumes: entries can mount " +
             "empty instead of failing. Move the project onto the Windows filesystem " +
             "(C:\\src\\myproject, say) if a container starts up without your files.");
@@ -1084,7 +1084,7 @@ internal sealed partial class CliContext
             return;
         }
 
-        Log.Info(
+        Log.Warn(
             $"commands.{name} in wip.yml is shadowed by the built-in `wip {name}`; " +
             $"run it with `wip dispatch {name}`");
     }

--- a/src/Wip.Cli/Program.cs
+++ b/src/Wip.Cli/Program.cs
@@ -26,7 +26,7 @@ internal static class Program
         }
         catch (WipException exception)
         {
-            Log.Info(exception.Message);
+            Log.Error(exception.Message);
             return 1;
         }
     }

--- a/src/Wip.Core/Diagnostics/Log.cs
+++ b/src/Wip.Core/Diagnostics/Log.cs
@@ -3,29 +3,62 @@ using Wip.Platform;
 namespace Wip.Diagnostics;
 
 /// <summary>
-/// Writes wip's own progress/status lines to stderr, tinting the "wip:" tag so they read apart
-/// at a glance from the raw, unprefixed passthrough output <see cref="Execution.CommandRunner"/>
-/// streams from whatever wip shells out to (docker, rsync, wslc, ...).
+/// Writes wip's own progress/status/warning/error lines to stderr, tinting the "wip:" tag so
+/// they read apart at a glance from the raw, unprefixed passthrough output
+/// <see cref="Execution.CommandRunner"/> streams from whatever wip shells out to (docker, rsync,
+/// wslc, ...), and tinting a "warning:"/"error:" label on top for the two lines actually mean.
 /// </summary>
 /// <remarks>
 /// Before this, every "wip: ..." line in <c>CliContext</c> was its own
 /// <c>Console.Error.WriteLine</c> call, indistinguishable in color or shape from a child
-/// process's raw output interleaved with it (issue #134). This does not touch <c>--debug</c>
-/// output: those "wip: [debug] ..." lines are a deliberately raw, uncolored channel already
-/// distinguished by their own tag, and stay on <see cref="DebugReporter"/>'s direct writes.
+/// process's raw output interleaved with it, and from each other regardless of whether the
+/// line was routine progress or something the user needed to notice (issue #134). Severity
+/// here covers only wip's own messages: a child process's raw output (a docker warning, an
+/// rsync error) is not parsed or reclassified, since guessing at arbitrary third-party output
+/// shapes is exactly the fragility the issue's design discussion ruled out. This also does not
+/// touch <c>--debug</c> output: those "wip: [debug] ..." lines are a deliberately raw,
+/// uncolored channel already distinguished by their own tag, and stay on
+/// <see cref="DebugReporter"/>'s direct writes.
 /// </remarks>
 public static class Log
 {
     private const string TagAccent = "\x1b[36m";
+    private const string WarnAccent = "\x1b[33m";
+    private const string ErrorAccent = "\x1b[31m";
     private const string Reset = "\x1b[0m";
 
     /// <summary>Writes "wip: message" to stderr, tinting the tag when the terminal supports it.</summary>
     public static void Info(string message) => Console.Error.WriteLine(Format(message, IsColorEnabled()));
 
+    /// <summary>Writes "wip: warning: message" -- something the user should notice but that
+    /// does not stop wip from continuing.</summary>
+    public static void Warn(string message) => Console.Error.WriteLine(FormatWarn(message, IsColorEnabled()));
+
+    /// <summary>Writes "wip: error: message" -- wip is about to stop, or a command it ran
+    /// already failed.</summary>
+    public static void Error(string message) => Console.Error.WriteLine(FormatError(message, IsColorEnabled()));
+
     /// <summary>Pure formatting, kept apart from <see cref="IsColorEnabled"/> so the tag's shape
     /// is testable without a real console or environment variables.</summary>
-    internal static string Format(string message, bool colorize) =>
-        colorize ? $"{TagAccent}wip:{Reset} {message}" : $"wip: {message}";
+    internal static string Format(string message, bool colorize) => FormatTagged(null, message, colorize);
+
+    internal static string FormatWarn(string message, bool colorize) =>
+        FormatTagged(("warning", WarnAccent), message, colorize);
+
+    internal static string FormatError(string message, bool colorize) =>
+        FormatTagged(("error", ErrorAccent), message, colorize);
+
+    private static string FormatTagged((string Label, string Accent)? severity, string message, bool colorize)
+    {
+        var tag = colorize ? $"{TagAccent}wip:{Reset}" : "wip:";
+        if (severity is not { } level)
+        {
+            return $"{tag} {message}";
+        }
+
+        var label = colorize ? $"{level.Accent}{level.Label}:{Reset}" : $"{level.Label}:";
+        return $"{tag} {label} {message}";
+    }
 
     /// <summary>
     /// NO_COLOR (https://no-color.org) always wins. Otherwise color only makes sense when

--- a/tests/Wip.Tests/LogTests.cs
+++ b/tests/Wip.Tests/LogTests.cs
@@ -20,6 +20,40 @@ public class LogTests
         Assert.Equal("\x1b[36mwip:\x1b[0m container 'app' not found, creating it", actual);
     }
 
+    [Fact]
+    public void WarnAddsAPlainWarningLabelWhenColorDisabled()
+    {
+        var actual = Log.FormatWarn("this project is on the WSL filesystem", colorize: false);
+
+        Assert.Equal("wip: warning: this project is on the WSL filesystem", actual);
+    }
+
+    [Fact]
+    public void WarnTintsTheTagAndTheLabelSeparatelyWhenColorEnabled()
+    {
+        var actual = Log.FormatWarn("this project is on the WSL filesystem", colorize: true);
+
+        Assert.Equal(
+            "\x1b[36mwip:\x1b[0m \x1b[33mwarning:\x1b[0m this project is on the WSL filesystem",
+            actual);
+    }
+
+    [Fact]
+    public void ErrorAddsAPlainErrorLabelWhenColorDisabled()
+    {
+        var actual = Log.FormatError("up failed (exit code 1)", colorize: false);
+
+        Assert.Equal("wip: error: up failed (exit code 1)", actual);
+    }
+
+    [Fact]
+    public void ErrorTintsTheTagAndTheLabelSeparatelyWhenColorEnabled()
+    {
+        var actual = Log.FormatError("up failed (exit code 1)", colorize: true);
+
+        Assert.Equal("\x1b[36mwip:\x1b[0m \x1b[31merror:\x1b[0m up failed (exit code 1)", actual);
+    }
+
     [Theory]
     [InlineData(false, false, false)]
     [InlineData(false, true, true)]


### PR DESCRIPTION
## Summary

Stacked on #136 (source attribution + final outcome line). Implements item 2 of #134's design discussion: severity marking for wip's own messages.

- `Log.Warn(message)` and `Log.Error(message)` join the existing `Log.Info(message)`. All three keep the same cyan `wip:` tag; `Warn`/`Error` add their own colored label (`warning:` in yellow, `error:` in red) so the left edge of the output is scannable for what actually needs attention.
- Scope stays on wip's own messages, matching the design discussion on #134: a child process's raw output (a docker warning, an rsync error) is not parsed or reclassified — that was explicitly ruled out as fragile.
- Promoted call sites:
  - `WarnWslProject` and `WarnShadowedCommand` → `Log.Warn` (both were already conceptually warnings; the WSL-filesystem one had a literal `"warning: "` string baked into the message before this, now redundant and removed)
  - `wip up`'s final failure line and `Program`'s top-level `WipException` handler → `Log.Error`

`--debug` output and raw child passthrough are untouched, same as #136.

## Test plan

- [x] `dotnet build` — 0 warnings
- [x] `dotnet test` — 630 passed, 16 pre-existing skips, 0 failed
- [x] New `LogTests` cover `FormatWarn`/`FormatError` plain and colorized output
- [x] Manual smoke test: `wip up` with no `wip.yml` now prints `wip: error: wip.yml was not found ...` instead of the plain `wip: ...` from #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rodvc77pcR2cbR3Z1VRkVG