### PR TITLE
fix(config): redact structured environment values

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.3.1</Version>
+    <Version>2.3.2</Version>
     <Authors>wip contributors</Authors>
     <Product>wip</Product>
     <Description>A developer-friendly CLI wrapper for Microsoft WSLC.</Description>

--- a/README.md
+++ b/README.md
@@ -403,11 +403,12 @@ sync: # optional; mirror the source into a named volume instead of bind-mounting
     - node_modules/
 ```
 
-`env` values are stringified. `wip config` masks every `env` value it prints, whatever the
-variable is called, and keeps the variable names so the output is still readable; elsewhere in
-the config it masks keys naming credential material (token, password, secret, credential, auth,
-passphrase, connection string, database URL, DSN, cookie, session, and API/access/private/SSH
-keys). Keep real secrets out of the config file and in your runtime environment instead — see
+`env` values are stringified. In the `env` block of a dependency or a command, `wip config`
+masks every value whatever the variable is called, keeping the variable names so the output is
+still readable. Everywhere else — including an `env` key somewhere other than those two places
+— it masks by key name only: token, password, secret, credential, auth, passphrase, connection
+string, database URL, DSN, cookie, session, and API/access/private/SSH keys. Keep real secrets
+out of the config file and in your runtime environment instead — see
 [Secret Masking](https://github.com/slidict/wip/wiki/Secret-Masking).
 
 `healthcheck.test` accepts the same three shapes real Compose does: a bare string (shell form,

--- a/README.md
+++ b/README.md
@@ -403,9 +403,12 @@ sync: # optional; mirror the source into a named volume instead of bind-mounting
     - node_modules/
 ```
 
-`env` values are stringified. `wip config` masks any key matching token, password, secret,
-credential, or auth. Keep real secrets out of the config file and in your runtime environment
-instead — see [Secret Masking](https://github.com/slidict/wip/wiki/Secret-Masking).
+`env` values are stringified. `wip config` masks every `env` value it prints, whatever the
+variable is called, and keeps the variable names so the output is still readable; elsewhere in
+the config it masks keys naming credential material (token, password, secret, credential, auth,
+passphrase, connection string, database URL, DSN, cookie, session, and API/access/private/SSH
+keys). Keep real secrets out of the config file and in your runtime environment instead — see
+[Secret Masking](https://github.com/slidict/wip/wiki/Secret-Masking).
 
 `healthcheck.test` accepts the same three shapes real Compose does: a bare string (shell form,
 run as `sh -c "..."`), an array starting with `CMD` (run exactly as written) or `CMD-SHELL`

--- a/src/Wip.Core/Configuration/Config.cs
+++ b/src/Wip.Core/Configuration/Config.cs
@@ -181,6 +181,12 @@ public sealed partial class Config
         return RubyValue.Merge(defaults, RubyValue.AsMapping(entry));
     }
 
+    /// <summary>
+    /// Renders the whole config the way <c>wip config</c> prints it, with dependency defaults
+    /// and inherited settings already merged into each command. Secrets are masked unless
+    /// <paramref name="redact"/> says otherwise; callers that need the real values (running a
+    /// container, building argv) read the config directly rather than going through here.
+    /// </summary>
     public OrderedDictionary<string, object?> ToMapping(bool redact = true)
     {
         var commands = RubyValue.NewMapping();
@@ -524,6 +530,12 @@ public sealed partial class Config
         }
     }
 
+    /// <summary>
+    /// Walks the rendered config and masks secret values, carrying the traversal
+    /// <paramref name="path"/> so <see cref="RedactMapping"/> can tell where a value lives.
+    /// Lists keep the path of their parent: an <c>env</c> mapping nested in one is still an
+    /// <c>env</c> mapping.
+    /// </summary>
     private static object? RedactSecrets(object? value, IReadOnlyList<string>? path = null) => value switch
     {
         List<object?> list => list.Select(item => RedactSecrets(item, path)).ToList(),
@@ -531,6 +543,12 @@ public sealed partial class Config
         _ => value,
     };
 
