### PR TITLE
fix(ai): bound local server responses

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.3.1</Version>
+    <Version>2.3.2</Version>
     <Authors>wip contributors</Authors>
     <Product>wip</Product>
     <Description>A developer-friendly CLI wrapper for Microsoft WSLC.</Description>

--- a/src/Wip.Core/Ai/LocalAiProvider.cs
+++ b/src/Wip.Core/Ai/LocalAiProvider.cs
@@ -21,10 +21,16 @@ public sealed class LocalAiProvider : IWipAiProvider
     internal const int GeneratedContentMaxCharacters = 1024 * 1024;
     internal const int ErrorBodyMaxBytes = 4 * 1024;
     private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan DiscoveryTimeout = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan GenerateTimeout = TimeSpan.FromMinutes(5);
 
     private readonly string baseUrl;
     private readonly string model;
     private readonly HttpMessageHandler? handler;
+
+    /// <summary>How long a whole <see cref="Generate"/> call may take, headers and body
+    /// together. Overridden only by tests, which cannot wait out the real deadline.</summary>
+    internal TimeSpan RequestTimeout { get; init; } = GenerateTimeout;
 
     public LocalAiProvider(string baseUrl, string model, HttpMessageHandler? handler = null)
     {
@@ -93,16 +99,24 @@ public sealed class LocalAiProvider : IWipAiProvider
     /// reasonable answer — the common case for a single `ollama pull`. Embedding models are
     /// excluded since they cannot generate the chat completion wip needs.
     /// </summary>
-    public static string DiscoverModel(string baseUrl, HttpMessageHandler? handler = null)
+    public static string DiscoverModel(string baseUrl, HttpMessageHandler? handler = null) =>
+        DiscoverModel(baseUrl, handler, DiscoveryTimeout);
+
+    internal static string DiscoverModel(string baseUrl, HttpMessageHandler? handler, TimeSpan timeout)
     {
         using var client = handler is null ? new HttpClient() : new HttpClient(handler);
-        client.Timeout = TimeSpan.FromSeconds(5);
+        client.Timeout = timeout;
+        // ResponseHeadersRead stops client.Timeout once the headers are in, so the body reads
+        // below need a deadline of their own or a server that stalls mid-body hangs wip forever.
+        // One source started before the request gives headers and body a single budget.
+        using var deadline = new CancellationTokenSource(timeout);
 
         HttpResponseMessage response;
         try
         {
             response = client.GetAsync(
-                $"{baseUrl}/models", HttpCompletionOption.ResponseHeadersRead).GetAwaiter().GetResult();
+                $"{baseUrl}/models", HttpCompletionOption.ResponseHeadersRead, deadline.Token)
+                .GetAwaiter().GetResult();
         }
         catch (HttpRequestException exception)
         {
@@ -111,32 +125,48 @@ public sealed class LocalAiProvider : IWipAiProvider
         catch (OperationCanceledException exception)
         {
             // DiscoverModel takes no caller cancellationToken, so any cancellation here can
-            // only be the client.Timeout above firing.
+            // only be the deadline above firing.
             throw new WipException($"Local AI server at '{baseUrl}' did not respond in time", exception);
         }
 
         using (response)
         {
-            if (!response.IsSuccessStatusCode)
+            try
             {
-                var detail = ReadErrorSnippetAsync(response.Content, CancellationToken.None).GetAwaiter().GetResult();
-                throw new WipException($"Local AI server returned {(int)response.StatusCode} listing models: {detail}");
-            }
+                if (!response.IsSuccessStatusCode)
+                {
+                    var detail = ReadErrorSnippetAsync(response.Content, deadline.Token).GetAwaiter().GetResult();
+                    throw new WipException(
+                        $"Local AI server returned {(int)response.StatusCode} listing models: {detail}");
+                }
 
-            using var document = ParseResponseAsync(
-                response.Content, ModelsResponseMaxBytes, "models list", CancellationToken.None).GetAwaiter().GetResult();
-            var models = ExtractModelIds(document);
-            return models.Count switch
+                using var document = ParseResponseAsync(
+                    response.Content, ModelsResponseMaxBytes, "models list", deadline.Token).GetAwaiter().GetResult();
+                var models = ExtractModelIds(document);
+                return models.Count switch
+                {
+                    0 => throw new WipException(MissingModelMessage()),
+                    1 => models[0],
+                    _ => throw new WipException(AmbiguousModelMessage(models)),
+                };
+            }
+            catch (OperationCanceledException exception)
             {
-                0 => throw new WipException(MissingModelMessage()),
-                1 => models[0],
-                _ => throw new WipException(AmbiguousModelMessage(models)),
-            };
+                throw new WipException($"Local AI server at '{baseUrl}' did not respond in time", exception);
+            }
         }
     }
 
     private static IReadOnlyList<string> ExtractModelIds(JsonDocument document)
     {
+        // TryGetProperty throws on anything but an object, so a bare array or string body would
+        // escape the WipException contract Doctor.CheckAi relies on.
+        if (document.RootElement.ValueKind != JsonValueKind.Object)
+        {
+            throw new WipException(
+                "Local AI server's models list was not shaped as expected: response is not an object");
+        }
+
         if (!document.RootElement.TryGetProperty("data", out var data))
         {
             var detail = document.RootElement.TryGetProperty("error", out var error)
@@ -171,7 +201,12 @@ public sealed class LocalAiProvider : IWipAiProvider
     public string Generate(string prompt, CancellationToken cancellationToken = default)
     {
         using var client = handler is null ? new HttpClient() : new HttpClient(handler);
-        client.Timeout = TimeSpan.FromMinutes(5);
+        client.Timeout = RequestTimeout;
+        // As in DiscoverModel: ResponseHeadersRead retires client.Timeout at the headers, so the
+        // body reads below run under a linked source that keeps both the caller's cancellation
+        // and a deadline covering the whole exchange.
+        using var deadline = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        deadline.CancelAfter(RequestTimeout);
 
         var body = new JsonObject
         {
@@ -188,7 +223,7 @@ public sealed class LocalAiProvider : IWipAiProvider
                 {
                     Content = new StringContent(body.ToJsonString(), Encoding.UTF8, "application/json"),
                 }, HttpCompletionOption.ResponseHeadersRead,
-                cancellationToken).GetAwaiter().GetResult();
+                deadline.Token).GetAwaiter().GetResult();
         }
         catch (HttpRequestException exception)
         {
@@ -196,29 +231,40 @@ public sealed class LocalAiProvider : IWipAiProvider
         }
         catch (OperationCanceledException exception) when (!cancellationToken.IsCancellationRequested)
         {
-            // The caller's own token is still live, so this cancellation can only be
-            // client.Timeout firing — a genuine caller cancellation instead propagates as-is.
+            // The caller's own token is still live, so this cancellation can only be the
+            // deadline firing — a genuine caller cancellation instead propagates as-is.
             throw new WipException($"Local AI server at '{baseUrl}' did not respond in time", exception);
         }
 
         using (response)
         {
-            if (!response.IsSuccessStatusCode)
+            try
             {
-                var detail = ReadErrorSnippetAsync(response.Content, cancellationToken).GetAwaiter().GetResult();
-                throw new WipException($"Local AI server returned {(int)response.StatusCode}: {detail}");
-            }
+                if (!response.IsSuccessStatusCode)
+                {
+                    var detail = ReadErrorSnippetAsync(response.Content, deadline.Token).GetAwaiter().GetResult();
+                    throw new WipException($"Local AI server returned {(int)response.StatusCode}: {detail}");
+                }
 
-            using var document = ParseResponseAsync(
-                response.Content, ChatResponseMaxBytes, "response", cancellationToken).GetAwaiter().GetResult();
-            return ExtractContent(document);
+                using var document = ParseResponseAsync(
+                    response.Content, ChatResponseMaxBytes, "response", deadline.Token).GetAwaiter().GetResult();
+                return ExtractContent(document);
+            }
+            catch (OperationCanceledException exception) when (!cancellationToken.IsCancellationRequested)
+            {
+                throw new WipException($"Local AI server at '{baseUrl}' did not respond in time", exception);
+            }
         }
     }
 
     private static string ExtractContent(JsonDocument document)
     {
-        if (!document.RootElement.TryGetProperty("choices", out var choices) ||
+        // Every TryGetProperty below is guarded by a ValueKind check, since TryGetProperty throws
+        // InvalidOperationException — not a WipException — on a non-object element.
+        if (document.RootElement.ValueKind != JsonValueKind.Object ||
+            !document.RootElement.TryGetProperty("choices", out var choices) ||
             choices.ValueKind != JsonValueKind.Array || choices.GetArrayLength() == 0 ||
+            choices[0].ValueKind != JsonValueKind.Object ||
             !choices[0].TryGetProperty("message", out var message) ||
             message.ValueKind != JsonValueKind.Object ||
             !message.TryGetProperty("content", out var contentElement) ||

--- a/src/Wip.Core/Ai/LocalAiProvider.cs
+++ b/src/Wip.Core/Ai/LocalAiProvider.cs
@@ -215,15 +215,19 @@ public sealed class LocalAiProvider : IWipAiProvider
             ["stream"] = false,
         };
 
+        // Disposed at the end of the method rather than right after the send: the response body
+        // is read further down, and tearing the request down early is what breaks that on a
+        // handler that ties the two together.
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"{baseUrl}/chat/completions")
+        {
+            Content = new StringContent(body.ToJsonString(), Encoding.UTF8, "application/json"),
+        };
+
         HttpResponseMessage response;
         try
         {
             response = client.SendAsync(
-                new HttpRequestMessage(HttpMethod.Post, $"{baseUrl}/chat/completions")
-                {
-                    Content = new StringContent(body.ToJsonString(), Encoding.UTF8, "application/json"),
-                }, HttpCompletionOption.ResponseHeadersRead,
-                deadline.Token).GetAwaiter().GetResult();
+                request, HttpCompletionOption.ResponseHeadersRead, deadline.Token).GetAwaiter().GetResult();
         }
         catch (HttpRequestException exception)
         {

--- a/src/Wip.Core/Ai/LocalAiProvider.cs
+++ b/src/Wip.Core/Ai/LocalAiProvider.cs
@@ -16,6 +16,10 @@ public sealed class LocalAiProvider : IWipAiProvider
     public const string BaseUrlEnvironmentVariable = "WIP_AI_BASE_URL";
     public const string ModelEnvironmentVariable = "WIP_AI_MODEL";
     public const string DefaultBaseUrl = "http://localhost:11434/v1";
+    internal const long ModelsResponseMaxBytes = 2 * 1024 * 1024;
+    internal const long ChatResponseMaxBytes = 4 * 1024 * 1024;
+    internal const int GeneratedContentMaxCharacters = 1024 * 1024;
+    internal const int ErrorBodyMaxBytes = 4 * 1024;
     private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(1);
 
     private readonly string baseUrl;
@@ -97,7 +101,8 @@ public sealed class LocalAiProvider : IWipAiProvider
         HttpResponseMessage response;
         try
         {
-            response = client.GetAsync($"{baseUrl}/models").GetAwaiter().GetResult();
+            response = client.GetAsync(
+                $"{baseUrl}/models", HttpCompletionOption.ResponseHeadersRead).GetAwaiter().GetResult();
         }
         catch (HttpRequestException exception)
         {
@@ -112,13 +117,15 @@ public sealed class LocalAiProvider : IWipAiProvider
 
         using (response)
         {
-            var text = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
             if (!response.IsSuccessStatusCode)
             {
-                throw new WipException($"Local AI server returned {(int)response.StatusCode} listing models: {text}");
+                var detail = ReadErrorSnippetAsync(response.Content, CancellationToken.None).GetAwaiter().GetResult();
+                throw new WipException($"Local AI server returned {(int)response.StatusCode} listing models: {detail}");
             }
 
-            var models = ExtractModelIds(text);
+            using var document = ParseResponseAsync(
+                response.Content, ModelsResponseMaxBytes, "models list", CancellationToken.None).GetAwaiter().GetResult();
+            var models = ExtractModelIds(document);
             return models.Count switch
             {
                 0 => throw new WipException(MissingModelMessage()),
@@ -128,50 +135,37 @@ public sealed class LocalAiProvider : IWipAiProvider
         }
     }
 
-    private static IReadOnlyList<string> ExtractModelIds(string responseBody)
+    private static IReadOnlyList<string> ExtractModelIds(JsonDocument document)
     {
-        JsonDocument document;
-        try
+        if (!document.RootElement.TryGetProperty("data", out var data))
         {
-            document = JsonDocument.Parse(responseBody);
+            var detail = document.RootElement.TryGetProperty("error", out var error)
+                ? TruncateAndEscape(error.ToString(), ErrorBodyMaxBytes)
+                : "unexpected response";
+            throw new WipException(
+                $"Local AI server rejected the models request: {detail} — check that " +
+                $"{BaseUrlEnvironmentVariable}/--url includes the API version path, e.g. '.../v1'.");
         }
-        catch (JsonException exception)
+
+        if (data.ValueKind != JsonValueKind.Array)
         {
-            throw new WipException("Local AI server returned a models list wip could not parse", exception);
+            throw new WipException("Local AI server's models list was not shaped as expected: data is not an array");
         }
 
-        using (document)
+        var models = new List<string>();
+        foreach (var element in data.EnumerateArray())
         {
-            if (!document.RootElement.TryGetProperty("data", out var data))
+            if (element.ValueKind == JsonValueKind.Object &&
+                element.TryGetProperty("id", out var idElement) &&
+                idElement.ValueKind == JsonValueKind.String &&
+                idElement.GetString() is { Length: > 0 } id &&
+                !id.Contains("embed", StringComparison.OrdinalIgnoreCase))
             {
-                var detail = document.RootElement.TryGetProperty("error", out var error)
-                    ? error.ToString()
-                    : responseBody;
-                throw new WipException(
-                    $"Local AI server rejected the models request: {detail} — check that " +
-                    $"{BaseUrlEnvironmentVariable}/--url includes the API version path, e.g. '.../v1'.");
+                models.Add(id);
             }
-
-            if (data.ValueKind != JsonValueKind.Array)
-            {
-                throw new WipException("Local AI server's models list was not shaped as expected: data is not an array");
-            }
-
-            var models = new List<string>();
-            foreach (var element in data.EnumerateArray())
-            {
-                if (element.ValueKind == JsonValueKind.Object &&
-                    element.TryGetProperty("id", out var idElement) &&
-                    idElement.ValueKind == JsonValueKind.String &&
-                    idElement.GetString() is { Length: > 0 } id &&
-                    !id.Contains("embed", StringComparison.OrdinalIgnoreCase))
-                {
-                    models.Add(id);
-                }
-            }
-
-            return models;
         }
+
+        return models;
     }
 
     public string Generate(string prompt, CancellationToken cancellationToken = default)
@@ -193,7 +187,7 @@ public sealed class LocalAiProvider : IWipAiProvider
                 new HttpRequestMessage(HttpMethod.Post, $"{baseUrl}/chat/completions")
                 {
                     Content = new StringContent(body.ToJsonString(), Encoding.UTF8, "application/json"),
-                },
+                }, HttpCompletionOption.ResponseHeadersRead,
                 cancellationToken).GetAwaiter().GetResult();
         }
         catch (HttpRequestException exception)
