### PR TITLE
Add opt-in --quiet mode to hold back child output until failure

### DIFF
--- a/src/Wip.Cli/CliContext.cs
+++ b/src/Wip.Cli/CliContext.cs
@@ -92,6 +92,8 @@ internal sealed partial class CliContext
     internal bool Debug =>
         options.Debug || !string.IsNullOrEmpty(System.Environment.GetEnvironmentVariable("WIP_DEBUG"));
 
+    internal bool Quiet => options.Quiet;
+
     internal ConfigLoader Loader => new(path: options.ConfigPath, envFile: options.EnvFile);
 
     internal Config Config => config ??= Loader.Load();
@@ -569,7 +571,7 @@ internal sealed partial class CliContext
         bool exitOnFailure = true,
         string? workingDirectory = null)
     {
-        var runner = new CommandRunner(Interpreter, debug: Debug);
+        var runner = new CommandRunner(Interpreter, debug: Debug, quiet: Quiet);
         var code = Reporter.Step(
             $"running: {CommandDisplay.ForDebug(command)}",
             () => runner.Run(command, interactive: interactive, workingDirectory: workingDirectory),
@@ -1225,4 +1227,4 @@ internal sealed partial class CliContext
 }
 
 /// <summary>The options every command shares, parsed once by <see cref="Program"/>.</summary>
-internal sealed record CliOptions(string? ConfigPath, string? EnvFile, bool Debug, string? DebugLog);
+internal sealed record CliOptions(string? ConfigPath, string? EnvFile, bool Debug, string? DebugLog, bool Quiet);

--- a/src/Wip.Cli/Program.cs
+++ b/src/Wip.Cli/Program.cs
@@ -91,6 +91,13 @@ internal static class Program
             Description = "Where --debug snapshots go: a file path, or \"-\" for inline",
             Recursive = true,
         };
+        var quietOption = new Option<bool>("--quiet", "-q")
+        {
+            Description =
+                "Hold back a shelled-out command's own output and print it only if that " +
+                "command fails (--debug's own lines are unaffected)",
+            Recursive = true,
+        };
 
         var root = new RootCommand("A developer-friendly CLI wrapper for Microsoft WSLC.")
         {
@@ -98,13 +105,15 @@ internal static class Program
             envFileOption,
             debugOption,
             debugLogOption,
+            quietOption,
         };
 
         CliContext Context(ParseResult parsed) => new(new CliOptions(
             parsed.GetValue(configOption),
             parsed.GetValue(envFileOption),
             parsed.GetValue(debugOption),
-            parsed.GetValue(debugLogOption)));
+            parsed.GetValue(debugLogOption),
+            parsed.GetValue(quietOption)));
 
         foreach (var command in BuildCommands(Context))
         {

--- a/src/Wip.Core/Execution/CommandRunner.cs
+++ b/src/Wip.Core/Execution/CommandRunner.cs
@@ -36,17 +36,26 @@ public sealed class CommandRunner
     private readonly TextWriter error;
     private readonly ErrorInterpreter interpreter;
     private readonly bool debug;
+    private readonly bool quiet;
 
+    /// <summary>
+    /// <paramref name="quiet"/> holds back the captured (non-interactive) path's own stdout
+    /// and stderr until the command is known to have failed, instead of streaming it live — see
+    /// issue #134's point 4. It has no effect on the interactive path: a child that owns the
+    /// console writes straight to it, with nothing passing through here to hold back.
+    /// </summary>
     public CommandRunner(
         ErrorInterpreter interpreter,
         TextWriter? output = null,
         TextWriter? error = null,
-        bool debug = false)
+        bool debug = false,
+        bool quiet = false)
     {
         this.interpreter = interpreter;
         this.output = output ?? Console.Out;
         this.error = error ?? Console.Error;
         this.debug = debug;
+        this.quiet = quiet;
     }
 
     /// <summary>
@@ -94,6 +103,13 @@ public sealed class CommandRunner
 
         var captured = new StringBuilder();
 
+        // Holding each stream's own writer back, rather than buffering just one merged
+        // stream, is what keeps stdout and stderr from bleeding into each other once a quiet
+        // run's output is finally released -- `captured` above still merges both, same as
+        // always, but that copy is only ever read by ErrorInterpreter, never replayed verbatim.
+        var outputSink = quiet ? new BufferingWriter(output) : output;
+        var errorSink = quiet ? new BufferingWriter(error) : error;
+
         try
         {
             using var process = Process.Start(startInfo)
@@ -106,8 +122,8 @@ public sealed class CommandRunner
 
             var pumps = new[]
             {
-                Pump(process.StandardOutput, output, captured),
-                Pump(process.StandardError, error, captured),
+                Pump(process.StandardOutput, outputSink, captured),
+                Pump(process.StandardError, errorSink, captured),
             };
 
             var exited = timeout is null || process.WaitForExit((int)timeout.Value.TotalMilliseconds);
@@ -122,6 +138,11 @@ public sealed class CommandRunner
             var code = exited ? process.ExitCode : TimeoutExitCode;
             if (code != 0)
             {
+                // A held-back run only earns its silence by succeeding; a failure gets the
+                // full transcript released before the hint, in the same shape it would have
+                // printed in all along.
+                (outputSink as BufferingWriter)?.Release();
+                (errorSink as BufferingWriter)?.Release();
                 ReportHint(captured.ToString());
             }
 
@@ -234,5 +255,47 @@ public sealed class CommandRunner
         }
 
         public void Dispose() => Console.CancelKeyPress -= handler;
