### PR TITLE
Flag non-English tool output as not coming from wip

### DIFF
--- a/src/Wip.Cli/CliContext.cs
+++ b/src/Wip.Cli/CliContext.cs
@@ -356,8 +356,29 @@ internal sealed partial class CliContext
             // plus ErrorInterpreter's hint on top); this is only the missing "it's over, and
             // it did not work" marker the issue asked for, not a second explanation of why.
             Log.Error($"up failed (exit code {exit.Code})");
+            NoteIfDisplayLanguageIsNotEnglish();
             throw;
         }
+    }
+
+    /// <summary>
+    /// The output just streamed above came straight from wslc/docker/rsync, unlike everything
+    /// else wip printed around it — and unlike wip's own strings, it is not guaranteed to be in
+    /// English if Windows' display language isn't (issue #134's "Windows / locale angle"; see
+    /// <see cref="DisplayLanguage"/>). A quick note here is cheaper than the reader wondering
+    /// whether a paragraph in another language part-way up the scrollback was a wip message
+    /// they somehow can't parse.
+    /// </summary>
+    private static void NoteIfDisplayLanguageIsNotEnglish()
+    {
+        if (DisplayLanguage.IsEnglish())
+        {
+            return;
+        }
+
+        Log.Info(
+            "the output above came from the command that failed, not from wip, and may not " +
+            "be in English (your Windows display language isn't)");
     }
 
     internal int Sync(bool watch, double? interval)

--- a/src/Wip.Core/Diagnostics/Doctor.cs
+++ b/src/Wip.Core/Diagnostics/Doctor.cs
@@ -36,13 +36,14 @@ public sealed class Doctor
                                new CommandResolver([], "compose command", ComposeBridge.InstallHint);
     }
 
-    public IReadOnlyList<Result> Call(string? aiBaseUrl = null)
+    public IReadOnlyList<Result> Call(string? aiBaseUrl = null, bool? englishDisplayLanguage = null)
     {
         var results = new List<Result>
         {
             new(environment.IsWsl2 ? Level.Ok : Level.Fail,
                 environment.IsWsl2 ? "WSL2 is available" : "WSL2 is not available"),
             new(Level.Ok, $"Architecture: {environment.Architecture}"),
+            DisplayLanguageResult(englishDisplayLanguage ?? DisplayLanguage.IsEnglish()),
         };
 
         var config = LoadConfig(results);
@@ -287,6 +288,17 @@ public sealed class Doctor
             "throwaway container) — sync.mode: exec’s `wip sync`/`wip sync --watch` run " +
             "rsync inside the primary container instead, so its image needs rsync too"));
     }