+    /// <summary>
+    /// Copies one mapping with its secret values replaced. Inside a container <c>env</c> block
+    /// every value goes, because a variable name is not a reliable signal of what it holds;
+    /// everywhere else only keys matching <see cref="SecretPattern"/> do. Keys and structure
+    /// survive either way, which is what makes the printed config still worth reading.
+    /// </summary>
     private static OrderedDictionary<string, object?> RedactMapping(
         OrderedDictionary<string, object?> mapping,
         IReadOnlyList<string> path)
@@ -547,6 +565,11 @@ public sealed partial class Config
         return result;
     }
 
+    /// <summary>
+    /// True for the <c>env</c> mapping of a dependency or a command — that is,
+    /// <c>dependencies.&lt;name&gt;.env</c> or <c>commands.&lt;name&gt;.env</c> — and nothing else,
+    /// so an <c>env</c> key elsewhere in the tree keeps name-based matching.
+    /// </summary>
     private static bool IsContainerEnvironment(IReadOnlyList<string> path) =>
         path.Count == 3 &&
         path[2] == "env" &&

--- a/src/Wip.Core/Configuration/Config.cs
+++ b/src/Wip.Core/Configuration/Config.cs
@@ -524,29 +524,39 @@ public sealed partial class Config
         }
     }
 
-    private static object? RedactSecrets(object? value) => value switch
+    private static object? RedactSecrets(object? value, IReadOnlyList<string>? path = null) => value switch
     {
-        List<object?> list => list.Select(RedactSecrets).ToList(),
-        OrderedDictionary<string, object?> mapping => RedactMapping(mapping),
+        List<object?> list => list.Select(item => RedactSecrets(item, path)).ToList(),
+        OrderedDictionary<string, object?> mapping => RedactMapping(mapping, path ?? []),
         _ => value,
     };
 
-    private static OrderedDictionary<string, object?> RedactMapping(OrderedDictionary<string, object?> mapping)
+    private static OrderedDictionary<string, object?> RedactMapping(
+        OrderedDictionary<string, object?> mapping,
+        IReadOnlyList<string> path)
     {
         var result = RubyValue.NewMapping();
+        var redactEnvironment = IsContainerEnvironment(path);
         foreach (var (key, value) in mapping)
         {
-            result[key] = SecretPattern().IsMatch(key) ? "[REDACTED]" : RedactSecrets(value);
+            result[key] = redactEnvironment || SecretPattern().IsMatch(key)
+                ? "[REDACTED]"
+                : RedactSecrets(value, [.. path, key]);
         }
 
         return result;
     }
 
+    private static bool IsContainerEnvironment(IReadOnlyList<string> path) =>
+        path.Count == 3 &&
+        path[2] == "env" &&
+        path[0] is "dependencies" or "commands";
+
     // Keep this focused on names conventionally used for secret material. A blanket "key"
     // match would hide harmless fields such as public_key, while omitting API_KEY and
     // SSH_KEY would leak two of the most common credential names from `wip config`.
     [GeneratedRegex(
-        "token|password|secret|credential|auth|passphrase|pwd|(?:api|access|private|ssh|encryption|signing)[_-]?key",
+        "token|password|secret|credential|auth|passphrase|pwd|connection[_-]?string|database[_-]?url|dsn|cookie|session|(?:api|access|private|ssh|encryption|signing)[_-]?key",
         RegexOptions.IgnoreCase)]
     private static partial Regex SecretPattern();
 }

--- a/tests/Wip.Tests/ConfigRedactionTests.cs
+++ b/tests/Wip.Tests/ConfigRedactionTests.cs
@@ -133,6 +133,35 @@ public class ConfigRedactionTests
         Assert.Equal("[REDACTED]", EnvironmentFrom(mapping)["SERVICE_URL"]);
     }
 
