### PR TITLE
feat(cli): ground wip help --ai in the wiki manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,7 @@ and examples — start at the
 | `wip init [--force] [--template NAME]` | Write a starter `wip.yml`: `mode: compose-native` if a `compose.yml`, `compose.yaml`, `docker-compose.yml`, or `docker-compose.yaml` is found next to it, `mode: container` otherwise |
 | `wip version` | wip's version, plus WSLC's if it can be detected |
 | `wip doctor` | Diagnose WSL2, WSLC, config, architecture, Git, and the `--ai` host |
+| `wip manual` | Download the wip wiki so `wip help --ai` can answer offline |
 | `wip config` | Print the effective configuration (secrets masked) |
 | `wip build [--no-cache] [-- OPTIONS]` | Build the image from the `build` definition |
 | `wip up [-d] [--no-sync] [--no-cache] [--watch] [--interval N]` | Start the configured stack, creating it if necessary (waits on any `healthcheck:` before starting whatever depends on it) |

--- a/src/Wip.Cli/CliContext.cs
+++ b/src/Wip.Cli/CliContext.cs
@@ -250,7 +250,8 @@ internal sealed partial class CliContext
         return 0;
     }
 
-    internal int HelpAi(string? url, IReadOnlyList<string> question, bool allowRemoteAi = false)
+    internal int HelpAi(
+        string? url, IReadOnlyList<string> question, bool allowRemoteAi = false, bool noCache = false)
     {
         var baseUrl = LocalAiProvider.ResolveBaseUrl(url);
         var endpoint = LocalAiProvider.ValidateBaseUrl(baseUrl, allowRemoteAi);
@@ -273,9 +274,11 @@ internal sealed partial class CliContext
             throw new WipException("A question is required");
         }
 
+        var (manual, manualSource) = ResolveManual(asked, noCache);
+        Log.Info($"manual: {manualSource}");
         Log.Info($"asking {model} at {baseUrl}");
         var answer = new LocalAiProvider(baseUrl, model, allowInsecureRemoteHttp: allowRemoteAi)
-            .Generate(HelpAiPrompt(asked));
+            .Generate(HelpAiPrompt(asked, manual));
         Console.WriteLine(answer);
         return 0;
     }
@@ -307,6 +310,45 @@ internal sealed partial class CliContext
         }
     }
 
