### PR TITLE
feat(ai): secure AI endpoint usage and require explicit remote approval

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.3.1</Version>
+    <Version>2.4.0</Version>
     <Authors>wip contributors</Authors>
     <Product>wip</Product>
     <Description>A developer-friendly CLI wrapper for Microsoft WSLC.</Description>

--- a/src/Wip.Cli/CliContext.cs
+++ b/src/Wip.Cli/CliContext.cs
@@ -136,7 +136,12 @@ internal sealed partial class CliContext
         }
     }
 
-    internal int Init(bool force, string? template, bool ai = false, string? url = null)
+    internal int Init(
+        bool force,
+        string? template,
+        bool ai = false,
+        string? url = null,
+        bool allowRemoteAi = false)
     {
         var path = Path.GetFullPath(options.ConfigPath ?? ConfigLoader.Filename);
         if (ai)
@@ -146,12 +151,17 @@ internal sealed partial class CliContext
                 throw new WipException("--template cannot be combined with --ai");
             }
 
-            return InitWithAi(path, url);
+            return InitWithAi(path, url, allowRemoteAi);
         }
 
         if (url is not null)
         {
             throw new WipException("--url requires --ai");
+        }
+
+        if (allowRemoteAi)
+        {
+            throw new WipException("--allow-remote-ai requires --ai");
         }
 
         if (File.Exists(path) && !force)
@@ -165,16 +175,19 @@ internal sealed partial class CliContext
         return 0;
     }
 