+    /// <summary>
+    /// The blanket rule is scoped to <c>dependencies.&lt;name&gt;.env</c> and
+    /// <c>commands.&lt;name&gt;.env</c>. An <c>env</c> mapping anywhere else is ordinary config and
+    /// falls back to name matching, so a change that widened the scope would fail here.
+    /// </summary>
+    [Fact]
+    public void KeepsNameMatchingForEnvironmentBlocksElsewhereInTheTree()
+    {
+        var config = ConfigFrom("""
+            version: 1
+            mode: container
+            container: app
+            dependencies:
+              app:
+                image: example
+                settings:
+                  env:
+                    LOG_LEVEL: debug
+                    API_KEY: sensitive-value
+            """);
+
+        var dependency = DependencyFrom(config.ToMapping());
+        var settings = (OrderedDictionary<string, object?>)dependency["settings"]!;
+        var environment = (OrderedDictionary<string, object?>)settings["env"]!;
+
+        Assert.Equal("debug", environment["LOG_LEVEL"]);
+        Assert.Equal("[REDACTED]", environment["API_KEY"]);
+    }
+
     /// <summary>Nothing is masked when the caller asks for the unredacted mapping.</summary>
     [Fact]
     public void KeepsEveryValueWhenRedactionIsDisabled()

--- a/tests/Wip.Tests/ConfigRedactionTests.cs
+++ b/tests/Wip.Tests/ConfigRedactionTests.cs
@@ -12,6 +12,11 @@ public class ConfigRedactionTests
     [InlineData("SIGNING-KEY")]
     [InlineData("PASSPHRASE")]
     [InlineData("PWD")]
+    [InlineData("CONNECTION_STRING")]
+    [InlineData("DATABASE_URL")]
+    [InlineData("DSN")]
+    [InlineData("COOKIE")]
+    [InlineData("SESSION")]
     public void RedactsCommonCredentialNames(string name)
     {
         var config = ConfigWithEnvironment(name, "sensitive-value");
@@ -20,13 +25,103 @@ public class ConfigRedactionTests
         Assert.Equal("[REDACTED]", environment[name]);
     }
 
+    [Theory]
+    [InlineData("connection_string")]
+    [InlineData("database_url")]
+    [InlineData("dsn")]
+    [InlineData("cookie")]
+    [InlineData("session")]
+    public void RedactsSupplementalSecretNamesOutsideEnvironmentBlocks(string name)
+    {
+        var config = ConfigFrom($$"""
+            version: 1
+            mode: container
+            container: app
+            dependencies:
+              app:
+                image: example
+                {{name}}: sensitive-value
+            """);
+
+        Assert.Equal("[REDACTED]", DependencyFrom(config.ToMapping())[name]);
+    }
+
     [Fact]
     public void DoesNotRedactPublicKeys()
     {
-        var config = ConfigWithEnvironment("PUBLIC_KEY", "safe-to-display");
-        var environment = EnvironmentFrom(config.ToMapping());
+        var config = ConfigFrom("""
+            version: 1
+            mode: container
+            container: app
+            dependencies:
+              app:
+                image: example
+                public_key: safe-to-display
+            """);
 
-        Assert.Equal("safe-to-display", environment["PUBLIC_KEY"]);
+        Assert.Equal("safe-to-display", DependencyFrom(config.ToMapping())["public_key"]);
+    }
+
+    [Fact]
+    public void RedactsEveryDependencyEnvironmentValueRegardlessOfVariableName()
+    {
+        var config = ConfigWithEnvironment("MY_UNUSUAL_SETTING", "sensitive-value");
+        var mapping = config.ToMapping();
+        var environment = EnvironmentFrom(mapping);
+
+        Assert.Equal("[REDACTED]", environment["MY_UNUSUAL_SETTING"]);
+        Assert.Equal("example", DependencyFrom(mapping)["image"]);
+    }
+
+    [Fact]
+    public void RedactsEnvironmentInheritedByCommands()
+    {
+        var config = ConfigFrom("""
+            version: 1
+            mode: container
+            container: app
+            dependencies:
+              app:
+                image: example
+                workdir: /workspace
+                env:
+                  CUSTOM_NAME: inherited-secret
+            commands:
+              test:
+                command: dotnet test
+            """);
+
+        var mapping = config.ToMapping();
+        var commands = (OrderedDictionary<string, object?>)mapping["commands"]!;
+        var test = (OrderedDictionary<string, object?>)commands["test"]!;
+        var environment = (OrderedDictionary<string, object?>)test["env"]!;
+
+        Assert.Equal("[REDACTED]", environment["CUSTOM_NAME"]);
+        Assert.Equal("/workspace", test["workdir"]);
+    }
+
+    [Fact]
+    public void PreservesNonSecretSettingsIncludingOrdinaryUrls()
+    {
+        var config = ConfigFrom("""
+            version: 1
+            mode: container
+            container: app
+            dependencies:
+              app:
+                image: example/app:latest
+                workdir: /workspace
+                homepage_url: https://example.test/service
+                env:
+                  SERVICE_URL: https://example.test/api
+            """);
+
+        var dependency = DependencyFrom(config.ToMapping());
+
+        Assert.Equal("example/app:latest", dependency["image"]);
+        Assert.Equal("/workspace", dependency["workdir"]);
+        Assert.Equal("https://example.test/service", dependency["homepage_url"]);
+        Assert.Equal("[REDACTED]", EnvironmentFrom(config.ToMapping())["SERVICE_URL"]);
     }
 
     private static Config ConfigWithEnvironment(string name, string value)