@@ -209,45 +203,137 @@ public sealed class LocalAiProvider : IWipAiProvider
 
         using (response)
         {
-            var text = response.Content.ReadAsStringAsync(cancellationToken).GetAwaiter().GetResult();
             if (!response.IsSuccessStatusCode)
             {
-                throw new WipException($"Local AI server returned {(int)response.StatusCode}: {text}");
+                var detail = ReadErrorSnippetAsync(response.Content, cancellationToken).GetAwaiter().GetResult();
+                throw new WipException($"Local AI server returned {(int)response.StatusCode}: {detail}");
             }
 
-            return ExtractContent(text);
+            using var document = ParseResponseAsync(
+                response.Content, ChatResponseMaxBytes, "response", cancellationToken).GetAwaiter().GetResult();
+            return ExtractContent(document);
         }
     }
 
-    private static string ExtractContent(string responseBody)
+    private static string ExtractContent(JsonDocument document)
     {
-        JsonDocument document;
+        if (!document.RootElement.TryGetProperty("choices", out var choices) ||
+            choices.ValueKind != JsonValueKind.Array || choices.GetArrayLength() == 0 ||
+            !choices[0].TryGetProperty("message", out var message) ||
+            message.ValueKind != JsonValueKind.Object ||
+            !message.TryGetProperty("content", out var contentElement) ||
+            contentElement.ValueKind != JsonValueKind.String)
+        {
+            throw new WipException(
+                "Local AI server response did not contain the expected choices[0].message.content field");
+        }
+
+        var content = contentElement.GetString();
+        if (content?.Length > GeneratedContentMaxCharacters)
+        {
+            throw new WipException(
+                $"Local AI server generated content larger than the {GeneratedContentMaxCharacters}-character limit");
+        }
+
+        return string.IsNullOrWhiteSpace(content)
+            ? throw new WipException("Local AI server returned an empty response")
+            : content;
+    }
+
+    private static async Task<JsonDocument> ParseResponseAsync(
+        HttpContent content, long maxBytes, string description, CancellationToken cancellationToken)
+    {
+        if (content.Headers.ContentLength is long contentLength && contentLength > maxBytes)
+        {
+            throw new WipException(
+                $"Local AI server returned a {description} larger than the {maxBytes}-byte limit");
+        }
+
         try
         {
-            document = JsonDocument.Parse(responseBody);
+            await using var responseStream = await content.ReadAsStreamAsync(cancellationToken);
+            await using var limitedStream = new LimitedReadStream(responseStream, maxBytes);
+            return await JsonDocument.ParseAsync(limitedStream, cancellationToken: cancellationToken);
+        }
+        catch (ResponseTooLargeException exception)
+        {
+            throw new WipException(
+                $"Local AI server returned a {description} larger than the {maxBytes}-byte limit", exception);
         }
         catch (JsonException exception)
         {
-            throw new WipException("Local AI server returned a response wip could not parse", exception);
+            throw new WipException($"Local AI server returned a {description} wip could not parse", exception);
+        }
+    }
+
+    private static async Task<string> ReadErrorSnippetAsync(HttpContent content, CancellationToken cancellationToken)
+    {
+        await using var stream = await content.ReadAsStreamAsync(cancellationToken);
+        var buffer = new byte[ErrorBodyMaxBytes + 1];
+        var read = 0;
+        while (read < buffer.Length)
+        {
+            var count = await stream.ReadAsync(buffer.AsMemory(read, buffer.Length - read), cancellationToken);
+            if (count == 0) break;
+            read += count;
         }
 
-        using (document)
-        {
-            if (!document.RootElement.TryGetProperty("choices", out var choices) ||
-                choices.ValueKind != JsonValueKind.Array || choices.GetArrayLength() == 0 ||
-                !choices[0].TryGetProperty("message", out var message) ||
-                message.ValueKind != JsonValueKind.Object ||
-                !message.TryGetProperty("content", out var contentElement) ||
-                contentElement.ValueKind != JsonValueKind.String)
-            {
-                throw new WipException(
-                    "Local AI server response did not contain the expected choices[0].message.content field");
-            }
+        var truncated = read > ErrorBodyMaxBytes;
+        var text = Encoding.UTF8.GetString(buffer, 0, Math.Min(read, ErrorBodyMaxBytes));
+        return TruncateAndEscape(text, ErrorBodyMaxBytes) + (truncated ? "… [truncated]" : string.Empty);
+    }
 
-            var content = contentElement.GetString();
-            return string.IsNullOrWhiteSpace(content)
-                ? throw new WipException("Local AI server returned an empty response")
-                : content;
+    private static string TruncateAndEscape(string value, int maxCharacters)
+    {
+        var length = Math.Min(value.Length, maxCharacters);
+        var result = new StringBuilder(length);
+        for (var index = 0; index < length; index++)
+        {
+            var character = value[index];
+            result.Append(char.IsControl(character) ? $"\\u{(int)character:x4}" : character);
+        }
+        return result.ToString();
+    }
+
+    private sealed class ResponseTooLargeException : IOException
+    {
+    }
+
+    private sealed class LimitedReadStream(Stream inner, long maxBytes) : Stream
+    {
+        private long bytesRead;
+
+        public override bool CanRead => inner.CanRead;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => bytesRead; set => throw new NotSupportedException(); }
+        public override void Flush() => throw new NotSupportedException();
+        public override int Read(byte[] buffer, int offset, int count) =>
+            ReadAsync(buffer.AsMemory(offset, count)).AsTask().GetAwaiter().GetResult();
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            if (buffer.IsEmpty) return 0;
+            var remainingWithSentinel = maxBytes - bytesRead + 1;
+            if (remainingWithSentinel <= 0) throw new ResponseTooLargeException();
+            var count = await inner.ReadAsync(buffer[..(int)Math.Min(buffer.Length, remainingWithSentinel)], cancellationToken);
+            bytesRead += count;
+            if (bytesRead > maxBytes) throw new ResponseTooLargeException();
+            return count;
+        }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing) inner.Dispose();
+            base.Dispose(disposing);
+        }
+        public override async ValueTask DisposeAsync()
+        {
+            await inner.DisposeAsync();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/tests/Wip.Tests/WipAiTests.cs
+++ b/tests/Wip.Tests/WipAiTests.cs
@@ -254,11 +254,117 @@ public class WipAiTests
         Assert.ThrowsAny<OperationCanceledException>(() => provider.Generate("Run Rails", cts.Token));
     }
 