-    private static int InitWithAi(string path, string? url)
+    private static int InitWithAi(string path, string? url, bool allowRemoteAi)
     {
         var baseUrl = LocalAiProvider.ResolveBaseUrl(url);
-        if (!LocalAiProvider.IsAvailable(baseUrl))
+        var endpoint = LocalAiProvider.ValidateBaseUrl(baseUrl, allowRemoteAi);
+        RequireRemoteApproval(endpoint, allowRemoteAi);
+        if (!LocalAiProvider.IsAvailable(baseUrl, allowRemoteAi))
         {
             throw new WipException(
                 $"{LocalAiProvider.NotFoundMessage(baseUrl)} Run `wip doctor` to check again.");
         }
 
-        var model = LocalAiProvider.ResolveModel() ?? LocalAiProvider.DiscoverModel(baseUrl);
+        var model = LocalAiProvider.ResolveModel() ?? LocalAiProvider.DiscoverModel(
+            baseUrl, allowInsecureRemoteHttp: allowRemoteAi);
 
         var directory = Path.GetDirectoryName(path) ?? Directory.GetCurrentDirectory();
         Console.Error.WriteLine(
@@ -190,8 +203,16 @@ internal sealed partial class CliContext
         var existing = File.Exists(path) ? File.ReadAllText(path) : null;
         Log.Info($"analyzing {directory}");
         var project = new ProjectAnalyzer(directory).Analyze();
+        Console.Error.WriteLine($"AI destination: {endpoint.Host} ({endpoint.Scheme.ToUpperInvariant()})");
+        Console.Error.WriteLine("Files to send:");
+        foreach (var file in project.Files)
+        {
+            Console.Error.WriteLine($"  - {file.RelativePath}");
+        }
+
         Log.Info($"sending {project.Files.Count} selected project files to {model} at {baseUrl}");
-        var candidate = new WipAiGenerator(new LocalAiProvider(baseUrl, model)).Generate(
+        var candidate = new WipAiGenerator(
+            new LocalAiProvider(baseUrl, model, allowInsecureRemoteHttp: allowRemoteAi)).Generate(
             string.Join(System.Environment.NewLine, lines), project, existing, path);
 
         Console.WriteLine(candidate);
@@ -211,16 +232,19 @@ internal sealed partial class CliContext
         return 0;
     }
 
-    internal int HelpAi(string? url, IReadOnlyList<string> question)
+    internal int HelpAi(string? url, IReadOnlyList<string> question, bool allowRemoteAi = false)
     {
         var baseUrl = LocalAiProvider.ResolveBaseUrl(url);
-        if (!LocalAiProvider.IsAvailable(baseUrl))
+        var endpoint = LocalAiProvider.ValidateBaseUrl(baseUrl, allowRemoteAi);
+        RequireRemoteApproval(endpoint, allowRemoteAi);
+        if (!LocalAiProvider.IsAvailable(baseUrl, allowRemoteAi))
         {
             throw new WipException(
                 $"{LocalAiProvider.NotFoundMessage(baseUrl)} Run `wip doctor` to check again.");
         }
 
-        var model = LocalAiProvider.ResolveModel() ?? LocalAiProvider.DiscoverModel(baseUrl);
+        var model = LocalAiProvider.ResolveModel() ?? LocalAiProvider.DiscoverModel(
+            baseUrl, allowInsecureRemoteHttp: allowRemoteAi);
         var asked = question.Count > 0 ? string.Join(' ', question) : ReadQuestion();
         if (string.IsNullOrWhiteSpace(asked))
         {
@@ -228,9 +252,20 @@ internal sealed partial class CliContext
         }
 
         Log.Info($"asking {model} at {baseUrl}");
-        var answer = new LocalAiProvider(baseUrl, model).Generate(HelpAiPrompt(asked));
+        Console.Error.WriteLine($"AI destination: {endpoint.Host} ({endpoint.Scheme.ToUpperInvariant()})");
+        var answer = new LocalAiProvider(baseUrl, model, allowInsecureRemoteHttp: allowRemoteAi)
+            .Generate(HelpAiPrompt(asked));
         Console.WriteLine(answer);
         return 0;
+    }
+
+    private static void RequireRemoteApproval(Uri endpoint, bool allowRemoteAi)
+    {
+        if (!endpoint.IsLoopback && !allowRemoteAi)
+        {
+            throw new WipException(
+                $"Refusing to send data to remote AI host '{endpoint.Host}' without --allow-remote-ai");
+        }
     }
 
     private static string ReadQuestion()

--- a/src/Wip.Cli/CliContext.cs
+++ b/src/Wip.Cli/CliContext.cs
@@ -180,6 +180,35 @@ internal sealed partial class CliContext
         var baseUrl = LocalAiProvider.ResolveBaseUrl(url);
         var endpoint = LocalAiProvider.ValidateBaseUrl(baseUrl, allowRemoteAi);
         RequireRemoteApproval(endpoint, allowRemoteAi);
+
+        // Everything that decides what leaves this machine is settled — and disclosed — before
+        // the first packet: the availability probe and model discovery below already talk to the
+        // endpoint, so announcing afterwards would tell the user where their data went, not
+        // where it is about to go.
+        var directory = Path.GetDirectoryName(path) ?? Directory.GetCurrentDirectory();
+        Log.Info($"analyzing {directory}");
+        var project = new ProjectAnalyzer(directory).Analyze();
+        var name = Path.GetFileName(path);
+        var existing = File.Exists(path) ? File.ReadAllText(path) : null;
+
+        // WipAiGenerator embeds the existing wip.yml in the prompt on its own, outside the
+        // analyzer's snapshot, so it needs the same screening the snapshot's files get — and the
+        // same disclosure, since it is sent just as literally as they are.
+        var existingToSend = existing is not null && !ProjectAnalyzer.ContainsPossibleSecret(existing)
+            ? existing
+            : null;
+        if (existing is not null && existingToSend is null)
+        {
+            Log.Warn($"{name} looks like it contains a secret — generating without sending it");
+        }
+
+        var sending = project.Files.Select(file => file.RelativePath).ToList();
+        if (existingToSend is not null)
+        {
+            sending.Add(name);
+        }
+
+        AnnounceDestination(endpoint, sending);
         if (!LocalAiProvider.IsAvailable(baseUrl, allowRemoteAi))
         {
             throw new WipException(
@@ -189,7 +218,6 @@ internal sealed partial class CliContext
         var model = LocalAiProvider.ResolveModel() ?? LocalAiProvider.DiscoverModel(
             baseUrl, allowInsecureRemoteHttp: allowRemoteAi);
 
-        var directory = Path.GetDirectoryName(path) ?? Directory.GetCurrentDirectory();
         Console.Error.WriteLine(
             "Describe the development environment wip should run, then press Enter twice " +
             "(once after your text, once more on a blank line) to finish:");
@@ -200,20 +228,10 @@ internal sealed partial class CliContext
             lines.Add(line);
         }
 
-        var existing = File.Exists(path) ? File.ReadAllText(path) : null;
-        Log.Info($"analyzing {directory}");
-        var project = new ProjectAnalyzer(directory).Analyze();
-        Console.Error.WriteLine($"AI destination: {endpoint.Host} ({endpoint.Scheme.ToUpperInvariant()})");
-        Console.Error.WriteLine("Files to send:");
-        foreach (var file in project.Files)
-        {
-            Console.Error.WriteLine($"  - {file.RelativePath}");
-        }
-
-        Log.Info($"sending {project.Files.Count} selected project files to {model} at {baseUrl}");
+        Log.Info($"sending {sending.Count} selected project files to {model} at {baseUrl}");
         var candidate = new WipAiGenerator(
             new LocalAiProvider(baseUrl, model, allowInsecureRemoteHttp: allowRemoteAi)).Generate(
-            string.Join(System.Environment.NewLine, lines), project, existing, path);
+            string.Join(System.Environment.NewLine, lines), project, existingToSend, path);
 
         Console.WriteLine(candidate);
         Console.Error.Write(existing is null
@@ -237,6 +255,10 @@ internal sealed partial class CliContext
         var baseUrl = LocalAiProvider.ResolveBaseUrl(url);
         var endpoint = LocalAiProvider.ValidateBaseUrl(baseUrl, allowRemoteAi);
         RequireRemoteApproval(endpoint, allowRemoteAi);
+
+        // `wip help --ai` sends the question and wip's own help text, never project files — but
+        // the destination is still announced before the probe below opens a connection to it.
+        AnnounceDestination(endpoint, []);
         if (!LocalAiProvider.IsAvailable(baseUrl, allowRemoteAi))
         {
             throw new WipException(
@@ -252,11 +274,28 @@ internal sealed partial class CliContext
         }
 
         Log.Info($"asking {model} at {baseUrl}");
-        Console.Error.WriteLine($"AI destination: {endpoint.Host} ({endpoint.Scheme.ToUpperInvariant()})");
         var answer = new LocalAiProvider(baseUrl, model, allowInsecureRemoteHttp: allowRemoteAi)
             .Generate(HelpAiPrompt(asked));
         Console.WriteLine(answer);
         return 0;
+    }
+
+    /// <summary>Names the host and transport the prompt is about to cross, and every file that
+    /// travels with it, so the user can stop an unintended destination before it is contacted.</summary>
+    private static void AnnounceDestination(Uri endpoint, IReadOnlyList<string> files)
+    {
+        Console.Error.WriteLine($"AI destination: {endpoint.Host} ({endpoint.Scheme.ToUpperInvariant()})");
+        if (files.Count == 0)
+        {
+            Console.Error.WriteLine("Files to send: none");
+            return;
+        }
+
+        Console.Error.WriteLine("Files to send:");
+        foreach (var file in files)
+        {
+            Console.Error.WriteLine($"  - {file}");
+        }
     }
 
     private static void RequireRemoteApproval(Uri endpoint, bool allowRemoteAi)

--- a/src/Wip.Cli/Program.cs
+++ b/src/Wip.Cli/Program.cs
@@ -134,7 +134,8 @@ internal static class Program
         };
         var ai = new Option<bool>("--ai")
         {
-            Description = "Generate or update wip.yml from a natural-language request using a local AI server",
+            Description = "Generate or update wip.yml from a natural-language request using an AI server " +
+                "(loopback only unless --allow-remote-ai is given)",
         };
         var url = AiUrlOption();
         var allowRemoteAi = AllowRemoteAiOption();
@@ -178,7 +179,8 @@ internal static class Program
 
     private static Option<string?> AiUrlOption() => new("--url")
     {
-        Description = $"Local AI server base URL for --ai (default: {LocalAiProvider.BaseUrlEnvironmentVariable} or {LocalAiProvider.DefaultBaseUrl})",
+        Description = "AI server base URL for --ai; non-loopback hosts need --allow-remote-ai " +
+            $"(default: {LocalAiProvider.BaseUrlEnvironmentVariable} or {LocalAiProvider.DefaultBaseUrl})",
     };
 
     private static Option<bool> AllowRemoteAiOption() => new("--allow-remote-ai")
@@ -198,12 +200,13 @@ internal static class Program
     {
         var ai = new Option<bool>("--ai")
         {
-            Description = "Ask a local AI server how to use wip instead of printing --help",
+            Description = "Ask an AI server how to use wip instead of printing --help " +
+                "(loopback only unless --allow-remote-ai is given)",
         };
         var url = AiUrlOption();
         var allowRemoteAi = AllowRemoteAiOption();
         var question = new Argument<string[]>("question") { Arity = ArgumentArity.ZeroOrMore };
-        var command = new Command("help", "Show usage help (add --ai to ask a local AI server instead)")
+        var command = new Command("help", "Show usage help (add --ai to ask an AI server instead)")
         {
             ai, url, allowRemoteAi, question,
         };

--- a/src/Wip.Cli/Program.cs
+++ b/src/Wip.Cli/Program.cs
@@ -137,15 +137,18 @@ internal static class Program
             Description = "Generate or update wip.yml from a natural-language request using a local AI server",
         };
         var url = AiUrlOption();
+        var allowRemoteAi = AllowRemoteAiOption();
         var init = new Command("init", "Create a starter wip.yml (detects an existing compose file)")
         {
             force,
             template,
             ai,
             url,
+            allowRemoteAi,
         };
         init.SetAction(parsed => context(parsed).Init(
-            parsed.GetValue(force), parsed.GetValue(template), parsed.GetValue(ai), parsed.GetValue(url)));
+            parsed.GetValue(force), parsed.GetValue(template), parsed.GetValue(ai), parsed.GetValue(url),
+            parsed.GetValue(allowRemoteAi)));
         yield return init;
 
         yield return DoctorCommand(context);