+
+    /// <summary>
+    /// Informational either way, never a <see cref="Level.Warn"/>: a non-English display
+    /// language is not itself a problem, just a fact worth surfacing so raw wslc/docker/rsync
+    /// text elsewhere in wip's output (or pasted into a bug report) has an explanation instead
+    /// of looking like garbage output.
+    /// </summary>
+    private static Result DisplayLanguageResult(bool isEnglish) => new(Level.Ok, isEnglish
+        ? "Display language: English"
+        : "Display language: not English (wslc/docker/rsync output may appear in a " +
+          "different language)");
 
     private static bool CommandAvailable(string name)
     {

--- a/src/Wip.Core/Platform/DisplayLanguage.cs
+++ b/src/Wip.Core/Platform/DisplayLanguage.cs
@@ -1,0 +1,34 @@
+using System.Runtime.InteropServices;
+
+namespace Wip.Platform;
+
+/// <summary>Whether Windows' own UI language is English.</summary>
+/// <remarks>
+/// wip builds with <c>InvariantGlobalization</c> (see <c>Directory.Build.props</c>) —
+/// deliberately, since that is exactly what keeps wip's own strings simple to hold
+/// culture-invariant (see <see cref="Diagnostics.Log"/>) — but the same setting also means
+/// <c>CultureInfo.CurrentUICulture</c> never reflects the real OS language: every culture
+/// collapses to the invariant one under it. Reading the language straight from Win32 instead
+/// (<c>GetUserDefaultUILanguage</c>, the same LANGID <c>FormatMessage</c> itself consults to
+/// render an HRESULT like <c>WSLC_E_IMAGE_NOT_FOUND</c>) is what still lets issue #134's locale
+/// note tell an English desktop apart from one where a shelled-out command's raw output is not
+/// in English.
+/// </remarks>
+public static partial class DisplayLanguage
+{
+    // The low 10 bits of a LANGID are its primary language, independent of sublanguage
+    // (en-US, en-GB, ...); 0x09 is LANG_ENGLISH, per the language identifier constants in
+    // the Windows SDK's winnt.h.
+    private const ushort PrimaryLanguageMask = 0x3FF;
+    private const ushort EnglishPrimaryLanguageId = 0x09;
+
+    public static bool IsEnglish() => IsEnglish(CurrentUiLanguageId());
+
+    internal static bool IsEnglish(ushort languageId) => (languageId & PrimaryLanguageMask) == EnglishPrimaryLanguageId;
+
+    private static ushort CurrentUiLanguageId() =>
+        OperatingSystem.IsWindows() ? GetUserDefaultUILanguage() : EnglishPrimaryLanguageId;
+
+    [LibraryImport("kernel32.dll")]
+    private static partial ushort GetUserDefaultUILanguage();
+}

--- a/tests/Wip.Tests/DisplayLanguageTests.cs
+++ b/tests/Wip.Tests/DisplayLanguageTests.cs
@@ -1,0 +1,31 @@
+using Wip.Platform;
+
+namespace Wip.Tests;
+
+/// <summary>
+/// Exercises against real Windows LANGID values rather than <c>CultureInfo</c>: wip builds
+/// with <c>InvariantGlobalization</c>, under which <c>CultureInfo.GetCultureInfo</c> throws for
+/// every name but the invariant one, so a test built on it would not even compile a case for
+/// "ja-JP" -- exactly the gap <see cref="DisplayLanguage"/> exists to work around.
+/// </summary>
+public class DisplayLanguageTests
+{
+    private const ushort EnglishUS = 0x0409;
+    private const ushort EnglishUK = 0x0809;
+    private const ushort JapaneseJP = 0x0411;
+    private const ushort GermanDE = 0x0407;
+    private const ushort FrenchFR = 0x040C;
+
+    [Theory]
+    [InlineData(EnglishUS, true)]
+    [InlineData(EnglishUK, true)]
+    [InlineData(JapaneseJP, false)]
+    [InlineData(GermanDE, false)]
+    [InlineData(FrenchFR, false)]
+    public void MatchesOnlyTheEnglishPrimaryLanguageId(ushort languageId, bool expected)
+    {
+        var actual = DisplayLanguage.IsEnglish(languageId);
+
+        Assert.Equal(expected, actual);
+    }
+}

--- a/tests/Wip.Tests/DoctorTests.cs
+++ b/tests/Wip.Tests/DoctorTests.cs
@@ -9,6 +9,31 @@ namespace Wip.Tests;
 public class DoctorTests
 {
     [Fact]
+    public void ReportsEnglishDisplayLanguageWithNoQualifier()
+    {
+        using var directory = new TemporaryDirectory();
+        var results = new Doctor(new ConfigLoader(directory.Path), new FakeEnvironment())
+            .Call(englishDisplayLanguage: true);
+
+        var language = Assert.Single(results, result => result.Message.StartsWith("Display language:"));
+        Assert.Equal(Doctor.Level.Ok, language.Level);
+        Assert.Equal("Display language: English", language.Message);
+    }
+
+    [Fact]
+    public void FlagsANonEnglishDisplayLanguageAsPossiblyAffectingToolOutput()
+    {
+        using var directory = new TemporaryDirectory();
+        var results = new Doctor(new ConfigLoader(directory.Path), new FakeEnvironment())
+            .Call(englishDisplayLanguage: false);
+
+        var language = Assert.Single(results, result => result.Message.StartsWith("Display language:"));
+        Assert.Equal(Doctor.Level.Ok, language.Level);
+        Assert.Contains("not English", language.Message);
+        Assert.Contains("may appear in a different language", language.Message);
+    }
+
+    [Fact]
     public void ReportsMissingAiServerAsWarnWithFixHint()
     {
         using var baseUrl = new TemporaryEnvironmentVariable(LocalAiProvider.BaseUrlEnvironmentVariable, "http://127.0.0.1:1");


### PR DESCRIPTION
## Summary

Stacked on #138 (quiet mode) → #137 (severity levels) → #136 (source attribution + final outcome line). Implements item 5 of #134's design discussion: locale-awareness. This is the last of the five items from the issue.

- **"be explicit when a message originates from a third-party tool that may print in the system locale"**: `wip up`'s failure path now adds a note when the current Windows UI language isn't English, pointing out that the output just shown came from the command that failed, not from wip. `wip doctor` also gets a new "Display language" line, so the fact is discoverable even outside a failure (useful on its own when someone pastes raw tool output into a bug report).
- **"make sure any wip-authored strings are translatable/consistent"**: audited — every numeric interpolation in a `Log.*` call already routes through `CultureInfo.InvariantCulture` (done incidentally back in #136), and `Log` (#136/#137) already means wip-authored strings are written from exactly one place. Nothing left to change here.

### A wrong turn worth calling out

My first pass used `CultureInfo.CurrentUICulture` to detect the OS display language. That's broken in this repo: `Directory.Build.props` sets `InvariantGlobalization=true` solution-wide (deliberate, for the AOT-published binary), under which `CultureInfo.CurrentUICulture` silently always reports the invariant culture regardless of Windows' actual setting, and `CultureInfo.GetCultureInfo(name)` throws for every name but that one. A test caught it before it shipped as a feature that looked like it worked but never actually detected anything. `DisplayLanguage.IsEnglish()` reads Windows' UI language straight from `GetUserDefaultUILanguage` (kernel32) instead — the same LANGID `FormatMessage` itself consults to render an HRESULT like `WSLC_E_IMAGE_NOT_FOUND`, which is exactly why wslc's own error text shows up in a non-English language on a non-English machine in the first place.

## Test plan

- [x] `dotnet build` — 0 warnings
- [x] `dotnet test` — 640 passed, 16 pre-existing skips, 0 failed
- [x] New `DisplayLanguageTests` cover the primary-language-id bitmask against real Windows LANGID values (en-US, en-GB, ja-JP, de-DE, fr-FR)
- [x] New `DoctorTests` cover the "Display language" result both ways
- [x] Manual smoke test against a real, Native AOT–published `wip.exe` on this (Japanese-locale Windows) machine: `wip doctor` reports `Display language: not English`, and a failing `wip up` prints the new note right after `wip: error: up failed (exit code 1)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rodvc77pcR2cbR3Z1VRkVG