### PR TITLE
Add opt-in --terminate-session to wip down

### DIFF
--- a/src/Wip.Cli/CliContext.cs
+++ b/src/Wip.Cli/CliContext.cs
@@ -372,7 +372,7 @@ internal sealed partial class CliContext
     /// <summary>
     /// <paramref name="terminateSession"/> is opt-in and never implied: <c>wslc system session
     /// terminate</c> resets the whole WSLC session, not anything scoped to this
-    /// <c>wip.yml</c> -- running it by default would silently take down unrelated containers
+    /// <c>wip.yml</c> — running it by default would silently take down unrelated containers
     /// from any other project currently using the same session. It runs regardless of which
     /// branch below removed this project's own containers.
     /// </summary>

--- a/src/Wip.Cli/CliContext.cs
+++ b/src/Wip.Cli/CliContext.cs
@@ -369,13 +369,29 @@ internal sealed partial class CliContext
         return 0;
     }
 
-    internal int Down()
+    /// <summary>
+    /// <paramref name="terminateSession"/> is opt-in and never implied: <c>wslc system session
+    /// terminate</c> resets the whole WSLC session, not anything scoped to this
+    /// <c>wip.yml</c> -- running it by default would silently take down unrelated containers
+    /// from any other project currently using the same session. It runs regardless of which
+    /// branch below removed this project's own containers.
+    /// </summary>
+    internal int Down(bool terminateSession = false)
     {
-        if (Config.IsCompose)
+        var code = Config.IsCompose ? DownCompose() : DownContainer();
+
+        if (terminateSession)
         {
-            return Execute(Bridge.Down(), exitOnFailure: false);
+            TerminateSession();
         }
 
+        return code;
+    }
+
+    private int DownCompose() => Execute(Bridge.Down(), exitOnFailure: false);
+
+    private int DownContainer()
+    {
         Execute(Builder.Remove(), exitOnFailure: false);
         foreach (var name in SidecarNames())
         {
@@ -383,6 +399,16 @@ internal sealed partial class CliContext
         }
 
         return 0;
+    }
+
+    /// <summary>
+    /// Best-effort, like the removes above it: a session that was already idle is not a reason
+    /// to fail <c>wip down</c> outright.
+    /// </summary>
+    private void TerminateSession()
+    {
+        Console.Error.WriteLine("wip: terminating WSLC session (--terminate-session)");
+        Execute(Builder.SystemSessionTerminate(), exitOnFailure: false);
     }
 
     /// <summary>

--- a/src/Wip.Cli/Program.cs
+++ b/src/Wip.Cli/Program.cs
@@ -309,7 +309,7 @@ internal static class Program
         var terminateSession = new Option<bool>("--terminate-session")
         {
             Description =
-                "Also run `wslc system session terminate` after removing containers -- resets " +
+                "Also run `wslc system session terminate` after removing containers — resets " +
                 "the whole WSLC session (every project sharing it, not just this one), which " +
                 "is otherwise a manual recovery step for a session-wide mounted-volume limit",
         };

--- a/src/Wip.Cli/Program.cs
+++ b/src/Wip.Cli/Program.cs
@@ -152,8 +152,7 @@ internal static class Program
 
         yield return Simple("stop", "Stop the configured container and its dependencies without removing them",
             context, ctx => ctx.Stop());
-        yield return Simple("down", "Stop and remove the configured container and its dependencies",
-            context, ctx => ctx.Down());
+        yield return DownCommand(context);
         yield return Simple("restart", "Restart the configured container or stack (stop, then start — no rebuild)",
             context, ctx => ctx.Restart());
 
@@ -302,6 +301,24 @@ internal static class Program
 
         var command = new Command("sync", "Mirror the source tree into the sync volume") { watch, interval };
         command.SetAction(parsed => context(parsed).Sync(parsed.GetValue(watch), parsed.GetValue(interval)));
+        return command;
+    }
+
+    private static Command DownCommand(Func<ParseResult, CliContext> context)
+    {
+        var terminateSession = new Option<bool>("--terminate-session")
+        {
+            Description =
+                "Also run `wslc system session terminate` after removing containers -- resets " +
+                "the whole WSLC session (every project sharing it, not just this one), which " +
+                "is otherwise a manual recovery step for a session-wide mounted-volume limit",
+        };
+
+        var command = new Command("down", "Stop and remove the configured container and its dependencies")
+        {
+            terminateSession,
+        };
+        command.SetAction(parsed => context(parsed).Down(parsed.GetValue(terminateSession)));
         return command;
     }
 