@@ -178,6 +181,11 @@ internal static class Program
         Description = $"Local AI server base URL for --ai (default: {LocalAiProvider.BaseUrlEnvironmentVariable} or {LocalAiProvider.DefaultBaseUrl})",
     };
 
+    private static Option<bool> AllowRemoteAiOption() => new("--allow-remote-ai")
+    {
+        Description = "Explicitly allow sending data to a non-loopback AI server (including insecure HTTP)",
+    };
+
     private static Command DoctorCommand(Func<ParseResult, CliContext> context)
     {
         var url = AiUrlOption();
@@ -193,10 +201,11 @@ internal static class Program
             Description = "Ask a local AI server how to use wip instead of printing --help",
         };
         var url = AiUrlOption();
+        var allowRemoteAi = AllowRemoteAiOption();
         var question = new Argument<string[]>("question") { Arity = ArgumentArity.ZeroOrMore };
         var command = new Command("help", "Show usage help (add --ai to ask a local AI server instead)")
         {
-            ai, url, question,
+            ai, url, allowRemoteAi, question,
         };
 
         command.SetAction(parsed =>
@@ -207,6 +216,10 @@ internal static class Program
                 {
                     throw new WipException("--url requires --ai");
                 }
+                if (parsed.GetValue(allowRemoteAi))
+                {
+                    throw new WipException("--allow-remote-ai requires --ai");
+                }
 
                 if ((parsed.GetValue(question) ?? []).Length > 0)
                 {
@@ -216,7 +229,8 @@ internal static class Program
                 return ShowHelp();
             }
 
-            return context(parsed).HelpAi(parsed.GetValue(url), parsed.GetValue(question) ?? []);
+            return context(parsed).HelpAi(
+                parsed.GetValue(url), parsed.GetValue(question) ?? [], parsed.GetValue(allowRemoteAi));
         });
 
         return command;