+    [Fact]
+    public void DiscoverModelRejectsOversizedContentLengthWithoutReadingTheBody()
+    {
+        var stream = new TrackingStream(new byte[] { (byte)'{' });
+        var content = new StreamContent(stream);
+        content.Headers.ContentLength = LocalAiProvider.ModelsResponseMaxBytes + 1;
+        var handler = new ResponseHandler(() => new HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = content });
+
+        var exception = Assert.Throws<WipException>(
+            () => LocalAiProvider.DiscoverModel("http://localhost:11434/v1", handler));
+
+        Assert.Contains("larger", exception.Message);
+        Assert.Equal(0, stream.BytesRead);
+    }
+
+    [Fact]
+    public void GenerateStopsAChunkedResponseAsSoonAsItExceedsTheStreamLimit()
+    {
+        var stream = new TrackingStream(Enumerable.Repeat(
+            (byte)' ', (int)LocalAiProvider.ChatResponseMaxBytes + 100).ToArray());
+        var content = new StreamContent(stream);
+        content.Headers.ContentLength = null;
+        var handler = new ResponseHandler(() => new HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = content });
+        var provider = new LocalAiProvider("http://localhost:11434/v1", "llama3.1", handler);
+
+        var exception = Assert.Throws<WipException>(
+            () => provider.Generate("Run Rails", TestContext.Current.CancellationToken));
+
+        Assert.Contains("larger", exception.Message);
+        Assert.Equal(LocalAiProvider.ChatResponseMaxBytes + 1, stream.BytesRead);
+    }
+
+    [Fact]
+    public void GenerateTruncatesAndEscapesAHugeErrorBody()
+    {
+        var body = "bad\n\t" + new string('x', LocalAiProvider.ErrorBodyMaxBytes * 2);
+        var handler = new ResponseHandler(() => new HttpResponseMessage(System.Net.HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent(body),
+        });
+        var provider = new LocalAiProvider("http://localhost:11434/v1", "llama3.1", handler);
+
+        var exception = Assert.Throws<WipException>(
+            () => provider.Generate("Run Rails", TestContext.Current.CancellationToken));
+
+        Assert.Contains("bad\\u000a\\u0009", exception.Message);
+        Assert.Contains("[truncated]", exception.Message);
+        Assert.True(exception.Message.Length < LocalAiProvider.ErrorBodyMaxBytes + 200);
+    }
+
+    [Fact]
+    public void GenerateAcceptsAResponseWithinAllLimits()
+    {
+        var expected = new string('a', 32 * 1024);
+        var handler = new StubHandler($"{{\"choices\":[{{\"message\":{{\"content\":\"{expected}\"}}}}]}}");
+        var provider = new LocalAiProvider("http://localhost:11434/v1", "llama3.1", handler);
+
+        Assert.Equal(expected, provider.Generate("Run Rails", TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public void GenerateRejectsContentThatExceedsItsOwnCharacterLimit()
+    {
+        var generated = new string('a', LocalAiProvider.GeneratedContentMaxCharacters + 1);
+        var handler = new StubHandler($"{{\"choices\":[{{\"message\":{{\"content\":\"{generated}\"}}}}]}}");
+        var provider = new LocalAiProvider("http://localhost:11434/v1", "llama3.1", handler);
+
+        var exception = Assert.Throws<WipException>(
+            () => provider.Generate("Run Rails", TestContext.Current.CancellationToken));
+        Assert.Contains("character limit", exception.Message);
+    }
+
     private sealed class ThrowingHandler(Exception exception) : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken) =>
             Task.FromException<HttpResponseMessage>(exception);
+    }
+
+    private sealed class ResponseHandler(Func<HttpResponseMessage> responseFactory) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(responseFactory());
+    }
+
+    private sealed class TrackingStream(byte[] bytes) : MemoryStream(bytes)
+    {
+        internal long BytesRead { get; private set; }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var read = base.Read(buffer, offset, count);
+            BytesRead += read;
+            return read;
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            var read = base.Read(buffer);
+            BytesRead += read;
+            return read;
+        }
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            var read = await base.ReadAsync(buffer, cancellationToken);
+            BytesRead += read;
+            return read;
+        }
     }
 
     private sealed class StubHandler(string responseBody) : HttpMessageHandler