@@ -42,14 +137,22 @@ public class ConfigRedactionTests
                          {name}: {value}
                    """;
 
-        return new Config(YamlLoader.LoadText(yaml, allowAliases: false));
+        return ConfigFrom(yaml);
+    }
+
+    private static Config ConfigFrom(string yaml) =>
+        new(YamlLoader.LoadText(yaml, allowAliases: false));
+
+    private static OrderedDictionary<string, object?> DependencyFrom(
+        OrderedDictionary<string, object?> mapping)
+    {
+        var dependencies = (OrderedDictionary<string, object?>)mapping["dependencies"]!;
+        return (OrderedDictionary<string, object?>)dependencies["app"]!;
     }
 
     private static OrderedDictionary<string, object?> EnvironmentFrom(
         OrderedDictionary<string, object?> mapping)
     {
-        var dependencies = (OrderedDictionary<string, object?>)mapping["dependencies"]!;
-        var app = (OrderedDictionary<string, object?>)dependencies["app"]!;
-        return (OrderedDictionary<string, object?>)app["env"]!;
+        return (OrderedDictionary<string, object?>)DependencyFrom(mapping)["env"]!;
     }
 }

--- a/tests/Wip.Tests/ConfigRedactionTests.cs
+++ b/tests/Wip.Tests/ConfigRedactionTests.cs
@@ -3,49 +3,47 @@ using Wip.Yaml;
 
 namespace Wip.Tests;
 
+/// <summary>
+/// Pins what <c>wip config</c> is allowed to print. Two rules are at work and the tests keep
+/// them apart: inside a dependency or command <c>env</c> block every value is masked, and
+/// outside one only keys that name credential material are.
+/// </summary>
 public class ConfigRedactionTests
 {
+    /// <summary>
+    /// Outside an <c>env</c> block redaction is name-based, so these are the names that have to
+    /// match. Placing them on the dependency itself keeps the blanket <c>env</c> rule out of the
+    /// way — inside <c>env</c> they would be masked whatever the pattern said.
+    /// </summary>
     [Theory]
-    [InlineData("API_KEY")]
-    [InlineData("AWS_ACCESS_KEY_ID")]
-    [InlineData("SSH_KEY")]
-    [InlineData("SIGNING-KEY")]
-    [InlineData("PASSPHRASE")]
-    [InlineData("PWD")]
-    [InlineData("CONNECTION_STRING")]
-    [InlineData("DATABASE_URL")]
-    [InlineData("DSN")]
-    [InlineData("COOKIE")]
-    [InlineData("SESSION")]
-    public void RedactsCommonCredentialNames(string name)
-    {
-        var config = ConfigWithEnvironment(name, "sensitive-value");
-        var environment = EnvironmentFrom(config.ToMapping());
-
-        Assert.Equal("[REDACTED]", environment[name]);
-    }
-
-    [Theory]
+    [InlineData("api_key")]
+    [InlineData("access_key")]
+    [InlineData("ssh_key")]
+    [InlineData("signing-key")]
+    [InlineData("passphrase")]
+    [InlineData("password")]
+    [InlineData("token")]
     [InlineData("connection_string")]
     [InlineData("database_url")]
     [InlineData("dsn")]
     [InlineData("cookie")]
     [InlineData("session")]
-    public void RedactsSupplementalSecretNamesOutsideEnvironmentBlocks(string name)
+    public void RedactsCredentialNamesOutsideEnvironmentBlocks(string name)
     {
-        var config = ConfigFrom($$"""
+        var config = ConfigFrom($"""
             version: 1
             mode: container
             container: app
             dependencies:
               app:
                 image: example
-                {{name}}: sensitive-value
+                {name}: sensitive-value
             """);
 
         Assert.Equal("[REDACTED]", DependencyFrom(config.ToMapping())[name]);
     }
 
