### PR TITLE
fix(execution): return resolved executable paths

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.3.1</Version>
+    <Version>2.3.2</Version>
     <Authors>wip contributors</Authors>
     <Product>wip</Product>
     <Description>A developer-friendly CLI wrapper for Microsoft WSLC.</Description>

--- a/src/Wip.Core/Execution/CommandResolver.cs
+++ b/src/Wip.Core/Execution/CommandResolver.cs
@@ -19,32 +19,33 @@ public sealed class CommandResolver
     private readonly IReadOnlyList<string> candidates;
     private readonly string label;
     private readonly string installHint;
-    private readonly Func<string, bool> isExecutable;
+    private readonly Func<string, string?> resolveExecutable;
 
     public CommandResolver(
         IReadOnlyList<string>? candidates = null,
         string label = "WSLC",
         string? installHint = null,
-        Func<string, bool>? isExecutable = null)
+        Func<string, string?>? resolveExecutable = null)
     {
         this.candidates = candidates ?? DefaultCandidates;
         this.label = label;
         this.installHint = installHint ?? DefaultInstallHint;
-        this.isExecutable = isExecutable ?? IsExecutable;
+        this.resolveExecutable = resolveExecutable ?? ResolveExecutable;
     }
 
     public string Resolve(string configured = "auto")
     {
         if (configured != "auto")
         {
-            return isExecutable(configured) ? configured : throw NotFound([configured]);
+            return resolveExecutable(configured) ?? throw NotFound([configured]);
         }
 
         foreach (var candidate in candidates)
         {
-            if (isExecutable(candidate))
+            var resolved = resolveExecutable(candidate);
+            if (resolved is not null)
             {
-                return candidate;
+                return resolved;
             }
         }
 
@@ -53,12 +54,15 @@ public sealed class CommandResolver
 
     private static IReadOnlyList<string> BuildDefaultCandidates()
     {
-        var candidates = new List<string> { "wslc.exe", "wslc" };
+        var candidates = new List<string>();
         if (OperatingSystem.IsWindows())
         {
             candidates.Add(Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.System),
                 "wslc.exe"));
         }
+
+        candidates.Add("wslc.exe");
+        candidates.Add("wslc");
 
         return candidates;
     }
@@ -68,40 +72,52 @@ public sealed class CommandResolver
     /// PATH. On Windows an extensionless name is retried against each PATHEXT suffix, which
     /// is what lets a bare "wslc" resolve to wslc.exe.
     /// </summary>