--- a/src/Wip.Core/Ai/LocalAiProvider.cs
+++ b/src/Wip.Core/Ai/LocalAiProvider.cs
@@ -101,6 +101,11 @@ public sealed class LocalAiProvider : IWipAiProvider
         $"No model configured, and the server has no model loaded either. Set {ModelEnvironmentVariable} " +
         "to a model name already pulled or loaded in your local AI server, e.g. WIP_AI_MODEL=llama3.1.";
 
+    public static string RedirectRefusedMessage(string baseUrl, Uri? location) =>
+        $"AI server at '{baseUrl}' answered with a redirect to " +
+        $"'{location?.ToString() ?? "an unspecified location"}'. wip does not follow redirects from " +
+        "an AI endpoint — point --url (or " + BaseUrlEnvironmentVariable + ") at the final URL instead.";
+
     public static string AmbiguousModelMessage(IReadOnlyList<string> models) =>
         $"No model configured, and the server has more than one loaded: {string.Join(", ", models)}. " +
         $"Set {ModelEnvironmentVariable} to the one to use, e.g. {ModelEnvironmentVariable}={models[0]}.";
@@ -117,7 +122,7 @@ public sealed class LocalAiProvider : IWipAiProvider
         bool allowInsecureRemoteHttp = false)
     {
         baseUrl = ValidateBaseUrl(baseUrl, allowInsecureRemoteHttp).ToString().TrimEnd('/');
-        using var client = handler is null ? new HttpClient() : new HttpClient(handler);
+        using var client = CreateClient(handler);
         client.Timeout = TimeSpan.FromSeconds(5);
 
         HttpResponseMessage response;
@@ -138,6 +143,7 @@ public sealed class LocalAiProvider : IWipAiProvider
 
         using (response)
         {
+            RejectRedirect(response, baseUrl);
             var text = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
             if (!response.IsSuccessStatusCode)
             {
@@ -202,7 +208,7 @@ public sealed class LocalAiProvider : IWipAiProvider
 
     public string Generate(string prompt, CancellationToken cancellationToken = default)
     {
-        using var client = handler is null ? new HttpClient() : new HttpClient(handler);
+        using var client = CreateClient(handler);
         client.Timeout = TimeSpan.FromMinutes(5);
 
         var body = new JsonObject
@@ -235,6 +241,7 @@ public sealed class LocalAiProvider : IWipAiProvider
 
         using (response)
         {
+            RejectRedirect(response, baseUrl);
             var text = response.Content.ReadAsStringAsync(cancellationToken).GetAwaiter().GetResult();
             if (!response.IsSuccessStatusCode)
             {
@@ -242,6 +249,26 @@ public sealed class LocalAiProvider : IWipAiProvider
             }
 
             return ExtractContent(text);
+        }
+    }
+
+    /// <summary>
+    /// The client every request goes through, with automatic redirects turned off.
+    /// <see cref="ValidateBaseUrl"/> only vets the URL wip was configured with, and 307/308
+    /// redirects preserve the method and body — so a loopback endpoint answering with one would
+    /// otherwise hand a whole prompt, project files included, to a host the user never approved.
+    /// </summary>
+    private static HttpClient CreateClient(HttpMessageHandler? handler) => handler is null
+        ? new HttpClient(new HttpClientHandler { AllowAutoRedirect = false })
+        : new HttpClient(handler);
+
+    /// <summary>Turns the redirect <see cref="CreateClient"/> declined to follow into an
+    /// explanation, rather than the bare status code the generic error would report.</summary>
+    private static void RejectRedirect(HttpResponseMessage response, string baseUrl)
+    {
+        if ((int)response.StatusCode is >= 300 and < 400)
+        {
+            throw new WipException(RedirectRefusedMessage(baseUrl, response.Headers.Location));
         }
     }
 

--- a/src/Wip.Core/Ai/LocalAiProvider.cs
+++ b/src/Wip.Core/Ai/LocalAiProvider.cs
@@ -22,11 +22,33 @@ public sealed class LocalAiProvider : IWipAiProvider
     private readonly string model;
     private readonly HttpMessageHandler? handler;
 
-    public LocalAiProvider(string baseUrl, string model, HttpMessageHandler? handler = null)
+    public LocalAiProvider(
+        string baseUrl,
+        string model,
+        HttpMessageHandler? handler = null,
+        bool allowInsecureRemoteHttp = false)
     {
-        this.baseUrl = baseUrl;
+        this.baseUrl = ValidateBaseUrl(baseUrl, allowInsecureRemoteHttp).ToString().TrimEnd('/');
         this.model = model;
         this.handler = handler;
+    }
+
+    /// <summary>Validates an AI endpoint and enforces transport security away from loopback.</summary>
+    public static Uri ValidateBaseUrl(string baseUrl, bool allowInsecureRemoteHttp = false)
+    {
+        if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out var uri) || string.IsNullOrEmpty(uri.Host) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            throw new WipException("AI server URL must be an absolute HTTP or HTTPS URL");
+        }
+
+        if (!uri.IsLoopback && uri.Scheme == Uri.UriSchemeHttp && !allowInsecureRemoteHttp)
+        {
+            throw new WipException(
+                "Remote AI servers must use HTTPS (or require explicit --allow-remote-ai approval for insecure HTTP)");
+        }
+
+        return uri;
     }
 
     /// <summary>The base URL a default instance would use: an explicit value, then the
@@ -45,14 +67,14 @@ public sealed class LocalAiProvider : IWipAiProvider
     /// <c>wip init --ai</c> can report a missing server up front instead of only after the
     /// user has typed a whole request into a prompt that was never going anywhere.
     /// </summary>
-    public static bool IsAvailable(string? baseUrl = null)
+    public static bool IsAvailable(string? baseUrl = null, bool allowInsecureRemoteHttp = false)
     {
         Uri uri;
         try
         {
-            uri = new Uri(ResolveBaseUrl(baseUrl));
+            uri = ValidateBaseUrl(ResolveBaseUrl(baseUrl), allowInsecureRemoteHttp);
         }
-        catch (UriFormatException)
+        catch (WipException)
         {
             return false;
         }
@@ -89,8 +111,12 @@ public sealed class LocalAiProvider : IWipAiProvider
     /// reasonable answer — the common case for a single `ollama pull`. Embedding models are
     /// excluded since they cannot generate the chat completion wip needs.
     /// </summary>
-    public static string DiscoverModel(string baseUrl, HttpMessageHandler? handler = null)
+    public static string DiscoverModel(
+        string baseUrl,
+        HttpMessageHandler? handler = null,
+        bool allowInsecureRemoteHttp = false)
     {
+        baseUrl = ValidateBaseUrl(baseUrl, allowInsecureRemoteHttp).ToString().TrimEnd('/');
         using var client = handler is null ? new HttpClient() : new HttpClient(handler);
         client.Timeout = TimeSpan.FromSeconds(5);
 

--- a/src/Wip.Core/Ai/ProjectAnalyzer.cs
+++ b/src/Wip.Core/Ai/ProjectAnalyzer.cs
@@ -19,6 +19,13 @@ public sealed class ProjectAnalyzer
 
     private readonly string directory;
 
+    private static readonly string[] SecretMarkers =
+    [
+        "-----BEGIN PRIVATE KEY-----", "-----BEGIN RSA PRIVATE KEY-----", "AKIA",
+        "ghp_", "github_pat_", "sk-", "password=", "password:", "api_key=", "api_key:",
+        "secret=", "secret:", "token=", "token:",
+    ];
+
     public ProjectAnalyzer(string? directory = null) =>
         this.directory = Path.GetFullPath(directory ?? Directory.GetCurrentDirectory());
 
@@ -37,12 +44,21 @@ public sealed class ProjectAnalyzer
 
             var remaining = Math.Min(MaxFileCharacters, MaxTotalCharacters - total);
             var content = ReadBounded(path, remaining);
+            if (ContainsPossibleSecret(content))
+            {
+                continue;
+            }
+
             total += content.Length;
             files.Add(new ProjectFile(name, content));
         }
 
         return new ProjectSnapshot(directory, files);
     }
+
+    /// <summary>Conservatively identifies files that should be excluded rather than rewritten.</summary>
+    public static bool ContainsPossibleSecret(string content) => SecretMarkers.Any(marker =>
+        content.Contains(marker, StringComparison.OrdinalIgnoreCase));
 
     private static string ReadBounded(string path, int limit)
     {

--- a/src/Wip.Core/Ai/ProjectAnalyzer.cs
+++ b/src/Wip.Core/Ai/ProjectAnalyzer.cs
@@ -1,9 +1,10 @@
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Wip.Ai;
 
 /// <summary>Collects a small, allow-listed project snapshot suitable for an AI prompt.</summary>
-public sealed class ProjectAnalyzer
+public sealed partial class ProjectAnalyzer
 {
     public const int MaxFileCharacters = 64 * 1024;
     public const int MaxTotalCharacters = 256 * 1024;
@@ -19,11 +20,11 @@ public sealed class ProjectAnalyzer
 
     private readonly string directory;
 
+    /// <summary>Markers that identify a credential by its own shape, wherever they appear.</summary>
     private static readonly string[] SecretMarkers =
     [
         "-----BEGIN PRIVATE KEY-----", "-----BEGIN RSA PRIVATE KEY-----", "AKIA",
-        "ghp_", "github_pat_", "sk-", "password=", "password:", "api_key=", "api_key:",
-        "secret=", "secret:", "token=", "token:",
+        "ghp_", "github_pat_", "sk-",
     ];
 
     public ProjectAnalyzer(string? directory = null) =>
@@ -57,8 +58,19 @@ public sealed class ProjectAnalyzer
     }
 
     /// <summary>Conservatively identifies files that should be excluded rather than rewritten.</summary>
-    public static bool ContainsPossibleSecret(string content) => SecretMarkers.Any(marker =>
-        content.Contains(marker, StringComparison.OrdinalIgnoreCase));
+    public static bool ContainsPossibleSecret(string content) =>
+        SecretMarkers.Any(marker => content.Contains(marker, StringComparison.OrdinalIgnoreCase)) ||
+        SecretAssignment().IsMatch(content);
+
+    /// <summary>
+    /// Assignment-shaped credentials, matched with the whitespace real files actually contain:
+    /// <c>API_KEY = "..."</c> and <c>password : "..."</c> name a secret exactly as plainly as
+    /// <c>api_key=</c> does, so keying the check on the unspaced form alone would have let the
+    /// file straight into the prompt. The names stay deliberately broad and the whole file is
+    /// dropped on a match, since a false positive only costs the model some context.
+    /// </summary>
+    [GeneratedRegex(@"(api[_-]?key|secret|token|password|passwd)[ \t]*[:=]", RegexOptions.IgnoreCase)]
+    private static partial Regex SecretAssignment();
 
     private static string ReadBounded(string path, int limit)
     {

--- a/tests/Wip.Tests/HelpCommandTests.cs
+++ b/tests/Wip.Tests/HelpCommandTests.cs
@@ -48,4 +48,25 @@ public class HelpCommandTests
         var ai = parsed.CommandResult.Command.Options.OfType<Option<bool>>().Single(option => option.Name == "--ai");
         Assert.False(parsed.GetValue(ai));
     }
+
+    [Fact]
+    public void RemoteAiIsRejectedWithoutExplicitApprovalBeforeAnyNetworkRequest()
+    {
+        var parsed = Program.BuildRoot().Parse(
+            ["help", "--ai", "--url", "https://ai.example.com/v1", "how do I sync"]);
+        var invocation = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
+
+        var exception = Assert.Throws<WipException>(() => parsed.Invoke(invocation));
+        Assert.Contains("--allow-remote-ai", exception.Message);
+        Assert.Contains("ai.example.com", exception.Message);
+    }
+
+    [Fact]
+    public void AllowRemoteAiFlagIsAvailableToAiCommands()
+    {
+        var root = Program.BuildRoot();
+
+        Assert.Empty(root.Parse(["init", "--ai", "--allow-remote-ai"]).Errors);
+        Assert.Empty(root.Parse(["help", "--ai", "--allow-remote-ai", "question"]).Errors);
+    }
 }

--- a/tests/Wip.Tests/HelpCommandTests.cs
+++ b/tests/Wip.Tests/HelpCommandTests.cs
@@ -61,6 +61,21 @@ public class HelpCommandTests
         Assert.Contains("ai.example.com", exception.Message);
     }
 
