### PR TITLE
fix(yaml): bound configuration resource usage

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.3.1</Version>
+    <Version>2.3.2</Version>
     <Authors>wip contributors</Authors>
     <Product>wip</Product>
     <Description>A developer-friendly CLI wrapper for Microsoft WSLC.</Description>

--- a/src/Wip.Core/Yaml/YamlLoader.cs
+++ b/src/Wip.Core/Yaml/YamlLoader.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 
@@ -26,10 +27,29 @@ public static class YamlLoader
     // Configuration files do not need arbitrary structural depth. Bounding recursion keeps
     // a malicious repository from turning `wip` startup into a stack-overflow crash.
     private const int MaxNestingDepth = 100;
+
+    /// <summary>Largest accepted document, in UTF-8 bytes, for both file and text input.</summary>
     internal const int MaxInputSize = 1024 * 1024;
+
+    /// <summary>Largest number of nodes one document may parse into.</summary>
     internal const int MaxTotalNodes = 150_000;
+
+    /// <summary>Largest accepted scalar, in characters.</summary>
     internal const int MaxScalarLength = 256 * 1024;
+
+    /// <summary>Largest number of elements one sequence or mapping may hold.</summary>
     internal const int MaxCollectionElements = 50_000;
+
+    /// <summary>
+    /// Largest number of entries <c>&lt;&lt;</c> merges may copy across one document.
+    /// </summary>
+    /// <remarks>
+    /// Aliases make a merge source shareable, so the node limits alone do not bound merge work:
+    /// <c>&lt;&lt;: [*big, *big, ...]</c> costs one node per copy but copies the whole source
+    /// each time, and repeating that across mappings multiplies it again. The copies are what
+    /// has to be budgeted.
+    /// </remarks>
+    internal const int MaxMergeEntries = 1_000_000;
 
     public static object? LoadFile(string path, bool allowAliases)
     {
@@ -47,9 +67,12 @@ public static class YamlLoader
 
     public static object? LoadText(string text, bool allowAliases, string path = "<text>")
     {
-        if (text.Length > MaxInputSize)
+        // Measured in UTF-8 bytes rather than UTF-16 code units so text and file input are held
+        // to the same bound: a document of non-ASCII characters is up to three times the size
+        // its character count suggests.
+        if (Encoding.UTF8.GetByteCount(text) > MaxInputSize)
         {
-            throw LimitExceeded(path, "input length", MaxInputSize);
+            throw LimitExceeded(path, "input size", MaxInputSize);
         }
 
         using var reader = new StringReader(text);
@@ -216,7 +239,7 @@ public static class YamlLoader
             var value = ReadNode(parser, allowAliases, anchors, pending, state, path, depth + 1);
             var name = RubyValue.ToStringValue(key);
 
-            if (name == MergeKey && TryMerge(mapping, value))
+            if (name == MergeKey && TryMerge(mapping, value, state, path))
             {
                 continue;
             }
@@ -244,11 +267,15 @@ public static class YamlLoader
     /// A sequence of mappings is merged back to front, which is what makes earlier entries
     /// take precedence over later ones.
     /// </remarks>
-    private static bool TryMerge(OrderedDictionary<string, object?> target, object? value)
+    private static bool TryMerge(
+        OrderedDictionary<string, object?> target,
+        object? value,
+        LoadState state,
+        string path)
     {
         if (RubyValue.AsMapping(value) is { } single)
         {
-            MergeInto(target, single);
+            MergeInto(target, single, state, path);
             return true;
         }
 
@@ -260,7 +287,7 @@ public static class YamlLoader
 
         for (var index = sequence.Count - 1; index >= 0; index--)
         {
-            MergeInto(target, RubyValue.AsMapping(sequence[index])!);
+            MergeInto(target, RubyValue.AsMapping(sequence[index])!, state, path);
         }
 
         return true;
@@ -270,8 +297,18 @@ public static class YamlLoader
     /// An existing key keeps its position but takes the new value; a new key is appended.
     /// Position matters because it becomes the order of the generated command line.
     /// </summary>
-    private static void MergeInto(OrderedDictionary<string, object?> target, OrderedDictionary<string, object?> source)
+    private static void MergeInto(
+        OrderedDictionary<string, object?> target,
+        OrderedDictionary<string, object?> source,
+        LoadState state,
+        string path)
     {
+        state.MergedEntries += source.Count;
+        if (state.MergedEntries > MaxMergeEntries)
+        {
+            throw LimitExceeded(path, "merge expansion", MaxMergeEntries);
+        }
+
         foreach (var (key, value) in source)
         {
             target[key] = value;
@@ -310,14 +347,24 @@ public static class YamlLoader
         }
     }
 
+    /// <summary>Names the limit and its value, so a caller can say what to shrink.</summary>
     private static ConfigException LimitExceeded(string path, string limit, int maximum) =>
         new($"Could not parse {path}: YAML {limit} exceeds the limit of {maximum}");
 
+    /// <summary>Counters that span a whole document rather than a single node.</summary>
     private sealed class LoadState
     {
+        /// <summary>Nodes parsed so far, bounded by <see cref="MaxTotalNodes"/>.</summary>
         public int NodeCount { get; set; }
+
+        /// <summary>Entries copied by merges so far, bounded by <see cref="MaxMergeEntries"/>.</summary>
+        public int MergedEntries { get; set; }
     }
 
+    /// <summary>
+    /// Stops reading past the byte maximum it is given, so a file that grows between the
+    /// <see cref="FileInfo.Length"/> check and the read still cannot exceed the bound.
+    /// </summary>
     private sealed class LimitedReadStream(Stream inner, int maximum, string path) : Stream
     {
         private int bytesRead;

--- a/src/Wip.Core/Yaml/YamlLoader.cs
+++ b/src/Wip.Core/Yaml/YamlLoader.cs
@@ -26,15 +26,32 @@ public static class YamlLoader
     // Configuration files do not need arbitrary structural depth. Bounding recursion keeps
     // a malicious repository from turning `wip` startup into a stack-overflow crash.
     private const int MaxNestingDepth = 100;
+    internal const int MaxInputSize = 1024 * 1024;
+    internal const int MaxTotalNodes = 150_000;
+    internal const int MaxScalarLength = 256 * 1024;
+    internal const int MaxCollectionElements = 50_000;
 
     public static object? LoadFile(string path, bool allowAliases)
     {
-        using var reader = new StreamReader(path);
+        var length = new FileInfo(path).Length;
+        if (length > MaxInputSize)
+        {
+            throw LimitExceeded(path, "file size", MaxInputSize);
+        }
+
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+        using var limitedStream = new LimitedReadStream(stream, MaxInputSize, path);
+        using var reader = new StreamReader(limitedStream);
         return Load(reader, allowAliases, path);
     }
 
     public static object? LoadText(string text, bool allowAliases, string path = "<text>")
     {
+        if (text.Length > MaxInputSize)
+        {
+            throw LimitExceeded(path, "input length", MaxInputSize);
+        }
+
         using var reader = new StringReader(text);
         return Load(reader, allowAliases, path);
     }
@@ -44,6 +61,7 @@ public static class YamlLoader
         var parser = new Parser(reader);
         var anchors = new Dictionary<string, object?>(StringComparer.Ordinal);
         var pending = new HashSet<string>(StringComparer.Ordinal);
+        var state = new LoadState();
 
         try
         {
@@ -54,7 +72,7 @@ public static class YamlLoader
             }
 
             parser.Consume<DocumentStart>();
-            var value = ReadNode(parser, allowAliases, anchors, pending, path, depth: 0);
+            var value = ReadNode(parser, allowAliases, anchors, pending, state, path, depth: 0);
             parser.Consume<DocumentEnd>();
             return value;
         }
@@ -69,6 +87,7 @@ public static class YamlLoader
         bool allowAliases,
         Dictionary<string, object?> anchors,
         HashSet<string> pending,
+        LoadState state,
         string path,
         int depth)
     {
@@ -76,6 +95,12 @@ public static class YamlLoader
         {
             throw new ConfigException(
                 $"Could not parse {path}: YAML nesting exceeds the limit of {MaxNestingDepth}");
+        }
+
+        state.NodeCount++;
+        if (state.NodeCount > MaxTotalNodes)
+        {
+            throw LimitExceeded(path, "total node count", MaxTotalNodes);
         }
 
         if (parser.Accept<AnchorAlias>(out var alias))
@@ -87,19 +112,23 @@ public static class YamlLoader
         if (parser.Accept<Scalar>(out var scalar))
         {
             parser.MoveNext();
-            var value = YamlScalarResolver.Resolve(scalar!.Value, scalar.Style);
+            if (scalar!.Value.Length > MaxScalarLength)
+            {
+                throw LimitExceeded(path, "scalar length", MaxScalarLength);
+            }
+            var value = YamlScalarResolver.Resolve(scalar.Value, scalar.Style);
             Remember(scalar.Anchor, value, anchors);
             return value;
         }
 
         if (parser.Accept<SequenceStart>(out var sequenceStart))
         {
-            return ReadSequence(parser, allowAliases, anchors, pending, path, sequenceStart!.Anchor, depth);
+            return ReadSequence(parser, allowAliases, anchors, pending, state, path, sequenceStart!.Anchor, depth);
         }
 
         if (parser.Accept<MappingStart>(out var mappingStart))
         {
-            return ReadMapping(parser, allowAliases, anchors, pending, path, mappingStart!.Anchor, depth);
+            return ReadMapping(parser, allowAliases, anchors, pending, state, path, mappingStart!.Anchor, depth);
         }
 
         throw new ConfigException($"Could not parse {path}: unexpected {parser.Current?.GetType().Name}");
@@ -138,6 +167,7 @@ public static class YamlLoader
         bool allowAliases,
         Dictionary<string, object?> anchors,
         HashSet<string> pending,
+        LoadState state,
         string path,
         AnchorName anchor,
         int depth)
@@ -148,7 +178,11 @@ public static class YamlLoader
 
         while (!parser.Accept<SequenceEnd>(out _))
         {
-            items.Add(ReadNode(parser, allowAliases, anchors, pending, path, depth + 1));
+            if (items.Count >= MaxCollectionElements)
+            {
+                throw LimitExceeded(path, "sequence element count", MaxCollectionElements);
+            }
+            items.Add(ReadNode(parser, allowAliases, anchors, pending, state, path, depth + 1));
         }
 
         parser.Consume<SequenceEnd>();
@@ -161,6 +195,7 @@ public static class YamlLoader
         bool allowAliases,
         Dictionary<string, object?> anchors,
         HashSet<string> pending,
+        LoadState state,
         string path,
         AnchorName anchor,
         int depth)
@@ -168,11 +203,17 @@ public static class YamlLoader
         parser.Consume<MappingStart>();
         var mapping = new OrderedDictionary<string, object?>(StringComparer.Ordinal);
         Track(anchor, pending);
+        var elementCount = 0;
 
         while (!parser.Accept<MappingEnd>(out _))
         {
-            var key = ReadNode(parser, allowAliases, anchors, pending, path, depth + 1);
-            var value = ReadNode(parser, allowAliases, anchors, pending, path, depth + 1);
+            if (elementCount >= MaxCollectionElements)
+            {
+                throw LimitExceeded(path, "mapping element count", MaxCollectionElements);
+            }
+            elementCount++;
+            var key = ReadNode(parser, allowAliases, anchors, pending, state, path, depth + 1);
+            var value = ReadNode(parser, allowAliases, anchors, pending, state, path, depth + 1);
             var name = RubyValue.ToStringValue(key);
 
             if (name == MergeKey && TryMerge(mapping, value))
@@ -267,5 +308,38 @@ public static class YamlLoader
         {
             anchors[anchor.ToString()] = value;
         }
+    }
+
+    private static ConfigException LimitExceeded(string path, string limit, int maximum) =>
+        new($"Could not parse {path}: YAML {limit} exceeds the limit of {maximum}");
+
+    private sealed class LoadState
+    {
+        public int NodeCount { get; set; }
+    }
+
+    private sealed class LimitedReadStream(Stream inner, int maximum, string path) : Stream
+    {
+        private int bytesRead;
+        public override bool CanRead => inner.CanRead;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => inner.Length;
+        public override long Position { get => inner.Position; set => throw new NotSupportedException(); }
+        public override void Flush() => inner.Flush();
+        public override int Read(byte[] buffer, int offset, int count) => Check(inner.Read(buffer, offset, count));
+        public override int Read(Span<byte> buffer) => Check(inner.Read(buffer));
+        private int Check(int count)
+        {
+            bytesRead += count;
+            if (bytesRead > maximum)
+            {
+                throw LimitExceeded(path, "file size", maximum);
+            }
+            return count;
+        }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
 }

--- a/tests/Wip.Tests/YamlLoaderSecurityTests.cs
+++ b/tests/Wip.Tests/YamlLoaderSecurityTests.cs
@@ -93,8 +93,44 @@ public class YamlLoaderSecurityTests
         File.WriteAllText(path, oversized);
         var fileException = Assert.Throws<ConfigException>(() => YamlLoader.LoadFile(path, allowAliases: false));
 
-        Assert.Contains($"input length exceeds the limit of {YamlLoader.MaxInputSize}", textException.Message);
+        Assert.Contains($"input size exceeds the limit of {YamlLoader.MaxInputSize}", textException.Message);
         Assert.Contains($"file size exceeds the limit of {YamlLoader.MaxInputSize}", fileException.Message);
+    }
+
+    [Fact]
+    public void RejectsTextThatOnlyExceedsTheLimitInUtf8Bytes()
+    {
+        // Three bytes per character in UTF-8, so this is over the byte limit while its
+        // character count stays well under it.
+        var yaml = new string('\u3042', (YamlLoader.MaxInputSize / 3) + 1);
+
+        var exception = Assert.Throws<ConfigException>(
+            () => YamlLoader.LoadText(yaml, allowAliases: false, path: "text.yml"));
+
+        Assert.Contains($"input size exceeds the limit of {YamlLoader.MaxInputSize}", exception.Message);
+    }
+
+    [Fact]
+    public void RejectsMergeExpansionOverTheLimit()
+    {
+        var yaml = MergeDocument((YamlLoader.MaxMergeEntries / MergeSourceKeys) + 1);
+
+        var exception = Assert.Throws<ConfigException>(
+            () => YamlLoader.LoadText(yaml, allowAliases: true, path: "merge.yml"));
+
+        Assert.Contains($"merge expansion exceeds the limit of {YamlLoader.MaxMergeEntries}", exception.Message);
+    }
+
+    [Fact]
+    public void AcceptsMergeExpansionAtTheLimit()
+    {
+        var yaml = MergeDocument(YamlLoader.MaxMergeEntries / MergeSourceKeys);
+
+        var value = Assert.IsType<OrderedDictionary<string, object?>>(
+            YamlLoader.LoadText(yaml, allowAliases: true, path: "merge.yml"));
+        var target = Assert.IsType<OrderedDictionary<string, object?>>(value["target"]);
+
+        Assert.Equal(MergeSourceKeys, target.Count);
     }
 
     [Fact]