-    private static bool IsExecutable(string command)
+    private static string? ResolveExecutable(string command)
     {
         if (command.Contains(Path.DirectorySeparatorChar) || command.Contains(Path.AltDirectorySeparatorChar))
         {
-            return FileExists(command);
+            return ResolveFile(command);
         }
 
         var path = System.Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
         foreach (var directory in path.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
         {
-            if (FileExists(Path.Combine(directory, command)))
+            var resolved = ResolveFile(Path.Combine(directory, command));
+            if (resolved is not null)
             {
-                return true;
+                return resolved;
             }
         }
 
-        return false;
+        return null;
     }
 
-    private static bool FileExists(string candidate)
+    private static string? ResolveFile(string candidate)
     {
-        if (File.Exists(candidate))
+        // Freeze relative paths before checking them so the returned value cannot be
+        // reinterpreted against a different working directory by the eventual caller.
+        var fullPath = Path.GetFullPath(candidate);
+        if (File.Exists(fullPath))
         {
-            return true;
+            return fullPath;
         }
 
         if (!OperatingSystem.IsWindows() || Path.HasExtension(candidate))
         {
-            return false;
+            return null;
         }
 
         var extensions = System.Environment.GetEnvironmentVariable("PATHEXT") ?? ".COM;.EXE;.BAT;.CMD";
-        return extensions.Split(';', StringSplitOptions.RemoveEmptyEntries)
-            .Any(extension => File.Exists(candidate + extension));
+        foreach (var extension in extensions.Split(';', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var extendedPath = Path.GetFullPath(candidate + extension);
+            if (File.Exists(extendedPath))
+            {
+                return extendedPath;
+            }
+        }
+
+        return null;
     }
 
     private CommandNotFoundException NotFound(IReadOnlyList<string> attempted) => new(

--- a/src/Wip.Core/Execution/CommandResolver.cs
+++ b/src/Wip.Core/Execution/CommandResolver.cs
@@ -37,12 +37,12 @@ public sealed class CommandResolver
     {
         if (configured != "auto")
         {
-            return resolveExecutable(configured) ?? throw NotFound([configured]);
+            return TryGetFullPath(resolveExecutable(configured)) ?? throw NotFound([configured]);
         }
 
         foreach (var candidate in candidates)
         {
-            var resolved = resolveExecutable(candidate);
+            var resolved = TryGetFullPath(resolveExecutable(candidate));
             if (resolved is not null)
             {
                 return resolved;
@@ -96,8 +96,8 @@ public sealed class CommandResolver
     {
         // Freeze relative paths before checking them so the returned value cannot be
         // reinterpreted against a different working directory by the eventual caller.
-        var fullPath = Path.GetFullPath(candidate);
-        if (File.Exists(fullPath))
+        var fullPath = TryGetFullPath(candidate);
+        if (fullPath is not null && File.Exists(fullPath))
         {
             return fullPath;
         }
@@ -110,14 +110,40 @@ public sealed class CommandResolver
         var extensions = System.Environment.GetEnvironmentVariable("PATHEXT") ?? ".COM;.EXE;.BAT;.CMD";
         foreach (var extension in extensions.Split(';', StringSplitOptions.RemoveEmptyEntries))
         {
-            var extendedPath = Path.GetFullPath(candidate + extension);
-            if (File.Exists(extendedPath))
+            var extendedPath = TryGetFullPath(candidate + extension);
+            if (extendedPath is not null && File.Exists(extendedPath))
             {
                 return extendedPath;
             }
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Normalizes a candidate against the current working directory, including one produced
+    /// by an injected resolver, so a later directory change cannot reinterpret it. A path the
+    /// runtime refuses to normalize (invalid characters, too long, unsupported format) counts
+    /// as unresolved, keeping <see cref="CommandNotFoundException"/> the only failure callers
+    /// have to handle.
+    /// </summary>
+    private static string? TryGetFullPath(string? candidate)
+    {
+        if (candidate is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return Path.GetFullPath(candidate);
+        }
+        catch (Exception exception)
+            when (exception is ArgumentException or IOException or NotSupportedException
+                or System.Security.SecurityException)
+        {
+            return null;
+        }
     }
 
     private CommandNotFoundException NotFound(IReadOnlyList<string> attempted) => new(

--- a/tests/Wip.Tests/CommandResolverTests.cs
+++ b/tests/Wip.Tests/CommandResolverTests.cs
@@ -119,15 +119,32 @@ public sealed class CommandResolverTests
         }
     }
 
+    [Fact]
+    public void ResolveNormalizesRelativePathReturnedByExecutableResolver()
+    {
+        var relative = Path.Combine("tools", "wslc");
+        var resolver = new CommandResolver(["wslc"], resolveExecutable: candidate =>
+            candidate == "wslc" ? relative : null);
+
+        var resolved = resolver.Resolve();
+
+        Assert.Equal(Path.GetFullPath(relative), resolved);
+        Assert.True(Path.IsPathFullyQualified(resolved));
+    }
+
+    [Fact]
+    public void UnnormalizableCandidateReportsCommandNotFoundInsteadOfThrowingIoException()
+    {
+        var resolver = new CommandResolver([]);
+
+        Assert.Throws<CommandNotFoundException>(() => resolver.Resolve(Path.Combine("bin", "to\0ol")));
+    }
+
     private sealed class TemporaryDirectory : IDisposable
     {
-        public TemporaryDirectory()
-        {
-            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"wip-{Guid.NewGuid():N}");
-            Directory.CreateDirectory(Path);
-        }
+        internal TemporaryDirectory() => Path = Directory.CreateTempSubdirectory("wip-resolver-test-").FullName;
 
-        public string Path { get; }
+        internal string Path { get; }
 
         public void Dispose() => Directory.Delete(Path, recursive: true);
     }

--- a/tests/Wip.Tests/CommandResolverTests.cs
+++ b/tests/Wip.Tests/CommandResolverTests.cs
@@ -1,0 +1,137 @@
+using Wip.Execution;
+
+namespace Wip.Tests;
+
+[Collection("Environment variables")]
+public sealed class CommandResolverTests
+{
+    [Fact]
+    public void ResolveReturnsAbsolutePathForExecutableFoundOnPath()
+    {
+        using var directory = new TemporaryDirectory();
+        var commandName = "wip-command-resolver-test";
+        var executable = Path.Combine(directory.Path, commandName);
+        File.WriteAllText(executable, string.Empty);
+
+        var originalPath = Environment.GetEnvironmentVariable("PATH");
+        try
+        {
+            Environment.SetEnvironmentVariable("PATH", directory.Path);
+
+            var resolved = new CommandResolver([commandName]).Resolve();
+
+            Assert.Equal(Path.GetFullPath(executable), resolved);
+            Assert.True(Path.IsPathFullyQualified(resolved));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PATH", originalPath);
+        }
+    }
+
+    [Fact]
+    public void ResolveReturnsPathProducedByExecutableResolver()
+    {
+        var actual = Path.GetFullPath(Path.Combine("tools", "wslc.EXE"));
+        var resolver = new CommandResolver(["wslc"], resolveExecutable: candidate =>
+            candidate == "wslc" ? actual : null);
+
+        Assert.Equal(actual, resolver.Resolve());
+    }
+
+    [Fact]
+    public void ResolveReturnsPathextCompletedFileNameOnWindows()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var directory = new TemporaryDirectory();
+        var executable = Path.Combine(directory.Path, "wip-pathext-test.WIPTEST");
+        File.WriteAllText(executable, string.Empty);
+        var originalPath = Environment.GetEnvironmentVariable("PATH");
+        var originalPathext = Environment.GetEnvironmentVariable("PATHEXT");
+        try
+        {
+            Environment.SetEnvironmentVariable("PATH", directory.Path);
+            Environment.SetEnvironmentVariable("PATHEXT", ".WIPTEST");
+
+            var resolved = new CommandResolver(["wip-pathext-test"]).Resolve();
+
+            Assert.Equal(Path.GetFullPath(executable), resolved);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PATH", originalPath);
+            Environment.SetEnvironmentVariable("PATHEXT", originalPathext);
+        }
+    }
+
+    [Fact]
+    public void ResolvedPathIsNotReplacedBySameNamedFileInNewWorkingDirectory()
+    {
+        using var pathDirectory = new TemporaryDirectory();
+        using var workingDirectory = new TemporaryDirectory();
+        const string commandName = "wip-stable-resolution-test";
+        var pathExecutable = Path.Combine(pathDirectory.Path, commandName);
+        File.WriteAllText(pathExecutable, "PATH");
+        File.WriteAllText(Path.Combine(workingDirectory.Path, commandName), "working directory");
+        var originalPath = Environment.GetEnvironmentVariable("PATH");
+        var originalDirectory = Environment.CurrentDirectory;
+        try
+        {
+            Environment.SetEnvironmentVariable("PATH", pathDirectory.Path);
+            var resolved = new CommandResolver([commandName]).Resolve();
+            Environment.CurrentDirectory = workingDirectory.Path;
+
+            Assert.Equal(Path.GetFullPath(pathExecutable), resolved);
+            Assert.Equal("PATH", File.ReadAllText(resolved));
+        }
+        finally
+        {
+            Environment.CurrentDirectory = originalDirectory;
+            Environment.SetEnvironmentVariable("PATH", originalPath);
+        }
+    }
+
+    [Fact]
+    public void ExplicitRelativePathIsFrozenAsAbsolutePath()
+    {
+        using var directory = new TemporaryDirectory();
+        var originalDirectory = Environment.CurrentDirectory;
+        try
+        {
+            Environment.CurrentDirectory = directory.Path;
+            var relative = Path.Combine("bin", "tool");
+            Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(relative))!);
+            File.WriteAllText(relative, string.Empty);
+
+            var resolved = new CommandResolver([]).Resolve(relative);
+            Environment.CurrentDirectory = originalDirectory;
+
+            Assert.Equal(Path.Combine(directory.Path, "bin", "tool"), resolved);
+            Assert.True(File.Exists(resolved));
+        }
+        finally
+        {
+            Environment.CurrentDirectory = originalDirectory;
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        public TemporaryDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"wip-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose() => Directory.Delete(Path, recursive: true);
+    }
+}
+
+[CollectionDefinition("Environment variables", DisableParallelization = true)]
+public sealed class EnvironmentVariablesCollection;


### PR DESCRIPTION
### Motivation

- Make `CommandResolver` return a normalized absolute path for a found executable rather than a boolean so callers receive the actual, stable file to run. 
- Prevent resolution from being affected by later working-directory changes or by losing PATHEXT-completed filenames on Windows. 

### Description

- Replace the `Func<string,bool> isExecutable` dependency with `Func<string,string?> resolveExecutable` and update `Resolve` to return the resolved path from that function. 
- Implement `ResolveExecutable` and `ResolveFile` which call `Path.GetFullPath` to freeze relative candidates and on Windows iterate `PATHEXT` to return the actual existing filename's absolute path. 
- Adjust `BuildDefaultCandidates` to place the System32 `wslc.exe` candidate first on Windows while still keeping `wslc.exe`/`wslc` in the default list. 
- Add `tests/Wip.Tests/CommandResolverTests.cs` covering PATH resolution returning absolute paths, PATHEXT completion on Windows, protection against resolution being replaced by same-named files in a changed working directory, and freezing explicit relative paths, and bump project version to `2.3.2` in `Directory.Build.props`. 

### Testing

- Ran `git diff --check` which succeeded. 
- Attempted `dotnet test tests/Wip.Tests/Wip.Tests.csproj --no-restore` but the command could not be executed because `dotnet` is not available in the environment. 
- New unit tests were added (see `tests/Wip.Tests/CommandResolverTests.cs`) but were not executed in this environment due to the missing `dotnet` runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a974fe9990083229811ce116bb96ddd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved executable discovery across configured paths and Windows environments.
  - Explicit and relative executable paths are now resolved consistently to stable absolute paths.
  - Invalid executable candidates now report a command-not-found error.
  - Improved command selection order on Windows for more reliable execution.

- **Tests**
  - Added coverage for path normalization and invalid executable handling.

- **Release**
  - Updated the project version to 2.3.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->