+    /// <summary>A key that merely contains "key" is not a secret; public_key stays readable.</summary>
     [Fact]
     public void DoesNotRedactPublicKeys()
     {
@@ -62,6 +60,10 @@ public class ConfigRedactionTests
         Assert.Equal("safe-to-display", DependencyFrom(config.ToMapping())["public_key"]);
     }
 
+    /// <summary>
+    /// The point of the blanket rule: a variable holding a credential under a house-style name
+    /// is masked too, while the variable names and the rest of the dependency stay printable.
+    /// </summary>
     [Fact]
     public void RedactsEveryDependencyEnvironmentValueRegardlessOfVariableName()
     {
@@ -69,10 +71,12 @@ public class ConfigRedactionTests
         var mapping = config.ToMapping();
         var environment = EnvironmentFrom(mapping);
 
+        Assert.True(environment.ContainsKey("MY_UNUSUAL_SETTING"));
         Assert.Equal("[REDACTED]", environment["MY_UNUSUAL_SETTING"]);
         Assert.Equal("example", DependencyFrom(mapping)["image"]);
     }
 
+    /// <summary>Commands inherit the primary dependency's env, and inherit the masking with it.</summary>
     [Fact]
     public void RedactsEnvironmentInheritedByCommands()
     {
@@ -100,6 +104,10 @@ public class ConfigRedactionTests
         Assert.Equal("/workspace", test["workdir"]);
     }
 
+    /// <summary>
+    /// A URL is not a secret by virtue of being a URL: one outside <c>env</c> stays readable,
+    /// and one inside is masked only because everything in <c>env</c> is.
+    /// </summary>
     [Fact]
     public void PreservesNonSecretSettingsIncludingOrdinaryUrls()
     {
@@ -116,14 +124,26 @@ public class ConfigRedactionTests
                   SERVICE_URL: https://example.test/api
             """);
 
-        var dependency = DependencyFrom(config.ToMapping());
+        var mapping = config.ToMapping();
+        var dependency = DependencyFrom(mapping);
 
         Assert.Equal("example/app:latest", dependency["image"]);
         Assert.Equal("/workspace", dependency["workdir"]);
         Assert.Equal("https://example.test/service", dependency["homepage_url"]);
-        Assert.Equal("[REDACTED]", EnvironmentFrom(config.ToMapping())["SERVICE_URL"]);
+        Assert.Equal("[REDACTED]", EnvironmentFrom(mapping)["SERVICE_URL"]);
     }
 
+    /// <summary>Nothing is masked when the caller asks for the unredacted mapping.</summary>
+    [Fact]
+    public void KeepsEveryValueWhenRedactionIsDisabled()
+    {
+        var config = ConfigWithEnvironment("DATABASE_PASSWORD", "swordfish");
+        var mapping = config.ToMapping(redact: false);
+
+        Assert.Equal("swordfish", EnvironmentFrom(mapping)["DATABASE_PASSWORD"]);
+    }
+
+    /// <summary>Builds a single-dependency config whose env holds one variable.</summary>
     private static Config ConfigWithEnvironment(string name, string value)
     {
         var yaml = $"""
@@ -140,9 +160,11 @@ public class ConfigRedactionTests
         return ConfigFrom(yaml);
     }
 
