### PR TITLE
fix(log): localize warning/error labels with English fallback

### DIFF
--- a/src/Wip.Core/Diagnostics/Log.cs
+++ b/src/Wip.Core/Diagnostics/Log.cs
@@ -22,6 +22,7 @@ namespace Wip.Diagnostics;
 /// </remarks>
 public static class Log
 {
+    private const ushort PrimaryLanguageMask = 0x3FF;
     private const ushort EnglishPrimaryLanguageId = 0x09;
     private const ushort JapanesePrimaryLanguageId = 0x11;
     private const string TagAccent = "\x1b[36m";
@@ -61,8 +62,11 @@ public static class Log
     /// <summary>
     /// Gets the translated severity label. English is deliberately the default branch so an
     /// OS language for which wip has no translation never produces a missing or blank label.
+    /// Accept both a complete Windows LANGID and an already-extracted primary language ID so
+    /// this pure formatting path has the same semantics as <see cref="DisplayLanguage"/>.
     /// </summary>
-    private static string SeverityLabel(ushort languageId, bool isError) => languageId switch
+    private static string SeverityLabel(ushort languageId, bool isError) =>
+        (languageId & PrimaryLanguageMask) switch
     {
         JapanesePrimaryLanguageId => isError ? "エラー" : "警告",
         _ => isError ? "error" : "warning",

--- a/src/Wip.Core/Diagnostics/Log.cs
+++ b/src/Wip.Core/Diagnostics/Log.cs
@@ -22,6 +22,8 @@ namespace Wip.Diagnostics;
 /// </remarks>
 public static class Log
 {
+    private const ushort EnglishPrimaryLanguageId = 0x09;
+    private const ushort JapanesePrimaryLanguageId = 0x11;
     private const string TagAccent = "\x1b[36m";
     private const string WarnAccent = "\x1b[33m";
     private const string ErrorAccent = "\x1b[31m";
@@ -32,21 +34,39 @@ public static class Log
 
     /// <summary>Writes "wip: warning: message" -- something the user should notice but that
     /// does not stop wip from continuing.</summary>
-    public static void Warn(string message) => Console.Error.WriteLine(FormatWarn(message, IsColorEnabled()));
+    public static void Warn(string message) => Console.Error.WriteLine(
+        FormatWarn(message, IsColorEnabled(), DisplayLanguage.CurrentPrimaryLanguageId()));
 
     /// <summary>Writes "wip: error: message" -- wip is about to stop, or a command it ran
     /// already failed.</summary>
-    public static void Error(string message) => Console.Error.WriteLine(FormatError(message, IsColorEnabled()));
+    public static void Error(string message) => Console.Error.WriteLine(
+        FormatError(message, IsColorEnabled(), DisplayLanguage.CurrentPrimaryLanguageId()));
 
     /// <summary>Pure formatting, kept apart from <see cref="IsColorEnabled"/> so the tag's shape
     /// is testable without a real console or environment variables.</summary>
     internal static string Format(string message, bool colorize) => FormatTagged(null, message, colorize);
 
     internal static string FormatWarn(string message, bool colorize) =>
-        FormatTagged(("warning", WarnAccent), message, colorize);
+        FormatWarn(message, colorize, EnglishPrimaryLanguageId);
+
+    internal static string FormatWarn(string message, bool colorize, ushort languageId) =>
+        FormatTagged((SeverityLabel(languageId, isError: false), WarnAccent), message, colorize);
 
     internal static string FormatError(string message, bool colorize) =>
-        FormatTagged(("error", ErrorAccent), message, colorize);
+        FormatError(message, colorize, EnglishPrimaryLanguageId);
+
+    internal static string FormatError(string message, bool colorize, ushort languageId) =>
+        FormatTagged((SeverityLabel(languageId, isError: true), ErrorAccent), message, colorize);
+
+    /// <summary>
+    /// Gets the translated severity label. English is deliberately the default branch so an
+    /// OS language for which wip has no translation never produces a missing or blank label.
+    /// </summary>
+    private static string SeverityLabel(ushort languageId, bool isError) => languageId switch
+    {
+        JapanesePrimaryLanguageId => isError ? "エラー" : "警告",
+        _ => isError ? "error" : "warning",
+    };
 
     private static string FormatTagged((string Label, string Accent)? severity, string message, bool colorize)
     {

--- a/src/Wip.Core/Platform/DisplayLanguage.cs
+++ b/src/Wip.Core/Platform/DisplayLanguage.cs
@@ -5,8 +5,8 @@ namespace Wip.Platform;
 /// <summary>Whether Windows' own UI language is English.</summary>
 /// <remarks>
 /// wip builds with <c>InvariantGlobalization</c> (see <c>Directory.Build.props</c>) —
-/// deliberately, since that is exactly what keeps wip's own strings simple to hold
-/// culture-invariant (see <see cref="Diagnostics.Log"/>) — but the same setting also means
+/// deliberately, since that keeps most of wip's own strings culture-invariant — but the
+/// same setting also means
 /// <c>CultureInfo.CurrentUICulture</c> never reflects the real OS language: every culture
 /// collapses to the invariant one under it. Reading the language straight from Win32 instead
 /// (<c>GetUserDefaultUILanguage</c>, the same LANGID <c>FormatMessage</c> itself consults to
@@ -22,9 +22,17 @@ public static partial class DisplayLanguage
     private const ushort PrimaryLanguageMask = 0x3FF;
     private const ushort EnglishPrimaryLanguageId = 0x09;
 
-    public static bool IsEnglish() => IsEnglish(CurrentUiLanguageId());
+    public static bool IsEnglish() => IsEnglish(CurrentPrimaryLanguageId());
 
     internal static bool IsEnglish(ushort languageId) => (languageId & PrimaryLanguageMask) == EnglishPrimaryLanguageId;
+
+    /// <summary>
+    /// Returns the primary language identifier for the current Windows UI language. On other
+    /// platforms, where wip does not query a platform-specific display language, English is
+    /// used as the stable default.
+    /// </summary>
+    internal static ushort CurrentPrimaryLanguageId() =>
+        (ushort)(CurrentUiLanguageId() & PrimaryLanguageMask);
 
     private static ushort CurrentUiLanguageId() =>
         OperatingSystem.IsWindows() ? GetUserDefaultUILanguage() : EnglishPrimaryLanguageId;

--- a/tests/Wip.Tests/LogTests.cs
+++ b/tests/Wip.Tests/LogTests.cs
@@ -4,6 +4,9 @@ namespace Wip.Tests;
 
 public class LogTests
 {
+    private const ushort JapaneseJP = 0x0411;
+    private const ushort GermanDE = 0x0407;
+
     [Fact]
     public void FormatsPlainWhenColorDisabled()
     {
@@ -52,6 +55,28 @@ public class LogTests
         var actual = Log.FormatError("up failed (exit code 1)", colorize: true);
 
         Assert.Equal("\x1b[36mwip:\x1b[0m \x1b[31merror:\x1b[0m up failed (exit code 1)", actual);
+    }
+
+    [Fact]
+    public void UsesTheLabelForASupportedDisplayLanguage()
+    {
+        Assert.Equal(
+            "wip: 警告: this project is on the WSL filesystem",
+            Log.FormatWarn("this project is on the WSL filesystem", colorize: false, JapaneseJP));
+        Assert.Equal(
+            "wip: エラー: up failed (exit code 1)",
+            Log.FormatError("up failed (exit code 1)", colorize: false, JapaneseJP));
+    }
+
+    [Fact]
+    public void FallsBackToEnglishWhenTheDisplayLanguageIsNotSupported()
+    {
+        Assert.Equal(
+            "wip: warning: this project is on the WSL filesystem",
+            Log.FormatWarn("this project is on the WSL filesystem", colorize: false, GermanDE));
+        Assert.Equal(
+            "wip: error: up failed (exit code 1)",
+            Log.FormatError("up failed (exit code 1)", colorize: false, GermanDE));
     }
 
     [Theory]

--- a/tests/Wip.Tests/LogTests.cs
+++ b/tests/Wip.Tests/LogTests.cs
@@ -69,6 +69,19 @@ public class LogTests
     }
 
     [Fact]
+    public void UsesTheLabelWhenPassedAPrimaryLanguageId()
+    {
+        const ushort japanesePrimaryLanguageId = 0x11;
+
+        Assert.Equal(
+            "wip: 警告: this project is on the WSL filesystem",
+            Log.FormatWarn(
+                "this project is on the WSL filesystem",
+                colorize: false,
+                japanesePrimaryLanguageId));
+    }
+
+    [Fact]
     public void FallsBackToEnglishWhenTheDisplayLanguageIsNotSupported()
     {
         Assert.Equal(


### PR DESCRIPTION
### Motivation

- Ensure wip's own `warning`/`error` labels are presented in the user's display language where supported, but reliably fall back to English when no translation exists. 
- Use the Windows LANGID primary language bits so sublanguage variants (e.g. `en-US` vs `en-GB`) do not affect the language selection logic.

### Description

- Add `DisplayLanguage.CurrentPrimaryLanguageId()` and change `IsEnglish()` to use the masked primary language id so primary-language checks ignore sublanguage bits in `src/Wip.Core/Platform/DisplayLanguage.cs`.
- Make `Log.Warn`/`Log.Error` pass the current primary UI language id and add overloads `FormatWarn(..., ushort languageId)` and `FormatError(..., ushort languageId)` in `src/Wip.Core/Diagnostics/Log.cs`.
- Implement `SeverityLabel(ushort languageId, bool isError)` to return translated labels for supported languages (Japanese: `警告`/`エラー`) and fall back to English (`warning`/`error`) for others.
- Add unit tests in `tests/Wip.Tests/LogTests.cs` that assert Japanese labels are used for a Japanese LANGID and that unsupported languages fall back to English.

### Testing

- Ran `git diff --check` and repository checks, which reported no problems. 
- Added unit tests (`tests/Wip.Tests/LogTests.cs`) covering the new label behavior but could not run `dotnet test` in this environment because the `dotnet` CLI is not available. 
- Committed changes as `fix(log): fall back to English labels` and verified the working tree is clean after the commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a97f5302df08322b5bea48b7da2d682)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Warning and error messages now display severity labels in English or Japanese based on the current primary display language.
  * Diagnostic messages support explicit language selection when being formatted.
  * Language handling recognizes both complete language identifiers and primary language identifiers.

* **Bug Fixes**
  * Unsupported display languages, such as German, now reliably fall back to English severity labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->