--- a/tests/Wip.Tests/WipAiTests.cs
+++ b/tests/Wip.Tests/WipAiTests.cs
@@ -287,6 +287,84 @@ public class WipAiTests
     }
 
     [Fact]
+    public void DiscoverModelGivesUpWhenTheBodyNeverFollowsItsHeaders()
+    {
+        var content = new StreamContent(new StallingStream());
+        content.Headers.ContentLength = null;
+        var handler = new ResponseHandler(() => new HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = content });
+
+        var exception = Assert.Throws<WipException>(() => LocalAiProvider.DiscoverModel(
+            "http://localhost:11434/v1", handler, TimeSpan.FromMilliseconds(200)));
+
+        Assert.Contains("did not respond in time", exception.Message);
+    }
+
+    [Fact]
+    public void GenerateGivesUpWhenTheBodyNeverFollowsItsHeaders()
+    {
+        var content = new StreamContent(new StallingStream());
+        content.Headers.ContentLength = null;
+        var handler = new ResponseHandler(() => new HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = content });
+        var provider = new LocalAiProvider("http://localhost:11434/v1", "llama3.1", handler)
+        {
+            RequestTimeout = TimeSpan.FromMilliseconds(200),
+        };
+
+        var exception = Assert.Throws<WipException>(
+            () => provider.Generate("Run Rails", TestContext.Current.CancellationToken));
+
+        Assert.Contains("did not respond in time", exception.Message);
+    }
+
+    [Fact]
+    public void GenerateLetsCallerCancellationOfAStalledBodyPropagateUnwrapped()
+    {
+        var content = new StreamContent(new StallingStream());
+        content.Headers.ContentLength = null;
+        var handler = new ResponseHandler(() => new HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = content });
+        // A deadline far longer than the caller's cancellation, so a regression that ignores the
+        // caller's token fails on the wrong exception type rather than hanging the suite.
+        var provider = new LocalAiProvider("http://localhost:11434/v1", "llama3.1", handler)
+        {
+            RequestTimeout = TimeSpan.FromSeconds(30),
+        };
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+
+        Assert.ThrowsAny<OperationCanceledException>(() => provider.Generate("Run Rails", cts.Token));
+    }
+
+    [Fact]
+    public void DiscoverModelRejectsARootThatIsNotAnObject()
+    {
+        var handler = new StubHandler("""["llama3.1"]""");
+
+        var exception = Assert.Throws<WipException>(() => LocalAiProvider.DiscoverModel("http://localhost:11434/v1", handler));
+        Assert.Contains("not shaped as expected", exception.Message);
+    }
+
+    [Fact]
+    public void GenerateRejectsARootThatIsNotAnObject()
+    {
+        var handler = new StubHandler("""["nope"]""");
+        var provider = new LocalAiProvider("http://localhost:11434/v1", "llama3.1", handler);
+
+        var exception = Assert.Throws<WipException>(
+            () => provider.Generate("Run Rails", TestContext.Current.CancellationToken));
+        Assert.Contains("choices[0].message.content", exception.Message);
+    }
+
+    [Fact]
+    public void GenerateRejectsAChoiceThatIsNotAnObject()
+    {
+        var handler = new StubHandler("""{"choices":["nope"]}""");
+        var provider = new LocalAiProvider("http://localhost:11434/v1", "llama3.1", handler);
+
+        var exception = Assert.Throws<WipException>(
+            () => provider.Generate("Run Rails", TestContext.Current.CancellationToken));
+        Assert.Contains("choices[0].message.content", exception.Message);
+    }
+
+    [Fact]
     public void GenerateTruncatesAndEscapesAHugeErrorBody()
     {
         var body = "bad\n\t" + new string('x', LocalAiProvider.ErrorBodyMaxBytes * 2);
@@ -340,6 +418,11 @@ public class WipAiTests
             Task.FromResult(responseFactory());
     }
 