--- a/src/Wip.Core/Execution/CommandBuilder.cs
+++ b/src/Wip.Core/Execution/CommandBuilder.cs
@@ -127,6 +127,15 @@ public sealed class CommandBuilder
     public IReadOnlyList<string> NetworkList() => [wslc, "network", "list", "--format", "json"];
 
     /// <summary>
+    /// Tears down the whole WSLC session, not anything scoped to this <c>wip.yml</c> —
+    /// <see cref="Wip.Diagnostics.ErrorInterpreter"/> already points a user at this same
+    /// command by hand, as the recovery step for a session-wide mounted-volume limit. Every
+    /// other command in this file resolves a specific container or network first; this one
+    /// takes no argument at all, because there is nothing project-scoped about it.
+    /// </summary>
+    public IReadOnlyList<string> SystemSessionTerminate() => [wslc, "system", "session", "terminate"];
+
+    /// <summary>
     /// Mirrors into the volume from a throwaway container, for <c>sync.mode: run</c>. The
     /// image comes from <c>sync.build</c>'s tag, else <c>sync.image</c>, else the primary
     /// dependencies entry; compose mode requires one of the first two, since it has no

--- a/tests/Wip.Tests/CommandBuilderSystemSessionTests.cs
+++ b/tests/Wip.Tests/CommandBuilderSystemSessionTests.cs
@@ -1,0 +1,42 @@
+using Wip.Configuration;
+using Wip.Execution;
+using Wip.Platform;
+using Wip.Yaml;
+
+namespace Wip.Tests;
+
+/// <summary>
+/// Covers <see cref="CommandBuilder.SystemSessionTerminate"/>, the one command here that takes
+/// no argument at all: unlike every other builder method, it isn't scoped to a container or
+/// network this <c>wip.yml</c> names.
+/// </summary>
+public class CommandBuilderSystemSessionTests
+{
+    [Fact]
+    public void TerminatesTheSessionWithNoProjectSpecificArgument()
+    {
+        var config = new Config(YamlLoader.LoadText("""
+            version: 1
+            mode: container
+            container: app
+            dependencies:
+              app:
+                image: example
+            """, allowAliases: false));
+
+        var builder = new CommandBuilder("wslc.exe", config, new FakeEnvironment());
+
+        Assert.Equal(
+            new[] { "wslc.exe", "system", "session", "terminate" },
+            builder.SystemSessionTerminate());
+    }
+
+    private sealed class FakeEnvironment : IEnvironment
+    {
+        public bool IsInteractive => false;
+
+        public bool IsWsl2 => true;
+
+        public string Architecture => "linux/amd64";
+    }
+}


### PR DESCRIPTION
## Summary

Not related to #134's logging work (separate discussion). Adds an opt-in `--terminate-session` flag to `wip down` that also runs `wslc system session terminate` after removing this project's containers.

### Why opt-in, not automatic

`wslc system session terminate` resets the whole WSLC session — `ErrorInterpreter` already hands this exact command to users by hand as the recovery step for a session-wide mounted-volume limit (`src/Wip.Core/Diagnostics/ErrorInterpreter.cs`). We discussed wiring it into `wip down` automatically and decided against it:

- The session is shared across projects, so a default `terminate` on every `wip down` would silently kill unrelated containers from any other project currently using the same session (e.g. a second `wip up -d` running in another terminal).
- It adds session-restart latency to whichever project's next `wslc`/`wip up` happens to run next, not just this one.
- Running it silently makes the blast radius above invisible until something else breaks in a confusing way.

So it's opt-in via `--terminate-session`, best-effort (`exitOnFailure: false`, matching the container removes already in `Down()`), and announced on stderr (`wip: terminating WSLC session (--terminate-session)`) before it runs, so it's never a silent surprise.

### Changes

- `CommandBuilder.SystemSessionTerminate()` — `[wslc, "system", "session", "terminate"]`, the one builder method that takes no project-specific argument at all.
- `CliContext.Down(bool terminateSession = false)` — split into `DownCompose()`/`DownContainer()` plus the new opt-in step, runs regardless of which branch handled the actual container removal.
- `wip down --terminate-session` wired up in `Program.cs`.

## Test plan

- [x] `dotnet build` — 0 warnings
- [x] `dotnet test` — 621 passed, 16 pre-existing skips, 0 failed
- [x] New `CommandBuilderSystemSessionTests` covers the argv shape
- [x] Manual smoke test against a real `wslc.exe`: `wip down` alone leaves the session alone; `wip down --terminate-session` prints the notice and runs the terminate command after the container removes; `wip down --help` shows the new option

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rodvc77pcR2cbR3Z1VRkVG