@@ -121,6 +157,19 @@ public class YamlLoaderSecurityTests
         var compose = ComposeFile.Load(path);
 
         Assert.Equal(["app", "worker"], compose.ServiceNamesInDependencyOrder);
+    }
+
+    private const int MergeSourceKeys = 1_000;
+
+    /// <summary>
+    /// A merge that costs one node per copy but copies <see cref="MergeSourceKeys"/> entries
+    /// each time — the shape the node limits alone do not bound.
+    /// </summary>
+    private static string MergeDocument(int copies)
+    {
+        var source = string.Concat(Enumerable.Range(0, MergeSourceKeys).Select(index => $"  k{index}: {index}\n"));
+        var aliases = string.Join(", ", Enumerable.Repeat("*source", copies));
+        return $"source: &source\n{source}target:\n  <<: [{aliases}]\n";
     }
 
     private sealed class TemporaryDirectory : IDisposable

--- a/tests/Wip.Tests/YamlLoaderSecurityTests.cs
+++ b/tests/Wip.Tests/YamlLoaderSecurityTests.cs
@@ -1,3 +1,4 @@
+using Wip.Compose;
 using Wip.Yaml;
 
 namespace Wip.Tests;
@@ -23,5 +24,109 @@ public class YamlLoaderSecurityTests
         var yaml = $"{new string('[', 100)}null{new string(']', 100)}";
 
         Assert.NotNull(YamlLoader.LoadText(yaml, allowAliases: false));