+    /// <summary>
+    /// A body stream that records how much of itself was actually consumed. Only the two
+    /// synchronous reads are counted: MemoryStream's own ReadAsync overloads delegate to them,
+    /// so counting ReadAsync too would double every byte.
+    /// </summary>
     private sealed class TrackingStream(byte[] bytes) : MemoryStream(bytes)
     {
         internal long BytesRead { get; private set; }
@@ -357,14 +440,38 @@ public class WipAiTests
             BytesRead += read;
             return read;
         }
+    }
+
+    /// <summary>A body stream whose headers arrived but whose content never does — the shape of a
+    /// server that stalls mid-response, which no HttpClient.Timeout covers under
+    /// ResponseHeadersRead.</summary>
+    private sealed class StallingStream : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => 0; set => throw new NotSupportedException(); }
+        public override void Flush() => throw new NotSupportedException();
+
+        // Only the token-carrying reads are supported: a synchronous read has no token to
+        // observe, so it could only ever hang the test run instead of failing it.
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override Task<int> ReadAsync(
+            byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+            ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
 
         public override async ValueTask<int> ReadAsync(
             Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
-            var read = await base.ReadAsync(buffer, cancellationToken);
-            BytesRead += read;
-            return read;
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+            return 0;
         }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
 
     private sealed class StubHandler(string responseBody) : HttpMessageHandler


### PR DESCRIPTION
### Motivation

- Prevent unbounded memory and CPU use when querying a misbehaving local OpenAI-compatible server by bounding sizes for model lists and chat completions. 
- Avoid reading huge response bodies into memory and fail fast when `Content-Length` declares a response larger than a sensible limit. 
- Ensure error responses are safely reported without spamming terminals or logs with raw control characters or multi-megabyte blobs.

### Description

- Add per-purpose limits: `ModelsResponseMaxBytes = 2 MiB`, `ChatResponseMaxBytes = 4 MiB`, `GeneratedContentMaxCharacters = 1 Mi` and `ErrorBodyMaxBytes = 4 KiB` in `LocalAiProvider`. 
- Use `HttpCompletionOption.ResponseHeadersRead` for `/models` and `/chat/completions`, check `Content-Length` before reading, and reject oversized declared responses. 
- Stream-parse JSON directly via `ParseResponseAsync` which wraps the response stream in a `LimitedReadStream` sentinel to stop parsing once the byte limit is exceeded and avoids building huge intermediate strings. 
- Read at most `ErrorBodyMaxBytes` from non-success responses with `ReadErrorSnippetAsync`, truncate and escape control characters via `TruncateAndEscape`, and cap the final `choices[0].message.content` length with an explicit error. 
- Add unit tests that exercise oversized `Content-Length` rejection, chunked/unknown-length stream overflow detection, large error-body truncation/escaping, an in-limit successful response, and generated-content character-limit rejection in `tests/Wip.Tests/WipAiTests.cs`.

### Testing

- `git diff --check` was run to validate formatting and reported no issues. 
- `dotnet test tests/Wip.Tests/Wip.Tests.csproj --no-restore` was attempted but could not be executed in this environment because `dotnet` is not installed, so the new tests were added but not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a975477d2288322920ea296cf30931d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added time limits for model discovery and chat generation, including streamed responses.
  * Preserved caller cancellation during chat generation.
  * Added safeguards limiting response sizes and generated-content length.
  * Improved handling of malformed responses and safely truncated error details.

* **Bug Fixes**
  * Prevented excessive response data from being read during AI interactions.

* **Tests**
  * Added coverage for response limits, streaming, error reporting, and content-length boundaries.

* **Chores**
  * Updated the project version to 2.3.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->