+    /// <summary>The option text is the only place a user learns remote use exists at all, so it
+    /// has to name both the possibility and the flag that gates it.</summary>
+    [Fact]
+    public void AiOptionDescriptionsSayRemoteUseNeedsExplicitApproval()
+    {
+        var root = Program.BuildRoot();
+
+        foreach (var name in new[] { "init", "help" })
+        {
+            var command = root.Subcommands.Single(subcommand => subcommand.Name == name);
+            var ai = command.Options.Single(option => option.Name == "--ai");
+            Assert.Contains("--allow-remote-ai", ai.Description);
+        }
+    }
+
     [Fact]
     public void AllowRemoteAiFlagIsAvailableToAiCommands()
     {

--- a/tests/Wip.Tests/WipAiTests.cs
+++ b/tests/Wip.Tests/WipAiTests.cs
@@ -170,6 +170,132 @@ public class WipAiTests
         Assert.DoesNotContain("do-not-send-this", snapshot.ToPromptText());
     }
 
+    [Theory]
+    [InlineData("API_KEY = \"do-not-send-this\"")]
+    [InlineData("password : do-not-send-this")]
+    [InlineData("Secret\t= do-not-send-this")]
+    [InlineData("access_token:do-not-send-this")]
+    public void AnalyzerExcludesASecretAssignmentWrittenWithWhitespace(string line)
+    {
+        using var directory = new TemporaryDirectory();
+        File.WriteAllText(Path.Combine(directory.Path, "README.md"), $"# project\n{line}\n");
+        File.WriteAllText(Path.Combine(directory.Path, "package.json"), "{\"name\":\"safe\"}");
+
+        var snapshot = new ProjectAnalyzer(directory.Path).Analyze();
+
+        Assert.True(ProjectAnalyzer.ContainsPossibleSecret(line));
+        Assert.Equal("package.json", Assert.Single(snapshot.Files).RelativePath);
+        Assert.DoesNotContain("do-not-send-this", snapshot.ToPromptText());
+    }
+
+    /// <summary>
+    /// ValidateBaseUrl only vets the URL wip was configured with, and 307/308 replay the method
+    /// and body at the new location — so an endpoint that answers a prompt with a redirect could
+    /// otherwise hand the whole prompt to a host the user never approved.
+    /// </summary>
+    [Fact]
+    public void GenerateRefusesToFollowARedirectAwayFromTheApprovedEndpoint()
+    {
+        using var target = LoopbackServer.Serving("""{"choices":[{"message":{"content":"version: 1"}}]}""");
+        using var redirector = LoopbackServer.Redirecting(target.BaseUrl);
+        var provider = new LocalAiProvider($"{redirector.BaseUrl}/v1", "llama3.1");
+
+        var exception = Assert.Throws<WipException>(
+            () => provider.Generate("Run Rails", TestContext.Current.CancellationToken));
+
+        Assert.Contains("redirect", exception.Message);
+        Assert.Equal(0, target.Requests);
+    }
+
+    [Fact]
+    public void DiscoverModelRefusesToFollowARedirectAwayFromTheApprovedEndpoint()
+    {
+        using var target = LoopbackServer.Serving("""{"data":[{"id":"llama3.1"}]}""");
+        using var redirector = LoopbackServer.Redirecting(target.BaseUrl);
+
+        var exception = Assert.Throws<WipException>(
+            () => LocalAiProvider.DiscoverModel($"{redirector.BaseUrl}/v1"));
+
+        Assert.Contains("redirect", exception.Message);
+        Assert.Equal(0, target.Requests);
+    }
+
+    /// <summary>
+    /// A real loopback HTTP server, since the redirect behaviour under test belongs to the
+    /// HttpClient wip builds for itself — an injected <see cref="HttpMessageHandler"/> would
+    /// replace exactly the handler whose configuration is the thing being asserted.
+    /// </summary>
+    private sealed class LoopbackServer : IDisposable
+    {
+        private readonly System.Net.HttpListener listener;
+        private readonly Action<System.Net.HttpListenerContext> respond;
+        private int requests;
+
+        private LoopbackServer(Action<System.Net.HttpListenerContext> respond)
+        {
+            this.respond = respond;
+            BaseUrl = $"http://127.0.0.1:{FreeTcpPort()}";
+            listener = new System.Net.HttpListener();
+            listener.Prefixes.Add(BaseUrl + "/");
+            listener.Start();
+            _ = Task.Run(Serve);
+        }
+
+        internal string BaseUrl { get; }
+
+        /// <summary>How many requests actually arrived, so a test can assert a redirect target
+        /// was never contacted rather than only that the call failed.</summary>
+        internal int Requests => Volatile.Read(ref requests);
+
+        /// <summary>Answers everything with a body-preserving 307, standing in for an endpoint
+        /// that hands prompts on to somewhere else.</summary>
+        internal static LoopbackServer Redirecting(string location) => new(context =>
+        {
+            context.Response.StatusCode = 307;
+            context.Response.Headers["Location"] = location + context.Request.Url!.AbsolutePath;
+            context.Response.OutputStream.Close();
+        });
+
+        internal static LoopbackServer Serving(string responseBody) => new(context =>
+        {
+            var buffer = System.Text.Encoding.UTF8.GetBytes(responseBody);
+            context.Response.ContentType = "application/json";
+            context.Response.OutputStream.Write(buffer, 0, buffer.Length);
+            context.Response.OutputStream.Close();
+        });
+
+        public void Dispose() => listener.Close();
+
+        private void Serve()
+        {
+            while (listener.IsListening)
+            {
+                System.Net.HttpListenerContext context;
+                try
+                {
+                    context = listener.GetContext();
+                }
+                catch (Exception exception) when (
+                    exception is System.Net.HttpListenerException or ObjectDisposedException)
+                {
+                    return;
+                }
+
+                Interlocked.Increment(ref requests);
+                respond(context);
+            }
+        }
+
+        private static int FreeTcpPort()
+        {
+            var probe = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            probe.Start();
+            var port = ((System.Net.IPEndPoint)probe.LocalEndpoint).Port;
+            probe.Stop();
+            return port;
+        }
+    }
+
     [Fact]
     public void GenerateSendsOpenAiCompatibleChatCompletionsRequest()
     {

--- a/tests/Wip.Tests/WipAiTests.cs
+++ b/tests/Wip.Tests/WipAiTests.cs
@@ -120,6 +120,56 @@ public class WipAiTests
         Assert.False(LocalAiProvider.IsAvailable("file:///tmp"));
     }
 