+    /// <summary>Loads a config from inline YAML, the way a wip.yml on disk would be read.</summary>
     private static Config ConfigFrom(string yaml) =>
         new(YamlLoader.LoadText(yaml, allowAliases: false));
 
+    /// <summary>Digs out the <c>app</c> dependency the fixtures above all define.</summary>
     private static OrderedDictionary<string, object?> DependencyFrom(
         OrderedDictionary<string, object?> mapping)
     {
@@ -150,6 +172,7 @@ public class ConfigRedactionTests
         return (OrderedDictionary<string, object?>)dependencies["app"]!;
     }
 
+    /// <summary>Digs out that dependency's <c>env</c> block.</summary>
     private static OrderedDictionary<string, object?> EnvironmentFrom(
         OrderedDictionary<string, object?> mapping)
     {

--- a/tests/golden/README.md
+++ b/tests/golden/README.md
@@ -50,6 +50,17 @@ Windows side rather than inside WSL — see `docs/csharp-migration-plan.md` §3:
 - `builder.up`, `builder.run`, `builder.custom[*]` → `-v` entries derived from `volumes:`
 - `config.compose_build_specs` → `context`
 
+There is one further divergence, and it is not about paths:
+
+- `config.to_h` → every value under `dependencies.*.env` and `commands.*.env`
+
+Ruby redacted environment values by variable *name*, so anything it did not recognise as
+a credential — `DATABASE_URL`, an `APP_*` variable holding a token, a password stored
+under a house-style name — was printed in full by `wip config`. Name matching cannot be
+made complete, so the port redacts the whole `env` mapping instead and keeps only the
+variable names, which is what the diagnostic actually needs. `config.to_h.unredacted` is
+unchanged and still records the real values.
+
 When one of these changes, update the expectation in the same commit as the code and say
 why. Everything else should stay green untouched; an unexplained diff outside this list
 is a regression.

--- a/tests/golden/cases/001-container-basic/cases.json
+++ b/tests/golden/cases/001-container-basic/cases.json
@@ -17,8 +17,8 @@
           "remove": true,
           "command": "server -p 3000",
           "env": {
-            "RAILS_ENV": "development",
-            "PORT": "3000",
+            "RAILS_ENV": "[REDACTED]",
+            "PORT": "[REDACTED]",
             "DATABASE_PASSWORD": "[REDACTED]"
           },
           "ports": [
@@ -54,8 +54,8 @@
           "interactive": true,
           "remove": true,
           "env": {
-            "RAILS_ENV": "development",
-            "PORT": "3000",
+            "RAILS_ENV": "[REDACTED]",
+            "PORT": "[REDACTED]",
             "DATABASE_PASSWORD": "[REDACTED]"
           },
           "ports": [
@@ -78,8 +78,8 @@
           "interactive": false,
           "remove": true,
           "env": {
-            "RAILS_ENV": "development",
-            "PORT": "3000",
+            "RAILS_ENV": "[REDACTED]",
+            "PORT": "[REDACTED]",
             "DATABASE_PASSWORD": "[REDACTED]"
           },
           "ports": [
@@ -102,8 +102,8 @@
           "interactive": true,
           "remove": true,
           "env": {
-            "RAILS_ENV": "development",
-            "PORT": "3000",
+            "RAILS_ENV": "[REDACTED]",
+            "PORT": "[REDACTED]",
             "DATABASE_PASSWORD": "[REDACTED]"
           },
           "ports": [
@@ -127,8 +127,8 @@
           "interactive": false,
           "remove": true,
           "env": {
-            "RAILS_ENV": "development",
-            "PORT": "3000",
+            "RAILS_ENV": "[REDACTED]",
+            "PORT": "[REDACTED]",
             "DATABASE_PASSWORD": "[REDACTED]"
           },
           "ports": [

--- a/tests/golden/cases/003-compose-native/cases.json
+++ b/tests/golden/cases/003-compose-native/cases.json
@@ -37,8 +37,8 @@
           "image": "wip-compose-web:latest",
           "command": "bin/rails server -b 0.0.0.0",
           "env": {
-            "RAILS_ENV": "development",
-            "DATABASE_URL": "postgres://db/app"
+            "RAILS_ENV": "[REDACTED]",
+            "DATABASE_URL": "[REDACTED]"
           },
           "ports": [
             "3000:3000"
@@ -64,8 +64,8 @@
           "interactive": true,
           "remove": true,
           "env": {
-            "RAILS_ENV": "development",
-            "DATABASE_URL": "postgres://db/app"
+            "RAILS_ENV": "[REDACTED]",
+            "DATABASE_URL": "[REDACTED]"
           },
           "ports": [
             "3000:3000"

--- a/tests/golden/cases/005-dotenv/cases.json
+++ b/tests/golden/cases/005-dotenv/cases.json
@@ -13,8 +13,8 @@
           "image": "myapp:dev",
           "workdir": "/app",
           "env": {
-            "RAILS_ENV": "development",
-            "PORT": "4000"
+            "RAILS_ENV": "[REDACTED]",
+            "PORT": "[REDACTED]"
           }
         }
       },
@@ -27,8 +27,8 @@
           "interactive": false,
           "remove": true,
           "env": {
-            "RAILS_ENV": "development",
-            "PORT": "4000"
+            "RAILS_ENV": "[REDACTED]",
+            "PORT": "[REDACTED]"
           },
           "ports": [],
           "volumes": [],

--- a/tests/golden/cases/007-interaction-alias/cases.json
+++ b/tests/golden/cases/007-interaction-alias/cases.json
@@ -43,7 +43,7 @@
           "interactive": false,
           "remove": false,
           "env": {
-            "RAILS_ENV": "test"
+            "RAILS_ENV": "[REDACTED]"
           },
           "ports": [],
           "volumes": [],


### PR DESCRIPTION
### Motivation

- Make secret redaction structure-aware so that environment mappings under `dependencies.*.env` and `commands.*.env` always have their values masked while preserving variable names and the overall config shape for diagnostics.
- Broaden fallback key-based detection for likely secrets without treating ordinary service URLs as secrets.
- Keep default behavior to hide secrets (explicit opt-in to show secrets can be added separately if needed).

### Description

- Extend `RedactSecrets` to track the traversal `path` and propagate it during recursive redaction so the code can reason about where a value lives in the config tree.
- Change `RedactMapping` to accept the current `path`, detect container environment mappings via a new `IsContainerEnvironment` helper, and redact every value under `dependencies.*.env` and `commands.*.env`; non-environment values fall back to `SecretPattern` name matching.
- Expand the `SecretPattern` regex to include `connection_string`, `database_url`, `dsn`, `cookie`, and `session` as supplemental secret-name matches while keeping existing patterns for API/private keys and passphrases.
- Add comprehensive tests in `tests/Wip.Tests/ConfigRedactionTests.cs` that validate: common credential name redaction, supplemental key-name redaction outside `env` blocks, environment inheritance into `commands`, and preservation of non-secret fields such as `image`, `workdir`, public keys, and ordinary URLs.
- Bump project version from `2.3.1` to `2.3.2` in `Directory.Build.props`.

### Testing

- Added unit tests: `tests/Wip.Tests/ConfigRedactionTests.cs` covering the redaction behavior described above.
- Ran `git diff --check` to validate there are no obvious diff issues; this passed.
- Attempted to run `dotnet test tests/Wip.Tests/Wip.Tests.csproj --filter FullyQualifiedName~ConfigRedactionTests` but the `dotnet` runtime was not available in the execution environment, so the unit tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a975479276883229350d3d2ab40e37b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret redaction across dependency and command environment settings, including nested configurations.
  * Added recognition for connection strings, database URLs, DSNs, cookies, sessions, and other credential-like values.
  * Preserved non-sensitive settings and ordinary URLs during redaction.
  * Disabled redaction now reliably preserves all configuration values.

* **Documentation**
  * Expanded guidance on masked environment values and supported credential patterns.

* **Chores**
  * Updated the application version from 2.3.1 to 2.3.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->