+    }
+
+    [Fact]
+    public void RejectsScalarOverTheLimit()
+    {
+        var yaml = new string('a', YamlLoader.MaxScalarLength + 1);
+
+        var exception = Assert.Throws<ConfigException>(
+            () => YamlLoader.LoadText(yaml, allowAliases: false, path: "scalar.yml"));
+
+        Assert.Contains("scalar.yml", exception.Message);
+        Assert.Contains($"scalar length exceeds the limit of {YamlLoader.MaxScalarLength}", exception.Message);
+    }
+
+    [Fact]
+    public void RejectsTooManyShallowSequenceElements()
+    {
+        var yaml = $"[{string.Join(',', Enumerable.Repeat("0", YamlLoader.MaxCollectionElements + 1))}]";
+
+        var exception = Assert.Throws<ConfigException>(
+            () => YamlLoader.LoadText(yaml, allowAliases: false, path: "sequence.yml"));
+
+        Assert.Contains($"sequence element count exceeds the limit of {YamlLoader.MaxCollectionElements}", exception.Message);
+    }
+
+    [Fact]
+    public void RejectsTooManyMappingElements()
+    {
+        var yaml = string.Concat(Enumerable.Range(0, YamlLoader.MaxCollectionElements + 1)
+            .Select(index => $"k{index}: 0\n"));
+
+        var exception = Assert.Throws<ConfigException>(
+            () => YamlLoader.LoadText(yaml, allowAliases: false, path: "mapping.yml"));
+
+        Assert.Contains($"mapping element count exceeds the limit of {YamlLoader.MaxCollectionElements}", exception.Message);
+    }
+
+    [Fact]
+    public void RejectsTooManyNodesAcrossSmallCollections()
+    {
+        var group = $"[{string.Join(',', Enumerable.Repeat("[]", 40_000))}]";
+        var yaml = $"[{group},{group},{group},{group}]";
+
+        var exception = Assert.Throws<ConfigException>(
+            () => YamlLoader.LoadText(yaml, allowAliases: false, path: "nodes.yml"));
+
+        Assert.Contains($"total node count exceeds the limit of {YamlLoader.MaxTotalNodes}", exception.Message);
+    }
+
+    [Fact]
+    public void AcceptsScalarAtTheLimit()
+    {
+        var yaml = new string('a', YamlLoader.MaxScalarLength);
+
+        Assert.Equal(yaml, YamlLoader.LoadText(yaml, allowAliases: false));
+    }
+
+    [Fact]
+    public void RejectsOversizedTextAndFileInputs()
+    {
+        var oversized = new string('#', YamlLoader.MaxInputSize + 1);
+        var textException = Assert.Throws<ConfigException>(
+            () => YamlLoader.LoadText(oversized, allowAliases: false, path: "text.yml"));
+
+        using var directory = new TemporaryDirectory();
+        var path = Path.Combine(directory.Path, "large.yml");
+        File.WriteAllText(path, oversized);
+        var fileException = Assert.Throws<ConfigException>(() => YamlLoader.LoadFile(path, allowAliases: false));
+
+        Assert.Contains($"input length exceeds the limit of {YamlLoader.MaxInputSize}", textException.Message);
+        Assert.Contains($"file size exceeds the limit of {YamlLoader.MaxInputSize}", fileException.Message);
+    }
+
+    [Fact]
+    public void AcceptsNormalWipFileAtTheInputBoundary()
+    {
+        const string document = "container: app\n";
+        var yaml = document + new string('#', YamlLoader.MaxInputSize - document.Length);
+
+        var value = Assert.IsType<OrderedDictionary<string, object?>>(
+            YamlLoader.LoadText(yaml, allowAliases: false, path: "wip.yml"));
+
+        Assert.Equal("app", value["container"]);
+    }
+
+    [Fact]
+    public void AcceptsComposeFileWithAliasesAtTheFileBoundary()
+    {
+        const string document = "services:\n  app: &app\n    image: example:latest\n  worker:\n    <<: *app\n";
+        var yaml = document + new string('#', YamlLoader.MaxInputSize - document.Length);
+        using var directory = new TemporaryDirectory();
+        var path = Path.Combine(directory.Path, "compose.yml");
+        File.WriteAllText(path, yaml);
+
+        var compose = ComposeFile.Load(path);
+
+        Assert.Equal(["app", "worker"], compose.ServiceNamesInDependencyOrder);
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        public TemporaryDirectory() => Path = Directory.CreateTempSubdirectory("wip-yaml-test-").FullName;
+        public string Path { get; }
+        public void Dispose() => Directory.Delete(Path, recursive: true);
     }
 }