+    [Theory]
+    [InlineData("http://localhost:11434/v1")]
+    [InlineData("http://127.42.1.9:11434/v1")]
+    [InlineData("http://[::1]:11434/v1")]
+    public void ValidationAllowsLoopbackHttp(string url)
+    {
+        Assert.True(LocalAiProvider.ValidateBaseUrl(url).IsLoopback);
+    }
+
+    [Fact]
+    public void ValidationAllowsRemoteHttps()
+    {
+        var endpoint = LocalAiProvider.ValidateBaseUrl("https://ai.example.com/v1");
+
+        Assert.Equal(Uri.UriSchemeHttps, endpoint.Scheme);
+        Assert.False(endpoint.IsLoopback);
+    }
+
+    [Fact]
+    public void ValidationRejectsRemoteHttpUnlessExplicitlyApproved()
+    {
+        Assert.Throws<WipException>(() => LocalAiProvider.ValidateBaseUrl("http://ai.example.com/v1"));
+
+        var endpoint = LocalAiProvider.ValidateBaseUrl(
+            "http://ai.example.com/v1", allowInsecureRemoteHttp: true);
+        Assert.Equal(Uri.UriSchemeHttp, endpoint.Scheme);
+    }
+
+    [Theory]
+    [InlineData("file:///tmp/model")]
+    [InlineData("ftp://localhost/model")]
+    public void ValidationRejectsNonHttpSchemes(string url)
+    {
+        Assert.Throws<WipException>(() => LocalAiProvider.ValidateBaseUrl(url));
+    }
+
+    [Fact]
+    public void AnalyzerExcludesAnAllowListedFileContainingAPossibleSecret()
+    {
+        using var directory = new TemporaryDirectory();
+        File.WriteAllText(Path.Combine(directory.Path, "README.md"), "API_KEY=do-not-send-this");
+        File.WriteAllText(Path.Combine(directory.Path, "package.json"), "{\"name\":\"safe\"}");
+
+        var snapshot = new ProjectAnalyzer(directory.Path).Analyze();
+
+        var file = Assert.Single(snapshot.Files);
+        Assert.Equal("package.json", file.RelativePath);
+        Assert.DoesNotContain("do-not-send-this", snapshot.ToPromptText());
+    }
+
     [Fact]
     public void GenerateSendsOpenAiCompatibleChatCompletionsRequest()
     {


### PR DESCRIPTION
### Motivation

- Prevent accidental leakage of project files to unintended hosts by validating AI endpoint schemes and requiring secure transport for non-loopback hosts.
- Make AI flows explicit and auditable by showing the destination host, transport scheme, and the list of files that will be sent before any network activity.
- Reduce the risk of sending secrets by conservatively excluding allow-listed files that contain likely secret markers rather than attempting in-place redaction.

### Description

- Added centralized endpoint validation in `LocalAiProvider.ValidateBaseUrl` that only accepts absolute `http`/`https` URIs, allows loopback `http`, and requires `https` for non-loopback hosts unless explicitly approved. (`src/Wip.Core/Ai/LocalAiProvider.cs`)
- Propagated validation and the explicit `allowInsecureRemoteHttp` approval through `IsAvailable`, `DiscoverModel`, and provider construction, and surfaced helpful error messages for unsupported schemes. (`src/Wip.Core/Ai/LocalAiProvider.cs`)
- Introduced a new `--allow-remote-ai` CLI option for AI-enabled commands and enforced that it can only be used together with `--ai`, rejecting remote use by default; commands now call the validation and refuse remote sends prior to network access. (`src/Wip.Cli/Program.cs`, `src/Wip.Cli/CliContext.cs`)
- Before generation, the AI flows now print the AI destination (`host`/`scheme`) and list the selected files to send, and they require explicit approval to contact non-loopback hosts. (`src/Wip.Cli/CliContext.cs`)
- Extended `ProjectAnalyzer` to conservatively exclude allow-listed files containing common secret markers (private key headers, API key prefixes, tokens, passwords, etc.) and added `ContainsPossibleSecret` for this check without modifying file contents. (`src/Wip.Core/Ai/ProjectAnalyzer.cs`)
- Added unit tests covering loopback HTTP allowance, remote `https` acceptance, rejection of remote `http` unless explicitly approved, non-HTTP scheme rejection, and exclusion of secret-bearing allow-listed files; also added CLI tests that verify remote AI is rejected without `--allow-remote-ai` and that the flag is available to AI commands. (`tests/Wip.Tests/WipAiTests.cs`, `tests/Wip.Tests/HelpCommandTests.cs`)
- Bumped project `Version` from `2.3.1` to `2.4.0`. (`Directory.Build.props`)

### Testing

- Added unit tests in `tests/Wip.Tests` exercising `LocalAiProvider` validation, `ProjectAnalyzer` secret exclusion, and CLI refusal semantics; these tests were added to the test suite files but could not be executed in this environment due to missing runtime.
- Ran repository checks including `git diff --check` which passed in the workspace where the changes were prepared. 
- Attempted to run `dotnet test --no-restore` but the environment lacks the `dotnet` executable, so the test suite could not be executed here; the new tests are present and should run in CI or a developer machine with .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a97546c4e74832288d4b7369bef0567)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `--allow-remote-ai` to AI-enabled `init` and `help` commands.
  - Commands now display the selected AI destination and disclosed files, including when no files are shared.
  - AI project analysis excludes files containing possible secrets from shared snapshots.

- **Bug Fixes**
  - Remote HTTP endpoints require explicit approval; invalid endpoints and redirects are rejected.
  - Improved handling of stalled, oversized, cancelled, or malformed AI responses.

- **Chores**
  - Updated the project version from 2.3.1 to 2.4.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->