+    }
+
+    /// <summary>
+    /// Accumulates everything written to it instead of forwarding it, until <see cref="Release"/>
+    /// says the run turned out to need it after all.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Pump"/> calls <see cref="TextWriter.Flush"/> after every chunk so a live run
+    /// echoes immediately; overriding it to do nothing here is exactly what makes a quiet run
+    /// quiet; without that override the base class default would still eagerly forward each
+    /// write.
+    /// </remarks>
+    private sealed class BufferingWriter(TextWriter inner) : TextWriter
+    {
+        private readonly StringBuilder buffer = new();
+
+        public override Encoding Encoding => inner.Encoding;
+
+        public override void Write(char value) => buffer.Append(value);
+
+        public override void Write(string? value)
+        {
+            if (value is not null)
+            {
+                buffer.Append(value);
+            }
+        }
+
+        public override void Flush()
+        {
+        }
+
+        internal void Release()
+        {
+            if (buffer.Length == 0)
+            {
+                return;
+            }
+
+            inner.Write(buffer.ToString());
+            inner.Flush();
+        }
     }
 }

--- a/tests/Wip.Tests/CommandRunnerQuietTests.cs
+++ b/tests/Wip.Tests/CommandRunnerQuietTests.cs
@@ -1,0 +1,63 @@
+using Wip.Diagnostics;
+using Wip.Execution;
+
+namespace Wip.Tests;
+
+/// <summary>
+/// Exercises quiet mode (issue #134's point 4) against a real child process rather than a
+/// fake: the behaviour under test is exactly the difference between what
+/// <see cref="CommandRunner.Run"/> streams live versus holds back, which a mock of the process
+/// I/O would define away rather than verify.
+/// </summary>
+public class CommandRunnerQuietTests
+{
+    private static readonly ErrorInterpreter Interpreter = new("linux/amd64");
+
+    [Fact]
+    public void QuietSuccessPrintsNothing()
+    {
+        Assert.SkipWhen(!OperatingSystem.IsWindows(), "cmd.exe is Windows-only");
+
+        var output = new StringWriter();
+        var error = new StringWriter();
+        var runner = new CommandRunner(Interpreter, output, error, quiet: true);
+
+        var code = runner.Run(Cmd("echo hello & exit /b 0"));
+
+        Assert.Equal(0, code);
+        Assert.Equal("", output.ToString());
+        Assert.Equal("", error.ToString());
+    }
+
+    [Fact]
+    public void QuietFailureReleasesTheHeldOutput()
+    {
+        Assert.SkipWhen(!OperatingSystem.IsWindows(), "cmd.exe is Windows-only");
+
+        var output = new StringWriter();
+        var error = new StringWriter();
+        var runner = new CommandRunner(Interpreter, output, error, quiet: true);
+
+        var code = runner.Run(Cmd("echo hello & exit /b 3"));
+
+        Assert.Equal(3, code);
+        Assert.Contains("hello", output.ToString());
+    }
+
+    [Fact]
+    public void NonQuietSuccessStillStreamsLive()
+    {
+        Assert.SkipWhen(!OperatingSystem.IsWindows(), "cmd.exe is Windows-only");
+
+        var output = new StringWriter();
+        var error = new StringWriter();
+        var runner = new CommandRunner(Interpreter, output, error);
+
+        var code = runner.Run(Cmd("echo hello & exit /b 0"));
+
+        Assert.Equal(0, code);
+        Assert.Contains("hello", output.ToString());
+    }
+
+    private static IReadOnlyList<string> Cmd(string script) => ["cmd.exe", "/c", script];
+}


### PR DESCRIPTION
## Summary

Stacked on #137 (severity levels), which is stacked on #136 (source attribution + final outcome line). Implements item 4 of #134's design discussion: verbosity control.

- New recursive `--quiet`/`-q` flag. When set, `CommandRunner`'s captured (non-interactive) path buffers each shelled-out command's stdout/stderr via a new `BufferingWriter` instead of streaming it live, and only releases the buffered output — in the exact shape it would have printed in all along, stdout and stderr kept separate — if the command's exit code is non-zero. A successful quiet run therefore prints only wip's own `Log` lines.
- Threaded through as a normal `CliOptions` field, same shape as `--debug`, so it applies uniformly to every command that goes through `CliContext.Execute` (`up`, `build`, `sync`, `doctor`, dependency/network setup, ...) rather than being special-cased to `wip up`.

### Deliberate deviation from the issue's literal wording

The issue's point 4 said "consider a **default** quiet-ish mode... full output only on failure or with `-v/--verbose`." This PR makes it opt-in instead, default unchanged (full live streaming, same as today) — flipping the default risks hiding real-time progress on a slow docker build with no way back short of learning a new flag, which felt like a bigger behavior change than this issue needs to force. Happy to revisit if the default is wanted after all.

`--debug` output and the interactive (attached-terminal) path are both untouched, same scoping as #136/#137.

## Test plan

- [x] `dotnet build` — 0 warnings
- [x] `dotnet test` — 633 passed, 16 pre-existing skips, 0 failed
- [x] New `CommandRunnerQuietTests` spawn a real `cmd.exe` child (skipped on non-Windows CI, matching this repo's Windows-only surface) and verify: quiet+success prints nothing, quiet+failure releases the held output, non-quiet is unaffected
- [x] Manual smoke test against a real `wslc.exe`: `wip up -d --no-sync` against a locally-cached image prints wslc's raw container-id line without `--quiet` and only wip's own lines with it; a failing image pull prints the identical full transcript either way

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rodvc77pcR2cbR3Z1VRkVG