### PR DESCRIPTION
### Motivation

- Prevent untrusted or malformed YAML from exhausting CPU/memory by bounding input size, total parsed nodes, scalar length, and collection element counts.
- Fail early with a path-aware error when limits are exceeded so callers can surface actionable messages instead of crashing or hanging.
- Apply the same protections to both file-based and in-memory text inputs and keep valid wip/Compose files working at the boundary.

### Description

- Introduce runtime limits and constants: `MaxInputSize`, `MaxTotalNodes`, `MaxScalarLength`, and `MaxCollectionElements` in `src/Wip.Core/Yaml/YamlLoader.cs` and wire them into the loader.
- Check `FileInfo.Length` before opening streams in `LoadFile`, and enforce a streaming byte limit via a `LimitedReadStream` while reading; apply `MaxInputSize` to `LoadText` as well.
- Add a `LoadState` node counter that is passed to `ReadNode` and incremented per parsed node, and validate `MaxTotalNodes`; validate scalar length on scalar events and enforce per-collection element limits in `ReadSequence` and `ReadMapping`.
- Emit a path-aware `ConfigException` via a new helper `LimitExceeded` when any limit is exceeded, add security-focused unit tests in `tests/Wip.Tests/YamlLoaderSecurityTests.cs`, and bump the package version to `2.3.2`.

### Testing

- Ran `git diff --check` to validate the patch formatting and it passed.
- Added unit tests in `tests/Wip.Tests/YamlLoaderSecurityTests.cs` covering oversized scalar, excessive sequence/mapping elements, total node count, oversized text/file inputs, boundary acceptance of normal `wip.yml`, and alias-enabled Compose file at the input boundary; these tests were added but not executed in this environment because `dotnet` is not available here (`dotnet test --no-restore` could not be run).
- Attempted to use the local PR helper tooling to record the PR metadata but the helper could not complete due to environment/network constraints; this does not affect the code changes or the added tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a97501c85188322832f9ddc8576d169)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safeguards for YAML input size, scalar length, collection size, total node count, and merge expansion.
  * Oversized or overly complex YAML files and text inputs are now rejected with clear limit errors.
  * Valid files at supported boundaries, including files using aliases, continue to load successfully.

* **Tests**
  * Added coverage for YAML security limits and boundary conditions.

* **Chores**
  * Updated the project version to 2.3.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->