+    /// <summary>
+    /// Selects the wiki manual page(s) relevant to <paramref name="question"/> (see <see
+    /// cref="ManualSelector"/>), preferring an already-downloaded cache (<c>wip manual</c>) over
+    /// a live wiki fetch, and falling back to no manual context at all when neither is
+    /// available. A live-fetch failure is swallowed rather than thrown: <c>help --ai</c> worked
+    /// without the manual before this existed, and a flaky network is not a reason to break it
+    /// now. <paramref name="noCache"/> (<c>help --ai --no-cache</c>) skips a downloaded cache
+    /// even when one exists, for a question about a page that changed on the wiki since the
+    /// last <c>wip manual</c> run.
+    /// </summary>
+    private static (string Excerpt, string Source) ResolveManual(string question, bool noCache = false)
+    {
+        IReadOnlyList<ManualPage> cached = noCache ? [] : WikiManual.LoadCache(WikiManual.DefaultCacheDirectory());
+        if (cached.Count > 0)
+        {
+            return (Join(ManualSelector.SelectRelevant(question, cached)), "cached");
+        }
+
+        if (!WikiManual.IsReachable())
+        {
+            return ("", "unavailable");
+        }
+
+        try
+        {
+            var wiki = new WikiManual();
+            var candidates = ManualSelector.SelectCandidateNames(question, wiki.FetchPageNames());
+            var pages = candidates.Count > 0 ? wiki.FetchPages(candidates) : [];
+            return (Join(ManualSelector.SelectRelevant(question, pages)), "live");
+        }
+        catch (WipException)
+        {
+            return ("", "live (fetch failed)");
+        }
+    }
+
+    private static string Join(IReadOnlyList<ManualPage> pages) =>
+        string.Join("\n\n", pages.Select(page => $"### {page.Name}\n{page.Content}"));
+
     private static string ReadQuestion()
     {
         Console.Error.WriteLine(
@@ -322,7 +364,7 @@ internal sealed partial class CliContext
         return string.Join(System.Environment.NewLine, lines);
     }
 
-    private static string HelpAiPrompt(string question) => $$"""
+    private static string HelpAiPrompt(string question, string manual) => $$"""
         You answer questions about how to use the wip CLI, a developer-friendly wrapper around
         Microsoft WSLC. Answer only from the reference below; say plainly that it is not covered
         there rather than guessing.
@@ -330,10 +372,26 @@ internal sealed partial class CliContext
         <wip-help>
         {{Program.HelpText()}}
         </wip-help>
-
+        {{(string.IsNullOrEmpty(manual) ? "" : $"\n<wip-manual>\n{manual}\n</wip-manual>\n")}}
         Question:
         {{question}}
         """;
+
+    /// <summary>Downloads the whole wiki manual to <see
+    /// cref="WikiManual.DefaultCacheDirectory"/> so <c>wip help --ai</c> can select from it
+    /// offline instead of needing a live fetch per question.</summary>
+    internal int ManualDownload()
+    {
+        if (!WikiManual.IsReachable())
+        {
+            throw new WipException("Could not reach the wip wiki (github.com). Check your network connection.");
+        }
+
+        var directory = WikiManual.DefaultCacheDirectory();
+        var count = new WikiManual().Download(directory);
+        Log.Info($"downloaded {count} manual page(s) to {directory}");
+        return 0;
+    }
 
     internal int Doctor(string? url = null)
     {

--- a/src/Wip.Cli/CliContext.cs
+++ b/src/Wip.Cli/CliContext.cs
@@ -384,7 +384,8 @@ internal sealed partial class CliContext
     {
         if (!WikiManual.IsReachable())
         {
-            throw new WipException("Could not reach the wip wiki (github.com). Check your network connection.");
+            throw new WipException(
+                "Could not reach the wip wiki (raw.githubusercontent.com). Check your network connection.");
         }
 
         var directory = WikiManual.DefaultCacheDirectory();

--- a/src/Wip.Cli/CliContext.cs
+++ b/src/Wip.Cli/CliContext.cs
@@ -320,17 +320,19 @@ internal sealed partial class CliContext
     /// even when one exists, for a question about a page that changed on the wiki since the
     /// last <c>wip manual</c> run.
     /// </summary>
+    /// <remarks>
+    /// No separate reachability preflight: a live fetch is simply attempted and its failure
+    /// caught. A preflight built on a raw TCP connect (as an earlier version of this did) gives
+    /// a false "unreachable" on a network that only permits HTTP through a proxy — the actual
+    /// fetch below goes through <see cref="HttpClient"/>, which is proxy-aware, so trying it
+    /// directly is both simpler and more accurate than probing first.
+    /// </remarks>
     private static (string Excerpt, string Source) ResolveManual(string question, bool noCache = false)
     {
         IReadOnlyList<ManualPage> cached = noCache ? [] : WikiManual.LoadCache(WikiManual.DefaultCacheDirectory());
         if (cached.Count > 0)
         {
             return (Join(ManualSelector.SelectRelevant(question, cached)), "cached");
-        }
-
-        if (!WikiManual.IsReachable())
-        {
-            return ("", "unavailable");
         }
 
         try
@@ -342,7 +344,7 @@ internal sealed partial class CliContext
         }
         catch (WipException)
         {
-            return ("", "live (fetch failed)");
+            return ("", "unavailable");
         }
     }
 
@@ -379,15 +381,11 @@ internal sealed partial class CliContext
 
     /// <summary>Downloads the whole wiki manual to <see
     /// cref="WikiManual.DefaultCacheDirectory"/> so <c>wip help --ai</c> can select from it
-    /// offline instead of needing a live fetch per question.</summary>
+    /// offline instead of needing a live fetch per question. A network failure surfaces as
+    /// <see cref="WikiManual"/>'s own <see cref="WipException"/> — naming the page it was
+    /// fetching — rather than a separate, less specific preflight check here.</summary>
     internal int ManualDownload()
     {
-        if (!WikiManual.IsReachable())
-        {
-            throw new WipException(
-                "Could not reach the wip wiki (raw.githubusercontent.com). Check your network connection.");
-        }
-
         var directory = WikiManual.DefaultCacheDirectory();
         var count = new WikiManual().Download(directory);
         Log.Info($"downloaded {count} manual page(s) to {directory}");

--- a/src/Wip.Cli/CliContext.cs
+++ b/src/Wip.Cli/CliContext.cs
@@ -348,8 +348,20 @@ internal sealed partial class CliContext
         }
     }
 
-    private static string Join(IReadOnlyList<ManualPage> pages) =>
-        string.Join("\n\n", pages.Select(page => $"### {page.Name}\n{page.Content}"));
+    /// <summary>
+    /// <see cref="ManualSelector.SelectRelevant"/> bounds each page's own content to its
+    /// character budget, but the "### {name}" headings and "\n\n" separators added here are
+    /// extra, unbudgeted bytes on top of that — so the joined result is clamped to the same
+    /// budget again, rather than letting formatting overhead quietly push the final prompt
+    /// excerpt past what <c>maxCharacters</c> was meant to enforce.
+    /// </summary>
+    internal static string Join(IReadOnlyList<ManualPage> pages)
+    {
+        var joined = string.Join("\n\n", pages.Select(page => $"### {page.Name}\n{page.Content}"));
+        return joined.Length <= ManualSelector.DefaultMaxCharacters
+            ? joined
+            : joined[..ManualSelector.DefaultMaxCharacters];
+    }
 
     private static string ReadQuestion()
     {

--- a/src/Wip.Cli/Program.cs
+++ b/src/Wip.Cli/Program.cs
@@ -154,6 +154,9 @@ internal static class Program
 
         yield return DoctorCommand(context);
         yield return HelpCommand(context);
+        yield return Simple(
+            "manual", "Download the wip wiki so `wip help --ai` can answer offline",
+            context, ctx => ctx.ManualDownload());
         yield return Simple("config", "Print the effective configuration", context, ctx => ctx.ShowConfig());
 
         yield return BuildCommand(context);
@@ -205,10 +208,14 @@ internal static class Program
         };
         var url = AiUrlOption();
         var allowRemoteAi = AllowRemoteAiOption();
+        var noCache = new Option<bool>("--no-cache")
+        {
+            Description = "Skip the `wip manual` cache and fetch the wiki manual live for this question",
+        };
         var question = new Argument<string[]>("question") { Arity = ArgumentArity.ZeroOrMore };
         var command = new Command("help", "Show usage help (add --ai to ask an AI server instead)")
         {
-            ai, url, allowRemoteAi, question,
+            ai, url, allowRemoteAi, noCache, question,
         };
 
         command.SetAction(parsed =>
@@ -224,6 +231,11 @@ internal static class Program
                     throw new WipException("--allow-remote-ai requires --ai");
                 }
 
+                if (parsed.GetValue(noCache))
+                {
+                    throw new WipException("--no-cache requires --ai");
+                }
+
                 if ((parsed.GetValue(question) ?? []).Length > 0)
                 {
                     throw new WipException("a question requires --ai");
@@ -233,7 +245,8 @@ internal static class Program
             }
 
             return context(parsed).HelpAi(
-                parsed.GetValue(url), parsed.GetValue(question) ?? [], parsed.GetValue(allowRemoteAi));
+                parsed.GetValue(url), parsed.GetValue(question) ?? [],
+                parsed.GetValue(allowRemoteAi), parsed.GetValue(noCache));
         });
 
         return command;

--- a/src/Wip.Core/Ai/ManualSelector.cs
+++ b/src/Wip.Core/Ai/ManualSelector.cs
@@ -28,6 +28,7 @@ public static partial class ManualSelector
         "was", "were", "be", "been", "being", "do", "does", "did", "can", "could", "would",
         "should", "will", "shall", "to", "of", "in", "on", "at", "for", "and", "or", "but",
         "not", "no", "so", "if", "this", "that", "these", "those", "it", "its", "you", "your",
+        "my", "me", "we", "us",
     };
 
     /// <summary>
@@ -35,7 +36,9 @@ public static partial class ManualSelector
     /// rest of the sentence is in another language — e.g. "ビルドキャッシュ使わないでbuildする
     /// には" yields just <c>build</c>, which is already enough to find the right page. Matches
     /// hyphenated flag names like <c>no-cache</c> as one token, and drops common function words
-    /// (see <see cref="Stopwords"/>) that would otherwise swamp the real signal.
+    /// (see <see cref="Stopwords"/>) that would otherwise swamp the real signal. The 2-character
+    /// minimum matters on its own: `wip up` and `wip ps` are real commands, and a 3-character
+    /// floor would silently make them unfindable.
     /// </summary>
     public static IReadOnlyList<string> ExtractKeywords(string question) =>
         Keyword().Matches(question).Select(match => match.Value.ToLowerInvariant())
@@ -97,10 +100,11 @@ public static partial class ManualSelector
                 break;
             }
 
-            trimmed.Add(page.Content.Length <= budget
+            var fitted = page.Content.Length <= budget
                 ? page
-                : page with { Content = page.Content[..budget] + "\n[truncated by wip]" });
-            budget -= page.Content.Length;
+                : page with { Content = page.Content[..budget] + "\n[truncated by wip]" };
+            trimmed.Add(fitted);
+            budget -= fitted.Content.Length;
         }
 
         return trimmed;
@@ -125,6 +129,6 @@ public static partial class ManualSelector
         return count;
     }
 
-    [GeneratedRegex(@"[A-Za-z][A-Za-z0-9\-]{2,}")]
+    [GeneratedRegex(@"[A-Za-z][A-Za-z0-9\-]{1,}")]
     private static partial Regex Keyword();
 }

--- a/src/Wip.Core/Ai/ManualSelector.cs
+++ b/src/Wip.Core/Ai/ManualSelector.cs
@@ -20,12 +20,24 @@ public static partial class ManualSelector
     private const string TruncationMarker = "\n[truncated by wip]";
 
     /// <summary>
+    /// <see cref="SelectRelevant"/>'s default character budget, exposed so a caller that adds
+    /// its own formatting around the selected pages (headings, separators — see
+    /// <c>CliContext.Join</c>) can clamp the final, formatted result to the same limit rather
+    /// than letting that formatting overhead push it past what the budget was meant to enforce.
+    /// </summary>
+    public const int DefaultMaxCharacters = 12000;
+
+    /// <summary>
     /// Common English function words that carry no page-selection signal on their own. Left
     /// unfiltered, a word like "the" or "how" occurs so often in ordinary prose that it can
     /// outscore the one real keyword in the question, dragging in unrelated pages (and pushing
     /// the actually relevant page's content past the character budget) — the exact way an
     /// otherwise-working query like "how do I disable the build cache?" picked
     /// <c>Shadow-Build-Context</c> and <c>Registry-Authentication</c> ahead of the real answer.
+    /// Also includes "wip" itself: every single page in this manual is about wip, so — unlike
+    /// an ordinary word — it can never help distinguish one page from another, and only dilutes
+    /// whatever real signal a question also contains (e.g. "what does -d do on wip up" wants
+    /// `wip-up`, not whichever page happens to say "wip" the most).
     /// </summary>
     private static readonly HashSet<string> Stopwords = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -33,7 +45,7 @@ public static partial class ManualSelector
         "was", "were", "be", "been", "being", "do", "does", "did", "can", "could", "would",
         "should", "will", "shall", "to", "of", "in", "on", "at", "for", "and", "or", "but",
         "not", "no", "so", "if", "this", "that", "these", "those", "it", "its", "you", "your",
-        "my", "me", "we", "us",
+        "my", "me", "we", "us", "wip",
     };
 
     /// <summary>
@@ -43,7 +55,10 @@ public static partial class ManualSelector
     /// hyphenated flag names like <c>no-cache</c> as one token, and drops common function words
     /// (see <see cref="Stopwords"/>) that would otherwise swamp the real signal. The 2-character
     /// minimum matters on its own: `wip up` and `wip ps` are real commands, and a 3-character
-    /// floor would silently make them unfindable.
+    /// floor would silently make them unfindable. A single-letter short flag like <c>-d</c> or
+    /// <c>-w</c> is matched as its own token too — it can't clear that 2-character floor on
+    /// letters alone, so it needs the separate <c>-[A-Za-z]</c> alternative below rather than a
+    /// lowered general floor, which would otherwise turn every lone letter into a keyword.
     /// </summary>
     public static IReadOnlyList<string> ExtractKeywords(string question) =>
         Keyword().Matches(question).Select(match => match.Value.ToLowerInvariant())
@@ -80,7 +95,8 @@ public static partial class ManualSelector
     /// the result stays within a small model's context budget.
     /// </summary>
     public static IReadOnlyList<ManualPage> SelectRelevant(
-        string question, IReadOnlyList<ManualPage> pages, int maxPages = 3, int maxCharacters = 12000)
+        string question, IReadOnlyList<ManualPage> pages, int maxPages = 3,
+        int maxCharacters = DefaultMaxCharacters)
     {
         var keywords = ExtractKeywords(question);
         if (keywords.Count == 0)
@@ -147,19 +163,28 @@ public static partial class ManualSelector
     /// command.
     /// </summary>
     /// <remarks>
-    /// Deliberately anchored at the *start* only, not both ends: requiring a boundary after the
-    /// match too would stop "disable" from matching "disables", or "build" from matching
-    /// "builds"/"building" — ordinary English inflections this selector needs to keep finding,
-    /// not noise to filter out. Anchoring the start alone already rules out the cases above,
-    /// since in each one the match begins mid-word, not after a break.
+    /// Anchored at the *start* only for an ordinary word of 3+ characters — requiring a
+    /// boundary after the match too would stop "disable" from matching "disables", or "build"
+    /// from matching "builds"/"building", ordinary English inflections this selector needs to
+    /// keep finding. Two shapes are anchored at *both* ends instead, since neither has
+    /// inflections worth preserving and each has its own way of hiding inside an unrelated,
+    /// longer word as only a prefix: a short flag token (<paramref name="needle"/> starting
+    /// with <c>-</c>, e.g. <c>-d</c>, which would otherwise match inside "-download" or
+    /// "-debug"), and a 1-2 character command name (<c>up</c>, <c>ps</c>), which as a bare
+    /// prefix would otherwise match inside ordinary words like "<b>up</b>date" or
+    /// "<b>up</b>grade" that have nothing to do with the command.
     /// </remarks>
     private static int CountWordStartOccurrences(string haystack, string needle)
     {
+        var requireEndBoundary = needle[0] == '-' || needle.Length <= 2;
         var count = 0;
         var index = 0;
         while ((index = haystack.IndexOf(needle, index, StringComparison.OrdinalIgnoreCase)) >= 0)
         {
-            if (index == 0 || !char.IsLetterOrDigit(haystack[index - 1]))
+            var startsWord = index == 0 || !char.IsLetterOrDigit(haystack[index - 1]);
+            var end = index + needle.Length;
+            var endsWord = !requireEndBoundary || end == haystack.Length || !char.IsLetterOrDigit(haystack[end]);
+            if (startsWord && endsWord)
             {
                 count++;
             }
@@ -170,6 +195,6 @@ public static partial class ManualSelector
         return count;
     }
 
-    [GeneratedRegex(@"[A-Za-z][A-Za-z0-9\-]{1,}")]
+    [GeneratedRegex(@"-[A-Za-z](?![A-Za-z0-9-])|[A-Za-z][A-Za-z0-9\-]{1,}")]
     private static partial Regex Keyword();
 }

--- a/src/Wip.Core/Ai/ManualSelector.cs
+++ b/src/Wip.Core/Ai/ManualSelector.cs
@@ -14,6 +14,11 @@ namespace Wip.Ai;
 /// </remarks>
 public static partial class ManualSelector
 {
+    /// <summary>Appended to a page truncated to fit the character budget; reserved space for
+    /// this is deducted from the budget before slicing, so the result never runs past
+    /// <c>maxCharacters</c> the way appending it afterward would.</summary>
+    private const string TruncationMarker = "\n[truncated by wip]";
+
     /// <summary>
     /// Common English function words that carry no page-selection signal on their own. Left
     /// unfiltered, a word like "the" or "how" occurs so often in ordinary prose that it can
@@ -100,9 +105,7 @@ public static partial class ManualSelector
                 break;
             }
 
-            var fitted = page.Content.Length <= budget
-                ? page
-                : page with { Content = page.Content[..budget] + "\n[truncated by wip]" };
+            var fitted = Fit(page, budget);
             trimmed.Add(fitted);
             budget -= fitted.Content.Length;
         }
@@ -110,19 +113,57 @@ public static partial class ManualSelector
         return trimmed;
     }
 
+    /// <summary>
+    /// Fits <paramref name="page"/>'s content into <paramref name="budget"/> characters,
+    /// guaranteeing the result never exceeds it — including the marker. When the marker itself
+    /// wouldn't fit in what's left, it is dropped rather than appended anyway, since attaching a
+    /// 19-character marker to a 5-character budget would blow straight past the limit it exists
+    /// to enforce.
+    /// </summary>
+    private static ManualPage Fit(ManualPage page, int budget)
+    {
+        if (page.Content.Length <= budget)
+        {
+            return page;
+        }
+
+        return budget > TruncationMarker.Length
+            ? page with { Content = page.Content[..(budget - TruncationMarker.Length)] + TruncationMarker }
+            : page with { Content = page.Content[..budget] };
+    }
+
     private static int NameScore(string name, IReadOnlyList<string> keywords) =>
-        keywords.Count(keyword => name.Contains(keyword, StringComparison.OrdinalIgnoreCase)) * 5;
+        keywords.Count(keyword => CountWordStartOccurrences(name, keyword) > 0) * 5;
 
     private static int ContentScore(string content, IReadOnlyList<string> keywords) =>
-        keywords.Sum(keyword => CountOccurrences(content, keyword));
+        keywords.Sum(keyword => CountWordStartOccurrences(content, keyword));
 
-    private static int CountOccurrences(string haystack, string needle)
+    /// <summary>
+    /// Occurrences of <paramref name="needle"/> in <paramref name="haystack"/> that start a
+    /// word — the character before the match must be missing or non-alphanumeric — rather than
+    /// merely appearing anywhere as a substring. Plain substring matching let a short command
+    /// name like <c>up</c> or <c>ps</c> match inside "set<b>up</b>", "back<b>up</b>", or
+    /// "ecli<b>ps</b>e", inflating unrelated pages ahead of the page that actually documents the
+    /// command.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately anchored at the *start* only, not both ends: requiring a boundary after the
+    /// match too would stop "disable" from matching "disables", or "build" from matching
+    /// "builds"/"building" — ordinary English inflections this selector needs to keep finding,
+    /// not noise to filter out. Anchoring the start alone already rules out the cases above,
+    /// since in each one the match begins mid-word, not after a break.
+    /// </remarks>
+    private static int CountWordStartOccurrences(string haystack, string needle)
     {
         var count = 0;
         var index = 0;
         while ((index = haystack.IndexOf(needle, index, StringComparison.OrdinalIgnoreCase)) >= 0)
         {
-            count++;
+            if (index == 0 || !char.IsLetterOrDigit(haystack[index - 1]))
+            {
+                count++;
+            }
+
             index += needle.Length;
         }
 

--- a/src/Wip.Core/Ai/ManualSelector.cs
+++ b/src/Wip.Core/Ai/ManualSelector.cs
@@ -1,0 +1,130 @@
+using System.Text.RegularExpressions;
+
+namespace Wip.Ai;
+
+/// <summary>
+/// Picks which page(s) of the wiki manual (see <see cref="WikiManual"/>) are worth showing a
+/// local AI model for a given question, instead of concatenating the whole ~270 KB manual into
+/// every prompt — local models often run with a small context window, and most of the manual is
+/// irrelevant to any one question anyway.
+/// </summary>
+/// <remarks>
+/// Pure and I/O-free by design: no HTTP, no filesystem, so it is trivial to unit test against
+/// fixed <see cref="ManualPage"/> values.
+/// </remarks>
+public static partial class ManualSelector
+{
+    /// <summary>
+    /// Common English function words that carry no page-selection signal on their own. Left
+    /// unfiltered, a word like "the" or "how" occurs so often in ordinary prose that it can
+    /// outscore the one real keyword in the question, dragging in unrelated pages (and pushing
+    /// the actually relevant page's content past the character budget) — the exact way an
+    /// otherwise-working query like "how do I disable the build cache?" picked
+    /// <c>Shadow-Build-Context</c> and <c>Registry-Authentication</c> ahead of the real answer.
+    /// </summary>
+    private static readonly HashSet<string> Stopwords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "how", "what", "when", "where", "which", "who", "why", "the", "a", "an", "is", "are",
+        "was", "were", "be", "been", "being", "do", "does", "did", "can", "could", "would",
+        "should", "will", "shall", "to", "of", "in", "on", "at", "for", "and", "or", "but",
+        "not", "no", "so", "if", "this", "that", "these", "those", "it", "its", "you", "your",
+    };
+
+    /// <summary>
+    /// Pulls ASCII technical terms (flag names, command names) out of a question, even when the
+    /// rest of the sentence is in another language — e.g. "ビルドキャッシュ使わないでbuildする
+    /// には" yields just <c>build</c>, which is already enough to find the right page. Matches
+    /// hyphenated flag names like <c>no-cache</c> as one token, and drops common function words
+    /// (see <see cref="Stopwords"/>) that would otherwise swamp the real signal.
+    /// </summary>
+    public static IReadOnlyList<string> ExtractKeywords(string question) =>
+        Keyword().Matches(question).Select(match => match.Value.ToLowerInvariant())
+            .Where(keyword => !Stopwords.Contains(keyword))
+            .Distinct()
+            .ToList();
+
+    /// <summary>
+    /// Name-only scoring, for the *live* (uncached) path: which pages are worth an HTTP fetch
+    /// before any content exists locally to search.
+    /// </summary>
+    public static IReadOnlyList<string> SelectCandidateNames(
+        string question, IReadOnlyList<string> names, int limit = 8)
+    {
+        var keywords = ExtractKeywords(question);
+        if (keywords.Count == 0)
+        {
+            return [];
+        }
+
+        return names
+            .Select(name => (name, score: NameScore(name, keywords)))
+            .Where(entry => entry.score > 0)
+            .OrderByDescending(entry => entry.score)
+            .Take(limit)
+            .Select(entry => entry.name)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Content-based scoring: ranks <paramref name="pages"/> by keyword occurrence count (with
+    /// a bonus when the keyword is also in the page's name), then takes the top <paramref
+    /// name="maxPages"/> and trims the combined content to <paramref name="maxCharacters"/> so
+    /// the result stays within a small model's context budget.
+    /// </summary>
+    public static IReadOnlyList<ManualPage> SelectRelevant(
+        string question, IReadOnlyList<ManualPage> pages, int maxPages = 3, int maxCharacters = 12000)
+    {
+        var keywords = ExtractKeywords(question);
+        if (keywords.Count == 0)
+        {
+            return [];
+        }
+
+        var ranked = pages
+            .Select(page => (page, score: NameScore(page.Name, keywords) + ContentScore(page.Content, keywords)))
+            .Where(entry => entry.score > 0)
+            .OrderByDescending(entry => entry.score)
+            .Take(maxPages)
+            .Select(entry => entry.page)
+            .ToList();
+
+        var trimmed = new List<ManualPage>();
+        var budget = maxCharacters;
+        foreach (var page in ranked)
+        {
+            if (budget <= 0)
+            {
+                break;
+            }
+
+            trimmed.Add(page.Content.Length <= budget
+                ? page
+                : page with { Content = page.Content[..budget] + "\n[truncated by wip]" });
+            budget -= page.Content.Length;
+        }
+
+        return trimmed;
+    }
+
+    private static int NameScore(string name, IReadOnlyList<string> keywords) =>
+        keywords.Count(keyword => name.Contains(keyword, StringComparison.OrdinalIgnoreCase)) * 5;
+
+    private static int ContentScore(string content, IReadOnlyList<string> keywords) =>
+        keywords.Sum(keyword => CountOccurrences(content, keyword));
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.OrdinalIgnoreCase)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+
+        return count;
+    }
+
+    [GeneratedRegex(@"[A-Za-z][A-Za-z0-9\-]{2,}")]
+    private static partial Regex Keyword();
+}

--- a/src/Wip.Core/Ai/WikiManual.cs
+++ b/src/Wip.Core/Ai/WikiManual.cs
@@ -67,11 +67,29 @@ public sealed partial class WikiManual
             .ToList();
     }
 
-    /// <summary>Fetches <c>_Sidebar.md</c> and extracts every page name it links to.</summary>
+    /// <summary>Fetches <c>_Sidebar.md</c> and extracts every page name it links to. A link
+    /// target is trusted as a page name only after stripping any <c>#fragment</c>/<c>?query</c>
+    /// and confirming what's left is a plain slug — no <c>/</c> or <c>..</c> — since this value
+    /// later becomes both a URL segment and a cache filename (see <see cref="Download"/>), and
+    /// a wiki page's own content should never be able to steer either off course.</summary>
     public IReadOnlyList<string> FetchPageNames()
     {
         var sidebar = FetchRaw(SidebarPageName);
-        return SidebarLink().Matches(sidebar).Select(match => match.Groups[1].Value).Distinct().ToList();
+        return SidebarLink().Matches(sidebar).Select(match => match.Groups[1].Value)
+            .Select(SanitizePageName)
+            .Where(name => name is not null)
+            .Cast<string>()
+            .Distinct()
+            .ToList();
+    }
+
+    /// <summary>Strips a trailing <c>#fragment</c> or <c>?query</c> from a raw link target and
+    /// returns it only if what remains is a safe, flat slug; <c>null</c> otherwise.</summary>
+    private static string? SanitizePageName(string rawTarget)
+    {
+        var cut = rawTarget.IndexOfAny(['#', '?']);
+        var name = cut < 0 ? rawTarget : rawTarget[..cut];
+        return SafePageName().IsMatch(name) ? name : null;
     }
 
     /// <summary>Fetches each named page, silently skipping one that fails (a renamed or removed
@@ -113,7 +131,11 @@ public sealed partial class WikiManual
 
     private string FetchRaw(string pageName)
     {
-        using var client = handler is null ? new HttpClient() : new HttpClient(handler);
+        // disposeHandler: false — a caller-injected handler is reused across every page this
+        // instance fetches (FetchPages/Download call this in a loop); the default `true` would
+        // dispose *their* handler the first time this method's `using` tears the client down,
+        // breaking every fetch after the first.
+        using var client = handler is null ? new HttpClient() : new HttpClient(handler, disposeHandler: false);
         client.Timeout = TimeSpan.FromSeconds(10);
 
         HttpResponseMessage response;
@@ -143,4 +165,10 @@ public sealed partial class WikiManual
 
     [GeneratedRegex(@"\[[^\]]+\]\(([^)\s]+)\)")]
     private static partial Regex SidebarLink();
+
+    /// <summary>A flat wiki-page slug: letters, digits, <c>-</c>, <c>_</c>, and <c>.</c> only —
+    /// no <c>/</c>, so it can't traverse into a subdirectory of the cache, and no leading
+    /// <c>.</c> pair, so it can't be <c>..</c>.</summary>
+    [GeneratedRegex(@"^(?!\.\.)[A-Za-z0-9_.-]+$")]
+    private static partial Regex SafePageName();
 }

--- a/src/Wip.Core/Ai/WikiManual.cs
+++ b/src/Wip.Core/Ai/WikiManual.cs
@@ -1,0 +1,146 @@
+using System.Net.Sockets;
+using System.Text.RegularExpressions;
+
+namespace Wip.Ai;
+
+/// <summary>One page of the <c>slidict/wip.wiki</c> manual, keyed by its wiki slug (e.g.
+/// <c>wip-build</c>), the same name it is cached under as <c>&lt;Name&gt;.md</c>.</summary>
+public readonly record struct ManualPage(string Name, string Content);
+
+/// <summary>
+/// Reads the <c>slidict/wip.wiki</c> manual over plain HTTP — GitHub serves every wiki page's
+/// raw Markdown at <c>raw.githubusercontent.com/wiki/&lt;owner&gt;/&lt;repo&gt;/&lt;Page&gt;.md</c>,
+/// so no <c>git clone</c> (and no dependency on a Windows-side <c>git</c>) is needed to reach
+/// it. <c>_Sidebar.md</c> doubles as the page index: it is a plain <c>[Title](Slug)</c> link
+/// list naming every other page.
+/// </summary>
+/// <remarks>
+/// Mirrors <see cref="LocalAiProvider"/>'s shape: an injectable <see cref="HttpMessageHandler"/>
+/// for tests, and network failures surfaced as <see cref="WipException"/> rather than a raw
+/// <see cref="HttpRequestException"/>.
+/// </remarks>
+public sealed partial class WikiManual
+{
+    private const string Owner = "slidict";
+    private const string Repository = "wip";
+    private const string RawBaseUrl = "https://raw.githubusercontent.com/wiki";
+    private const string SidebarPageName = "_Sidebar";
+    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(1);
+
+    private readonly HttpMessageHandler? handler;
+
+    public WikiManual(HttpMessageHandler? handler = null) => this.handler = handler;
+
+    /// <summary>Where <c>wip manual</c> writes pages to, and where <see cref="LoadCache"/> reads
+    /// them back from: <c>%LocalAppData%\wip\manual</c>, the same
+    /// <c>%LocalAppData%\wip\&lt;name&gt;</c> shape as <c>BuildContext.DefaultCacheRoot()</c>.</summary>
+    public static string DefaultCacheDirectory() => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "wip", "manual");
+
+    /// <summary>Whether the wiki's raw-content host is reachable, so callers can fall back to
+    /// "no manual" instead of hanging or throwing when there is no network. Host/port are
+    /// overridable so tests can point this at a local listener instead of the real internet.</summary>
+    public static bool IsReachable(string? host = null, int port = 443)
+    {
+        try
+        {
+            using var client = new TcpClient();
+            return client.ConnectAsync(host ?? "raw.githubusercontent.com", port).Wait(ProbeTimeout);
+        }
+        catch (Exception exception) when (exception is AggregateException or ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>Reads whatever <c>*.md</c> pages are already sitting in <paramref
+    /// name="cacheDirectory"/> — empty when <c>wip manual</c> has never been run.</summary>
+    public static IReadOnlyList<ManualPage> LoadCache(string cacheDirectory)
+    {
+        if (!Directory.Exists(cacheDirectory))
+        {
+            return [];
+        }
+
+        return Directory.GetFiles(cacheDirectory, "*.md")
+            .Select(path => new ManualPage(Path.GetFileNameWithoutExtension(path), File.ReadAllText(path)))
+            .ToList();
+    }
+
+    /// <summary>Fetches <c>_Sidebar.md</c> and extracts every page name it links to.</summary>
+    public IReadOnlyList<string> FetchPageNames()
+    {
+        var sidebar = FetchRaw(SidebarPageName);
+        return SidebarLink().Matches(sidebar).Select(match => match.Groups[1].Value).Distinct().ToList();
+    }
+
+    /// <summary>Fetches each named page, silently skipping one that fails (a renamed or removed
+    /// page in a stale <c>_Sidebar.md</c> reference should not take the whole batch down).</summary>
+    public IReadOnlyList<ManualPage> FetchPages(IReadOnlyList<string> names)
+    {
+        var pages = new List<ManualPage>();
+        foreach (var name in names)
+        {
+            try
+            {
+                pages.Add(new ManualPage(name, FetchRaw(name)));
+            }
+            catch (WipException)
+            {
+                // Best-effort: one missing/renamed page should not sink the rest.
+            }
+        }
+
+        return pages;
+    }
+
+    /// <summary>Downloads every page named in <c>_Sidebar.md</c> into <paramref
+    /// name="cacheDirectory"/>, overwriting whatever was cached before. Returns the number of
+    /// pages written.</summary>
+    public int Download(string cacheDirectory)
+    {
+        var names = FetchPageNames();
+        var pages = FetchPages(names);
+
+        Directory.CreateDirectory(cacheDirectory);
+        foreach (var page in pages)
+        {
+            File.WriteAllText(Path.Combine(cacheDirectory, $"{page.Name}.md"), page.Content);
+        }
+
+        return pages.Count;
+    }
+
+    private string FetchRaw(string pageName)
+    {
+        using var client = handler is null ? new HttpClient() : new HttpClient(handler);
+        client.Timeout = TimeSpan.FromSeconds(10);
+
+        HttpResponseMessage response;
+        try
+        {
+            response = client.GetAsync($"{RawBaseUrl}/{Owner}/{Repository}/{pageName}.md").GetAwaiter().GetResult();
+        }
+        catch (HttpRequestException exception)
+        {
+            throw new WipException($"Could not reach the wip wiki fetching '{pageName}'", exception);
+        }
+        catch (OperationCanceledException exception)
+        {
+            throw new WipException($"Timed out fetching '{pageName}' from the wip wiki", exception);
+        }
+
+        using (response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new WipException($"wip wiki returned {(int)response.StatusCode} fetching '{pageName}'");
+            }
+
+            return response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+        }
+    }
+
+    [GeneratedRegex(@"\[[^\]]+\]\(([^)\s]+)\)")]
+    private static partial Regex SidebarLink();
+}

--- a/src/Wip.Core/Ai/WikiManual.cs
+++ b/src/Wip.Core/Ai/WikiManual.cs
@@ -1,4 +1,3 @@
-using System.Net.Sockets;
 using System.Text.RegularExpressions;
 
 namespace Wip.Ai;
@@ -25,9 +24,9 @@ public sealed partial class WikiManual
     private const string Repository = "wip";
     private const string RawBaseUrl = "https://raw.githubusercontent.com/wiki";
     private const string SidebarPageName = "_Sidebar";
-    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(1);
 
     private readonly HttpMessageHandler? handler;
+    private HttpClient? client;
 
     public WikiManual(HttpMessageHandler? handler = null) => this.handler = handler;
 
@@ -36,22 +35,6 @@ public sealed partial class WikiManual
     /// <c>%LocalAppData%\wip\&lt;name&gt;</c> shape as <c>BuildContext.DefaultCacheRoot()</c>.</summary>
     public static string DefaultCacheDirectory() => Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "wip", "manual");
-
-    /// <summary>Whether the wiki's raw-content host is reachable, so callers can fall back to
-    /// "no manual" instead of hanging or throwing when there is no network. Host/port are
-    /// overridable so tests can point this at a local listener instead of the real internet.</summary>
-    public static bool IsReachable(string? host = null, int port = 443)
-    {
-        try
-        {
-            using var client = new TcpClient();
-            return client.ConnectAsync(host ?? "raw.githubusercontent.com", port).Wait(ProbeTimeout);
-        }
-        catch (Exception exception) when (exception is AggregateException or ArgumentException)
-        {
-            return false;
-        }
-    }
 
     /// <summary>Reads whatever <c>*.md</c> pages are already sitting in <paramref
     /// name="cacheDirectory"/> — empty when <c>wip manual</c> has never been run.</summary>
@@ -129,19 +112,30 @@ public sealed partial class WikiManual
         return pages.Count;
     }
 
+    /// <summary>
+    /// One client for this instance's whole lifetime, not one per page: <see cref="Download"/>
+    /// and <see cref="FetchPages"/> can call this dozens of times in a loop, and a fresh
+    /// <see cref="HttpClient"/> per call both wastes a connection setup each time and — with a
+    /// caller-injected <paramref name="handler"/> — would dispose it the moment the first
+    /// request's client is torn down, breaking every fetch after the first. Never disposed: a
+    /// `wip` invocation is a short-lived process, so there is nothing to reclaim the client's
+    /// resources back to.
+    /// </summary>
+    private HttpClient Client => client ??= CreateClient();
+
+    private HttpClient CreateClient()
+    {
+        var created = handler is null ? new HttpClient() : new HttpClient(handler, disposeHandler: false);
+        created.Timeout = TimeSpan.FromSeconds(10);
+        return created;
+    }
+
     private string FetchRaw(string pageName)
     {
-        // disposeHandler: false — a caller-injected handler is reused across every page this
-        // instance fetches (FetchPages/Download call this in a loop); the default `true` would
-        // dispose *their* handler the first time this method's `using` tears the client down,
-        // breaking every fetch after the first.
-        using var client = handler is null ? new HttpClient() : new HttpClient(handler, disposeHandler: false);
-        client.Timeout = TimeSpan.FromSeconds(10);
-
         HttpResponseMessage response;
         try
         {
-            response = client.GetAsync($"{RawBaseUrl}/{Owner}/{Repository}/{pageName}.md").GetAwaiter().GetResult();
+            response = Client.GetAsync($"{RawBaseUrl}/{Owner}/{Repository}/{pageName}.md").GetAwaiter().GetResult();
         }
         catch (HttpRequestException exception)
         {

--- a/tests/Wip.Tests/HelpCommandTests.cs
+++ b/tests/Wip.Tests/HelpCommandTests.cs
@@ -30,6 +30,16 @@ public class HelpCommandTests
     }
 
     [Fact]
+    public void NoCacheWithoutAiIsRejected()
+    {
+        var parsed = Program.BuildRoot().Parse(["help", "--no-cache"]);
+        var invocation = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
+
+        var exception = Assert.Throws<WipException>(() => parsed.Invoke(invocation));
+        Assert.Equal("--no-cache requires --ai", exception.Message);
+    }
+
+    [Fact]
     public void QuestionWithoutAiIsRejected()
     {
         var parsed = Program.BuildRoot().Parse(["help", "how", "do", "I", "sync"]);

--- a/tests/Wip.Tests/ManualTests.cs
+++ b/tests/Wip.Tests/ManualTests.cs
@@ -1,0 +1,207 @@
+using Wip.Ai;
+
+namespace Wip.Tests;
+
+/// <summary>Covers <see cref="WikiManual"/> (reading/fetching the wiki manual) and <see
+/// cref="ManualSelector"/> (deciding which page(s) are relevant to a question) independently of
+/// <c>CliContext.HelpAi</c>, which wires the two together.</summary>
+public class ManualTests
+{
+    [Fact]
+    public void LoadCacheReturnsEmptyForAMissingDirectory()
+    {
+        Assert.Empty(WikiManual.LoadCache(Path.Combine(Path.GetTempPath(), "wip-manual-does-not-exist")));
+    }
+
+    [Fact]
+    public void LoadCacheReadsEveryMarkdownFileByItsNameWithoutExtension()
+    {
+        using var directory = new TemporaryDirectory();
+        File.WriteAllText(Path.Combine(directory.Path, "wip-build.md"), "# wip build\n--no-cache disables it");
+        File.WriteAllText(Path.Combine(directory.Path, "wip-up.md"), "# wip up");
+
+        var pages = WikiManual.LoadCache(directory.Path);
+
+        Assert.Equal(2, pages.Count);
+        Assert.Contains(pages, page => page.Name == "wip-build" && page.Content.Contains("--no-cache"));
+    }
+
+    [Fact]
+    public void FetchPageNamesParsesEveryLinkOutOfTheSidebar()
+    {
+        var handler = new StubWikiHandler(new Dictionary<string, string>
+        {
+            ["_Sidebar"] = """
+                **[Home](Home)**
+                - [wip build](wip-build)
+                - [wip up](wip-up)
+                """,
+        });
+
+        var names = new WikiManual(handler).FetchPageNames();
+
+        Assert.Equal(["Home", "wip-build", "wip-up"], names);
+    }
+
+    [Fact]
+    public void FetchPagesSkipsAPageThatFailsInsteadOfThrowing()
+    {
+        var handler = new StubWikiHandler(new Dictionary<string, string>
+        {
+            ["wip-build"] = "# wip build",
+        });
+
+        var pages = new WikiManual(handler).FetchPages(["wip-build", "missing-page"]);
+
+        var page = Assert.Single(pages);
+        Assert.Equal("wip-build", page.Name);
+    }
+
+    [Fact]
+    public void DownloadWritesEveryFetchedPageToTheCacheDirectory()
+    {
+        using var directory = new TemporaryDirectory();
+        var handler = new StubWikiHandler(new Dictionary<string, string>
+        {
+            ["_Sidebar"] = "- [wip build](wip-build)\n- [wip up](wip-up)",
+            ["wip-build"] = "# wip build\n--no-cache disables it",
+            ["wip-up"] = "# wip up",
+        });
+
+        var count = new WikiManual(handler).Download(directory.Path);
+
+        Assert.Equal(2, count);
+        Assert.Equal("# wip build\n--no-cache disables it", File.ReadAllText(Path.Combine(directory.Path, "wip-build.md")));
+        Assert.True(File.Exists(Path.Combine(directory.Path, "wip-up.md")));
+    }
+
+    [Fact]
+    public void IsReachableFindsAListeningHostAndRejectsAClosedPort()
+    {
+        using var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+        try
+        {
+            Assert.True(WikiManual.IsReachable("127.0.0.1", port));
+        }
+        finally
+        {
+            listener.Stop();
+        }
+
+        Assert.False(WikiManual.IsReachable("127.0.0.1", 1));
+    }
+
+    /// <summary>Reproduces issue #135's own repro question: "build" is the only ASCII keyword
+    /// in it, and matching it against page names/content must still be enough to surface the
+    /// page documenting `--no-cache`.</summary>
+    [Fact]
+    public void SelectRelevantFindsTheBuildPageFromTheIssuesJapaneseReproQuestion()
+    {
+        var pages = new[]
+        {
+            new ManualPage("wip-build", "# wip build\n`--no-cache` disables the build cache."),
+            new ManualPage("wip-up", "# wip up\nStarts the configured stack."),
+        };
+
+        var selected = ManualSelector.SelectRelevant("ビルドキャッシュ使わないでbuildするにはどうするんだ？", pages);
+
+        var page = Assert.Single(selected);
+        Assert.Equal("wip-build", page.Name);
+    }
+
+    /// <summary>
+    /// Regression for a real failure: "how do I disable the build cache?" ranked
+    /// `Shadow-Build-Context` (heavy on ordinary prose) ahead of `wip-build` (the actual
+    /// answer) before stopwords were filtered, because "the" and "how" occur so often in plain
+    /// English that they outweighed the one real signal, "build" — and the diluted excerpt made
+    /// the local model answer "not covered" for a question it should have been able to answer.
+    /// </summary>
+    [Fact]
+    public void SelectRelevantIgnoresStopwordsSoTheRealAnswerOutranksGenericProse()
+    {
+        var pages = new[]
+        {
+            new ManualPage("wip-build", "# wip build\n`--no-cache` disables the build cache."),
+            new ManualPage("Shadow-Build-Context", string.Concat(Enumerable.Repeat("the quick brown fox jumps. ", 50))),
+        };
+
+        var selected = ManualSelector.SelectRelevant("how do I disable the build cache?", pages, maxPages: 1);
+
+        var page = Assert.Single(selected);
+        Assert.Equal("wip-build", page.Name);
+    }
+
+    [Fact]
+    public void ExtractKeywordsDropsCommonEnglishFunctionWords()
+    {
+        var keywords = ManualSelector.ExtractKeywords("how do I disable the build cache?");
+
+        Assert.Equal(["disable", "build", "cache"], keywords);
+    }
+
+    [Fact]
+    public void SelectRelevantReturnsNothingWhenNoKeywordMatchesAnyPage()
+    {
+        var pages = new[] { new ManualPage("wip-build", "# wip build") };
+
+        Assert.Empty(ManualSelector.SelectRelevant("何もヒットしない質問です", pages));
+    }
+
+    [Fact]
+    public void SelectRelevantTrimsToTheCharacterBudget()
+    {
+        var pages = new[] { new ManualPage("wip-build", "build " + new string('x', 100)) };
+
+        var selected = ManualSelector.SelectRelevant("build", pages, maxCharacters: 20);
+
+        var page = Assert.Single(selected);
+        Assert.Equal(20 + "\n[truncated by wip]".Length, page.Content.Length);
+        Assert.EndsWith("[truncated by wip]", page.Content);
+    }
+
+    [Fact]
+    public void SelectCandidateNamesMatchesPageNamesContainingAKeyword()
+    {
+        var names = new[] { "wip-build", "Compose-Build", "wip-up", "Dockerignore" };
+
+        var candidates = ManualSelector.SelectCandidateNames("how do I build without cache", names);
+
+        Assert.Contains("wip-build", candidates);
+        Assert.Contains("Compose-Build", candidates);
+        Assert.DoesNotContain("wip-up", candidates);
+        Assert.DoesNotContain("Dockerignore", candidates);
+    }
+
+    [Fact]
+    public void SelectCandidateNamesReturnsNothingForAQuestionWithNoAsciiKeywords()
+    {
+        Assert.Empty(ManualSelector.SelectCandidateNames("これは英数字を含まない質問", ["wip-build"]));
+    }
+
+    private sealed class StubWikiHandler(IReadOnlyDictionary<string, string> pagesByName) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var name = Path.GetFileNameWithoutExtension(request.RequestUri!.AbsolutePath);
+            if (!pagesByName.TryGetValue(name, out var content))
+            {
+                return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.NotFound));
+            }
+
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent(content),
+            });
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        internal TemporaryDirectory() => Path = Directory.CreateTempSubdirectory("wip-manual-test-").FullName;
+        internal string Path { get; }
+        public void Dispose() => Directory.Delete(Path, recursive: true);
+    }
+}

--- a/tests/Wip.Tests/ManualTests.cs
+++ b/tests/Wip.Tests/ManualTests.cs
@@ -1,10 +1,12 @@
 using Wip.Ai;
+using Wip.Cli;
 
 namespace Wip.Tests;
 
-/// <summary>Covers <see cref="WikiManual"/> (reading/fetching the wiki manual) and <see
-/// cref="ManualSelector"/> (deciding which page(s) are relevant to a question) independently of
-/// <c>CliContext.HelpAi</c>, which wires the two together.</summary>
+/// <summary>Covers <see cref="WikiManual"/> (reading/fetching the wiki manual), <see
+/// cref="ManualSelector"/> (deciding which page(s) are relevant to a question), and
+/// <see cref="CliContext.Join"/> (formatting the selected pages into the prompt excerpt)
+/// independently of <c>CliContext.HelpAi</c>, which wires all three together.</summary>
 public class ManualTests
 {
     [Fact]
@@ -256,6 +258,84 @@ public class ManualTests
 
         Assert.Contains("wip-up", ManualSelector.SelectCandidateNames("how do I start it back up", names));
         Assert.Contains("wip-ps", ManualSelector.SelectCandidateNames("wip ps command", names));
+    }
+
+    /// <summary>Every page in this manual is about wip, so the word "wip" itself can never help
+    /// pick one page over another — it should never survive into the keyword list.</summary>
+    [Fact]
+    public void ExtractKeywordsTreatsWipItselfAsAStopword()
+    {
+        Assert.DoesNotContain("wip", ManualSelector.ExtractKeywords("what does -d do on wip up"));
+    }
+
+    /// <summary>
+    /// Regression for a real failure found testing against the live wiki: "what does -d do on
+    /// wip up" picked `wip-help` and two unrelated pages ahead of `wip-up` itself, because (a)
+    /// "wip" matched everywhere and (b) "up" matched as a bare prefix of ordinary words like
+    /// "up-to-date" content mentions elsewhere in the manual. Fixed by treating "wip" as a
+    /// stopword and requiring a full word match (not just a prefix) for 1-2 character keywords.
+    /// </summary>
+    [Fact]
+    public void SelectRelevantDoesNotLetAShortCommandMatchAsAPrefixOfALongerWord()
+    {
+        var pages = new[]
+        {
+            new ManualPage("wip-up", "# wip up\n`-d` runs the container detached."),
+            new ManualPage("Noise", string.Concat(Enumerable.Repeat(
+                "update, upgrade, uptime, upload. ", 20))),
+        };
+
+        var selected = ManualSelector.SelectRelevant("what does -d do on wip up", pages, maxPages: 1);
+
+        var page = Assert.Single(selected);
+        Assert.Equal("wip-up", page.Name);
+    }
+
+    /// <summary>A single-letter short flag can't clear the general 2-character keyword floor on
+    /// its own, so it needs the regex's separate `-[A-Za-z]` alternative.</summary>
+    [Fact]
+    public void ExtractKeywordsIncludesSingleLetterFlags()
+    {
+        Assert.Equal(["-d"], ManualSelector.ExtractKeywords("-d"));
+        Assert.Contains("-w", ManualSelector.ExtractKeywords("run with -w please"));
+    }
+
+    /// <summary>Regression: a short flag keyword is anchored at both ends, unlike an ordinary
+    /// word, so "-d" does not also match inside the unrelated "-download" or "-detach".</summary>
+    [Fact]
+    public void SelectRelevantDoesNotLetAShortFlagMatchInsideALongerFlag()
+    {
+        var pages = new[]
+        {
+            new ManualPage("wip-up", "# wip up\n`-d` runs the container detached."),
+            new ManualPage("Noise", string.Concat(Enumerable.Repeat(
+                "use -download or -detach for other tools. ", 20))),
+        };
+
+        var selected = ManualSelector.SelectRelevant("-d", pages, maxPages: 1);
+
+        var page = Assert.Single(selected);
+        Assert.Equal("wip-up", page.Name);
+    }
+
+    /// <summary>
+    /// <see cref="ManualSelector.SelectRelevant"/> bounds each page's own content, but
+    /// <see cref="CliContext.Join"/> adds a "### {name}" heading and "\n\n" separators on top —
+    /// unbudgeted bytes that must not let the final, formatted excerpt run past the same limit.
+    /// </summary>
+    [Fact]
+    public void JoinClampsTheFormattedExcerptToTheCharacterBudget()
+    {
+        var pages = new[]
+        {
+            new ManualPage("a-very-long-page-name-that-adds-heading-overhead",
+                new string('x', ManualSelector.DefaultMaxCharacters)),
+        };
+
+        var joined = CliContext.Join(pages);
+
+        Assert.True(joined.Length <= ManualSelector.DefaultMaxCharacters,
+            $"expected <= {ManualSelector.DefaultMaxCharacters} chars, got {joined.Length}");
     }
 
     private class StubWikiHandler(IReadOnlyDictionary<string, string> pagesByName) : HttpMessageHandler

--- a/tests/Wip.Tests/ManualTests.cs
+++ b/tests/Wip.Tests/ManualTests.cs
@@ -118,24 +118,6 @@ public class ManualTests
         Assert.True(File.Exists(Path.Combine(directory.Path, "wip-up.md")));
     }
 
-    [Fact]
-    public void IsReachableFindsAListeningHostAndRejectsAClosedPort()
-    {
-        using var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
-        try
-        {
-            Assert.True(WikiManual.IsReachable("127.0.0.1", port));
-        }
-        finally
-        {
-            listener.Stop();
-        }
-
-        Assert.False(WikiManual.IsReachable("127.0.0.1", 1));
-    }
-
     /// <summary>Reproduces issue #135's own repro question: "build" is the only ASCII keyword
     /// in it, and matching it against page names/content must still be enough to surface the
     /// page documenting `--no-cache`.</summary>
@@ -200,8 +182,41 @@ public class ManualTests
         var selected = ManualSelector.SelectRelevant("build", pages, maxCharacters: 20);
 
         var page = Assert.Single(selected);
-        Assert.Equal(20 + "\n[truncated by wip]".Length, page.Content.Length);
+        Assert.Equal(20, page.Content.Length);
         Assert.EndsWith("[truncated by wip]", page.Content);
+    }
+
+    /// <summary>The marker itself is 19 characters; a budget smaller than that must drop it
+    /// rather than hand back content longer than the budget it was supposed to enforce.</summary>
+    [Fact]
+    public void SelectRelevantOmitsTheMarkerWhenItWouldNotFitTheBudget()
+    {
+        var pages = new[] { new ManualPage("wip-build", "build " + new string('x', 100)) };
+
+        var selected = ManualSelector.SelectRelevant("build", pages, maxCharacters: 5);
+
+        var page = Assert.Single(selected);
+        Assert.Equal(5, page.Content.Length);
+        Assert.DoesNotContain("truncated", page.Content);
+    }
+
+    /// <summary>Regression for a real failure: substring matching let the two-letter command
+    /// keywords `up`/`ps` match inside unrelated words ("setup", "backup", "eclipse"), so a page
+    /// full of that prose could outrank the page that actually documents the command.</summary>
+    [Fact]
+    public void SelectRelevantDoesNotLetShortKeywordsMatchInsideLongerWords()
+    {
+        var pages = new[]
+        {
+            new ManualPage("wip-up", "# wip up\nStarts the configured stack."),
+            new ManualPage("Noise", string.Concat(Enumerable.Repeat(
+                "setup your backup before opening eclipse. ", 20))),
+        };
+
+        var selected = ManualSelector.SelectRelevant("up", pages, maxPages: 1);
+
+        var page = Assert.Single(selected);
+        Assert.Equal("wip-up", page.Name);
     }
 
     [Fact]

--- a/tests/Wip.Tests/ManualTests.cs
+++ b/tests/Wip.Tests/ManualTests.cs
@@ -43,6 +43,49 @@ public class ManualTests
         Assert.Equal(["Home", "wip-build", "wip-up"], names);
     }
 
+    /// <summary>A link target becomes both a URL segment and a cache filename (see <see
+    /// cref="WikiManual.Download"/>), so a fragment/query suffix or a traversal-shaped target
+    /// must never survive into the returned name list.</summary>
+    [Fact]
+    public void FetchPageNamesStripsFragmentsAndRejectsUnsafeTargets()
+    {
+        var handler = new StubWikiHandler(new Dictionary<string, string>
+        {
+            ["_Sidebar"] = """
+                - [Build flags](wip-build#flags)
+                - [Search](wip-build?query=1)
+                - [Traversal](../../etc/passwd)
+                - [wip up](wip-up)
+                """,
+        });
+
+        var names = new WikiManual(handler).FetchPageNames();
+
+        Assert.Equal(["wip-build", "wip-up"], names);
+    }
+
+    /// <summary>
+    /// `HttpClient(handler)` disposes <paramref name="handler"/> by default once the client is
+    /// torn down; since <see cref="WikiManual.FetchPages"/> and <see cref="WikiManual.Download"/>
+    /// call <c>FetchRaw</c> in a loop on one injected handler, that default would break every
+    /// fetch after the first against a real (non-test-double) handler.
+    /// </summary>
+    [Fact]
+    public void FetchingMultiplePagesDoesNotDisposeAnInjectedHandler()
+    {
+        var handler = new DisposeTrackingWikiHandler(new Dictionary<string, string>
+        {
+            ["_Sidebar"] = "- [wip build](wip-build)\n- [wip up](wip-up)",
+            ["wip-build"] = "# wip build",
+            ["wip-up"] = "# wip up",
+        });
+
+        var wiki = new WikiManual(handler);
+        wiki.FetchPages(wiki.FetchPageNames());
+
+        Assert.False(handler.WasDisposed);
+    }
+
     [Fact]
     public void FetchPagesSkipsAPageThatFailsInsteadOfThrowing()
     {
@@ -180,7 +223,27 @@ public class ManualTests
         Assert.Empty(ManualSelector.SelectCandidateNames("これは英数字を含まない質問", ["wip-build"]));
     }
 
-    private sealed class StubWikiHandler(IReadOnlyDictionary<string, string> pagesByName) : HttpMessageHandler
+    /// <summary>
+    /// `up` and `ps` are real, two-letter wip commands. A 3-character keyword floor would make
+    /// them permanently unmatchable — this pins the 2-character minimum that fixed it.
+    /// </summary>
+    [Fact]
+    public void ExtractKeywordsIncludesTwoLetterCommandNames()
+    {
+        Assert.Equal(["up"], ManualSelector.ExtractKeywords("up"));
+        Assert.Equal(["ps"], ManualSelector.ExtractKeywords("ps"));
+    }
+
+    [Fact]
+    public void SelectCandidateNamesMatchesTwoLetterCommandNames()
+    {
+        var names = new[] { "wip-up", "wip-ps", "wip-build" };
+
+        Assert.Contains("wip-up", ManualSelector.SelectCandidateNames("how do I start it back up", names));
+        Assert.Contains("wip-ps", ManualSelector.SelectCandidateNames("wip ps command", names));
+    }
+
+    private class StubWikiHandler(IReadOnlyDictionary<string, string> pagesByName) : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
@@ -195,6 +258,18 @@ public class ManualTests
             {
                 Content = new StringContent(content),
             });
+        }
+    }
+
+    private sealed class DisposeTrackingWikiHandler(IReadOnlyDictionary<string, string> pagesByName)
+        : StubWikiHandler(pagesByName)
+    {
+        internal bool WasDisposed { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            WasDisposed = true;
+            base.Dispose(disposing);
         }
     }
 


### PR DESCRIPTION
## Summary
- `wip help --ai` only ever saw the top-level `--help` listing, so a question about a subcommand flag (e.g. `wip build --no-cache`) came back "not covered" even though it's documented on the wiki (#135)
- New `wip manual` command downloads the wiki (`slidict/wip.wiki`) to `%LocalAppData%\wip\manual` for offline use, via plain HTTPS raw-content fetches (no `git` dependency)
- `wip help --ai` now selects the wiki page(s) relevant to the question — keyword-matched, character-budgeted so a small local model's context isn't overrun — from that cache, or fetches them live when nothing has been downloaded yet
- New `wip help --ai --no-cache` skips a downloaded cache for one question, for when the wiki has changed since the last `wip manual` run
- Wiki updated to document `wip manual` and the `--no-cache` flag (new `wip-manual` page, `wip-help` and `CLI-Command-Reference` updated)

## Test plan
- [x] `dotnet test tests/Wip.Tests/Wip.Tests.csproj` — 695 passed, 0 failed, 16 pre-existing skips
- [x] `dotnet build wip.slnx` — 0 warnings, 0 errors
- [x] `dotnet publish src/Wip.Cli/Wip.Cli.csproj -c Release -r win-x64` — builds under Native AOT
- [x] Manual smoke test against the real `slidict/wip.wiki`: `wip manual` downloads 70 pages; issue #135's exact repro question against the local build now answers with `wip build --no-cache` instead of "not covered", both with a downloaded cache and via `--no-cache` live fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YFfsaFtFQpS2XKdgBnEzX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a command to download the wiki manual for offline AI-assisted help.
  - AI help now uses relevant manual pages for more informed answers.
  - Added `--no-cache` to retrieve the latest manual content.
  - Added explicit approval for remote AI access and secure endpoint validation.
  - Commands preview destinations and selected files before network access.

- **Bug Fixes**
  - Prevented unapproved remote requests and invalid `--no-cache` usage.
  - Improved manual selection, command matching, caching, and graceful handling of unavailable pages.

- **Documentation**
  - Updated the command reference with the manual download command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->