### PR TITLE
fix(cli): read wslc 2.9.10's docker-shaped container listing

### DIFF
--- a/src/Wip.Cli/CliContext.cs
+++ b/src/Wip.Cli/CliContext.cs
@@ -993,9 +993,16 @@ internal sealed partial class CliContext
             return (false, null);
         }
 
-        var named = records.Where(record => RecordNames(record).Any()).ToList();
+        // Read once per record rather than once per question asked of it: both the "has a name
+        // at all" test and the match below want the same list, and the restart watch runs
+        // this on every tick.
+        var named = records
+            .Select(record => (Record: record, Names: RecordNames(record).ToList()))
+            .Where(entry => entry.Names.Count > 0)
+            .ToList();
+
         var match = named.Count > 0
-            ? named.FirstOrDefault(record => RecordNames(record).Contains(name))
+            ? named.FirstOrDefault(entry => entry.Names.Contains(name)).Record
             : records[0];
 
         if (match.ValueKind != JsonValueKind.Object)

--- a/src/Wip.Cli/CliContext.cs
+++ b/src/Wip.Cli/CliContext.cs
@@ -823,6 +823,12 @@ internal sealed partial class CliContext
     /// which envelope it came in does not. Anything unparseable stays "no records" rather
     /// than an exception — a probe exists to answer a question, not to take the command down.
     /// </para>
+    /// <para>
+    /// The shape did change: 2.9.10 replaced that record with docker's, which spells the
+    /// fields differently. The envelope is still one of these three, so this method is
+    /// unaffected — see <see cref="RecordNames"/> and <see cref="ReadState"/> for the fields
+    /// themselves.
+    /// </para>
     /// </remarks>
     internal static IReadOnlyList<JsonElement> ParseRecords(string output)
     {
@@ -893,6 +899,81 @@ internal sealed partial class CliContext
         return true;
     }
 
+    private static readonly string[] NameFields = ["Name", "Names"];
+
+    /// <summary>
+    /// The names one listing record answers to.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// wslc 2.9.9 printed <c>"Name":"app"</c>. 2.9.10 moved the whole listing to docker's
+    /// shape, where the field is <c>Names</c> and holds a comma-separated list — one record
+    /// can answer to several names. Both are read here so a single wip binary keeps working
+    /// across that release boundary in either direction, and so the field name lives in one
+    /// place instead of at each of the three sites that used to spell it out.
+    /// </para>
+    /// <para>
+    /// A leading <c>/</c> is trimmed because that is how docker's own API writes a container
+    /// name, and wslc's compatibility layer is the reason this shape is here at all.
+    /// </para>
+    /// </remarks>
+    private static IEnumerable<string> RecordNames(JsonElement record)
+    {
+        foreach (var field in NameFields)
+        {
+            if (!record.TryGetProperty(field, out var value) || value.ValueKind != JsonValueKind.String)
+            {
+                continue;
+            }
+
+            foreach (var entry in (value.GetString() ?? "").Split(','))
+            {
+                var trimmed = entry.Trim().TrimStart('/');
+                if (trimmed.Length > 0)
+                {
+                    yield return trimmed;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads <c>State</c> as wip's vocabulary — the numbers wslc's own enum uses.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// 2.9.9 reported the number; 2.9.10 reports docker's name for the same thing
+    /// (<c>"State":"running"</c>). The names are mapped onto the numbers rather than the
+    /// other way round so every caller — <see cref="DecideContainerAction"/>,
+    /// <see cref="StatusLabel"/>, the restart watch — keeps reading one vocabulary and needs
+    /// no change of its own.
+    /// </para>
+    /// <para>
+    /// Only the four states wslc itself defines are mapped. Docker names with no wslc
+    /// equivalent (<c>paused</c>, <c>restarting</c>, <c>dead</c>) stay null, which is the
+    /// same "listed, state unknown" answer an unreadable state has always produced: the
+    /// conservative fallbacks those callers document are a better answer than a guess at
+    /// which wslc state a docker-only name is supposed to be.
+    /// </para>
+    /// </remarks>
+    private static int? ReadState(JsonElement state) => state.ValueKind switch
+    {
+        // The kind is checked before the read: TryGetInt32 only reports "no" for a number it
+        // cannot fit, and throws for a String or a Bool.
+        JsonValueKind.Number => state.TryGetInt32(out var reported) ? reported : (int?)null,
+        JsonValueKind.String => StateFromName(state.GetString()),
+        _ => null,
+    };
+
+    private static int? StateFromName(string? reported) => reported?.Trim().ToLowerInvariant() switch
+    {
+        "created" => (int?)WslcContainerStateCreated,
+        "running" => WslcContainerStateRunning,
+        "exited" => WslcContainerStateExited,
+        "deleted" => WslcContainerStateDeleted,
+        _ => null,
+    };
+
     /// <summary>
     /// Picks <paramref name="name"/>'s record out of a listing and reports whether it is
     /// there and what state it is in.
@@ -900,9 +981,9 @@ internal sealed partial class CliContext
     /// <remarks>
     /// The name is matched rather than the first record taken: <c>--filter name=</c> narrows
     /// the listing but does not promise a single exact hit, so <c>app</c> could otherwise be
-    /// answered with <c>app-worker</c>'s state. A listing whose records carry no <c>Name</c>
-    /// at all falls back to the first record, which keeps a future rename of that field from
-    /// turning every container into "not found".
+    /// answered with <c>app-worker</c>'s state. A listing whose records carry no name field
+    /// wip knows falls back to the first record, which keeps a future rename of that field
+    /// from turning every container into "not found".
     /// </remarks>
     internal static (bool Exists, int? State) ReadContainerEntry(string output, string name)
     {
@@ -912,12 +993,9 @@ internal sealed partial class CliContext
             return (false, null);
         }
 
-        var named = records.Where(record => record.TryGetProperty("Name", out _)).ToList();
+        var named = records.Where(record => RecordNames(record).Any()).ToList();
         var match = named.Count > 0
-            ? named.FirstOrDefault(record =>
-                record.TryGetProperty("Name", out var value) &&
-                value.ValueKind == JsonValueKind.String &&
-                value.GetString() == name)
+            ? named.FirstOrDefault(record => RecordNames(record).Contains(name))
             : records[0];
 
         if (match.ValueKind != JsonValueKind.Object)
@@ -925,24 +1003,15 @@ internal sealed partial class CliContext
             return (false, null);
         }
 
-        // The kind is checked before the read: TryGetInt32 only reports "no" for a number it
-        // cannot fit, and throws for a String or a Bool. So a wslc that ever reported State
-        // as "running" would take the command down here -- which is the opposite of what a
-        // watch loop needs, and what the old comment on this line wrongly assumed was
-        // already handled. An unreadable state leaves the container listed, state unknown.
-        return match.TryGetProperty("State", out var state) &&
-               state.ValueKind == JsonValueKind.Number &&
-               state.TryGetInt32(out var reported)
+        // An unreadable state leaves the container listed, state unknown.
+        return match.TryGetProperty("State", out var state) && ReadState(state) is { } reported
             ? (true, reported)
             : (true, null);
     }
 
     /// <summary>Whether a network listing names <paramref name="network"/>.</summary>
     internal static bool ListsNetwork(string output, string network) =>
-        ParseRecords(output).Any(record =>
-            record.TryGetProperty("Name", out var name) &&
-            name.ValueKind == JsonValueKind.String &&
-            name.GetString() == network);
+        ParseRecords(output).Any(record => RecordNames(record).Contains(network));
 
     private void EnsureNetwork()
     {

--- a/tests/Wip.Tests/ContainerEntryTests.cs
+++ b/tests/Wip.Tests/ContainerEntryTests.cs
@@ -10,8 +10,9 @@ namespace Wip.Tests;
 /// This layer had no tests at all, and that is exactly where the bug lived. StatusLabelTests
 /// and ContainerActionTests take <c>exists</c> and <c>state</c> as inputs, so they passed on
 /// a real machine where a running container was reported as "not found" — the parse handing
-/// them <c>(false, null)</c> was never in question. The samples below are copied from a real
-/// WSLC 2.9.9 run in the end-to-end job rather than written from the shape wip expected.
+/// them <c>(false, null)</c> was never in question. The samples below are copied from real
+/// WSLC runs in the end-to-end job -- 2.9.9 and the docker-shaped listing 2.9.10 replaced it
+/// with -- rather than written from the shape wip expected.
 /// </remarks>
 public class ContainerEntryTests
 {
@@ -85,15 +86,72 @@ public class ContainerEntryTests
     /// A listed container whose state wip cannot read is still listed: it exists, and the
     /// state falls through to "unknown" rather than making the container disappear.
     /// </summary>
+    /// <remarks>
+    /// The samples are states with no wslc equivalent, and a record carrying no state at all.
+    /// A docker state name wslc does report is read, not treated as unreadable — see
+    /// <see cref="ReadsTheDockerShapedListing"/>.
+    /// </remarks>
     [Fact]
     public void UnreadableStateStillCountsAsPresent()
     {
         Assert.Equal(
             (true, (int?)null),
-            CliContext.ReadContainerEntry("""{"Name":"wip-e2e-app","State":"running"}""", "wip-e2e-app"));
+            CliContext.ReadContainerEntry("""{"Name":"wip-e2e-app","State":"paused"}""", "wip-e2e-app"));
+        Assert.Equal(
+            (true, (int?)null),
+            CliContext.ReadContainerEntry("""{"Name":"wip-e2e-app","State":true}""", "wip-e2e-app"));
         Assert.Equal(
             (true, (int?)null),
             CliContext.ReadContainerEntry("""{"Name":"wip-e2e-app"}""", "wip-e2e-app"));
+    }
+
+    /// <summary>
+    /// What wslc 2.9.10 prints for the same command, copied from the end-to-end job: the
+    /// listing moved to docker's shape, so <c>Name</c> became <c>Names</c> and the numeric
+    /// <c>State</c> became docker's name for it.
+    /// </summary>
+    /// <remarks>
+    /// This is the regression the end-to-end job caught. Against 2.9.10 the parse read no
+    /// name (falling back to whichever record came first) and no state at all, so `wip ps`
+    /// called a running container "unknown", `wip up` tried to start one that was already
+    /// running, and a `restart:` policy never saw an exited container.
+    /// </remarks>
+    private const string DockerShapedObject =
+        """{"Command":"\"sleep 600\"","CreatedAt":"2026-09-05 01:09:48 +0000 UTC","HealthStatus":"","ID":"53054d746ba9","Image":"wip-e2e:latest","LocalVolumes":"0","Mounts":"","Names":"wip-e2e-app","Networks":"wip-e2e-net","Ports":"","RunningFor":"1 second ago","Size":"0B","State":"running","Status":"Up Less than a second"}""";
+
+    [Fact]
+    public void ReadsTheDockerShapedListing()
+    {
+        Assert.Equal((true, Running), CliContext.ReadContainerEntry(DockerShapedObject, "wip-e2e-app"));
+        Assert.Equal((false, (int?)null), CliContext.ReadContainerEntry(DockerShapedObject, "wip-e2e-app-worker"));
+    }
+
+    /// <summary>Every state name wslc has a state of its own for.</summary>
+    [Theory]
+    [InlineData("created", 1)]
+    [InlineData("running", 2)]
+    [InlineData("exited", 3)]
+    [InlineData("deleted", 4)]
+    public void ReadsDockerStateNames(string reported, int expected)
+    {
+        Assert.Equal(
+            (true, (int?)expected),
+            CliContext.ReadContainerEntry($$"""{"Names":"wip-e2e-app","State":"{{reported}}"}""", "wip-e2e-app"));
+    }
+
+    /// <summary>
+    /// docker writes several names for one container as a comma-separated list, and its API
+    /// spelling carries a leading slash. Either has to still name the container.
+    /// </summary>
+    [Fact]
+    public void ReadsOneOfSeveralNames()
+    {
+        Assert.Equal(
+            (true, Running),
+            CliContext.ReadContainerEntry("""{"Names":"other,wip-e2e-app","State":2}""", "wip-e2e-app"));
+        Assert.Equal(
+            (true, Running),
+            CliContext.ReadContainerEntry("""{"Names":"/wip-e2e-app","State":2}""", "wip-e2e-app"));
     }
 
     /// <summary>
@@ -114,5 +172,13 @@ public class ContainerEntryTests
         Assert.False(CliContext.ListsNetwork(listing, "wip-e2e"));
         Assert.True(CliContext.ListsNetwork("""{"Name":"wip-e2e-net"}""", "wip-e2e-net"));
         Assert.False(CliContext.ListsNetwork("", "wip-e2e-net"));
+    }
+
+    /// <summary>The network listing gets the same treatment: one spelling must not miss it.</summary>
+    [Fact]
+    public void NetworksAreMatchedUnderEitherFieldName()
+    {
+        Assert.True(CliContext.ListsNetwork("""{"Names":"wip-e2e-net"}""", "wip-e2e-net"));
+        Assert.False(CliContext.ListsNetwork("""{"Names":"wip-e2e-network"}""", "wip-e2e-net"));
     }
 }

--- a/tests/e2e/run-e2e.ps1
+++ b/tests/e2e/run-e2e.ps1
@@ -120,6 +120,24 @@ function Assert-NoMatch($Result, [string] $Pattern, [string] $What) {
     }
 }
 
+# wslc's own container states, from microsoft/WSL's ContainerModel.h -- the same table
+# CliContext maps. `--format json` reported the number through 2.9.9 and docker's name for it
+# from 2.9.10; both are accepted here for the reason wip accepts both, which is that the
+# assertion is about the container's state and not about which release printed it.
+$script:WslcStateNumbers = @{ created = 1; running = 2; exited = 3; deleted = 4 }
+
+function Assert-State($Result, [string] $Expected, [string] $What) {
+    $number = $script:WslcStateNumbers[$Expected]
+    if ($null -eq $number) { throw "no wslc state number for '$Expected'" }
+
+    # Anchored on the field so a state name appearing anywhere else in the record -- in an
+    # image tag, a container name -- cannot answer for it.
+    $pattern = '"State"\s*:\s*(?:' + $number + '|"' + $Expected + '")'
+    if ($Result.Output -notmatch $pattern) {
+        throw "$What did not report State $Expected ($number): $($Result.Output.Trim())"
+    }
+}
+
 # Runs whatever wslc can still tell us about the machine. Best effort by design: this is
 # reached when something has already failed, so a second failure here must not replace the
 # original one.
@@ -237,18 +255,25 @@ try {
     $up = Invoke-Wip @('up', '-d')
     Assert-Exit $up 0 "wip up -d"
 
-    # The probe wip's own status and create-vs-start decisions are built on, printed raw and
-    # before anything asserts. Not asserted itself -- it is here so the log carries the JSON
-    # shape those decisions have to parse, and it has to run ahead of the assertions or the
-    # first failure takes the log entry with it.
-    Write-Step "Diagnostic: the JSON probe wip reads (not asserted)"
-    Invoke-Wslc @('list', '--all', '--filter', "name=$($script:Container)", '--format', 'json') | Out-Null
-
     # wslc's own view first, state and all. It runs ahead of `wip ps` deliberately: if the
     # container really is not running, that is the container failing and this line says so,
     # and only once wslc has been made to agree does a disagreeing `wip ps` mean wip is wrong.
+    #
+    # It is the JSON probe that is asserted, not the table: State there is the field wip's own
+    # status and create-vs-start decisions parse, so this assertion covers what wip reads. The
+    # table's STATUS column is prose for a person -- 2.9.9 wrote "running Less than a second
+    # ago" and 2.9.10 writes docker's "Up Less than a second", which names no state at all --
+    # and a lifecycle assertion has no business resting on which phrasing is current.
+    Write-Step "wslc's own view of the container"
+    $probe = Invoke-Wslc @('list', '--all', '--filter', "name=$($script:Container)", '--format', 'json')
+    Assert-Exit $probe 0 "wslc list --format json after wip up"
+    Assert-Match $probe $script:ContainerPattern "wslc list --format json after wip up"
+    Assert-State $probe 'running' "wslc list --format json after wip up"
+
+    # The table too, unasserted beyond the name: it is the view a person reading this log has,
+    # and it is where a renamed column or a dropped row shows up at a glance.
     $listed = Invoke-Wslc @('list', '--all')
-    Assert-Match $listed "(?m)^.*\b$($script:ContainerPattern)\b.*\brunning\b" "wslc list --all after wip up"
+    Assert-Match $listed $script:ContainerPattern "wslc list --all after wip up"
 
     # The state column, not just the name: `wip ps` exits 0 and prints the row whatever the
     # container's state is, so matching the name alone would pass on a row reading

--- a/tests/e2e/run-e2e.ps1
+++ b/tests/e2e/run-e2e.ps1
@@ -126,15 +126,58 @@ function Assert-NoMatch($Result, [string] $Pattern, [string] $What) {
 # assertion is about the container's state and not about which release printed it.
 $script:WslcStateNumbers = @{ created = 1; running = 2; exited = 3; deleted = 4 }
 
+# The envelopes CliContext.ParseRecords accepts: an array, a lone object, or one object per
+# line. Read the same way here, because the point of asserting on this output is to read the
+# listing the way wip reads it.
+function Read-WslcRecords([string] $Json) {
+    if (-not $Json.Trim()) { return @() }
+
+    # The whole output first, which covers an array and a lone object in one step.
+    try { return @($Json | ConvertFrom-Json) } catch { }
+
+    # Several values in sequence are trailing data to ConvertFrom-Json, so line-delimited
+    # output only parses a line at a time.
+    $records = @()
+    foreach ($line in $Json -split "`n") {
+        if ($line.Trim()) {
+            try { $records += @($line | ConvertFrom-Json) } catch { }
+        }
+    }
+
+    return $records
+}
+
+# The names one record answers to: `Name` through 2.9.9, docker's `Names` -- comma-separated,
+# an optional leading slash -- from 2.9.10. The two spellings CliContext reads.
+function Get-RecordNames($Record) {
+    foreach ($field in 'Name', 'Names') {
+        $value = $Record.$field
+        if ($value -is [string] -and $value) {
+            foreach ($entry in $value -split ',') {
+                $trimmed = $entry.Trim().TrimStart('/')
+                if ($trimmed) { $trimmed }
+            }
+        }
+    }
+}
+
 function Assert-State($Result, [string] $Expected, [string] $What) {
     $number = $script:WslcStateNumbers[$Expected]
     if ($null -eq $number) { throw "no wslc state number for '$Expected'" }
 
-    # Anchored on the field so a state name appearing anywhere else in the record -- in an
-    # image tag, a container name -- cannot answer for it.
-    $pattern = '"State"\s*:\s*(?:' + $number + '|"' + $Expected + '")'
-    if ($Result.Output -notmatch $pattern) {
-        throw "$What did not report State $Expected ($number): $($Result.Output.Trim())"
+    # This container's record, not any record in the listing: `--filter name=` narrows without
+    # promising an exact hit, so app-worker's row must not answer for app's -- and matching
+    # the name and the state as two independent patterns over the whole output would let it.
+    $record = Read-WslcRecords $Result.Output |
+        Where-Object { (Get-RecordNames $_) -contains $script:Container } |
+        Select-Object -First 1
+    if (-not $record) {
+        throw "$What listed no record named $($script:Container): $($Result.Output.Trim())"
+    }
+
+    $state = $record.State
+    if ($state -ne $number -and "$state" -ne $Expected) {
+        throw "$What reported State '$state' for $($script:Container), expected $Expected ($number)"
     }
 }
 
@@ -267,7 +310,6 @@ try {
     Write-Step "wslc's own view of the container"
     $probe = Invoke-Wslc @('list', '--all', '--filter', "name=$($script:Container)", '--format', 'json')
     Assert-Exit $probe 0 "wslc list --format json after wip up"
-    Assert-Match $probe $script:ContainerPattern "wslc list --format json after wip up"
     Assert-State $probe 'running' "wslc list --format json after wip up"
 
     # The table too, unasserted beyond the name: it is the view a person reading this log has,


### PR DESCRIPTION
### Motivation

The `Lifecycle against real WSLC` job started failing on 2026-09-05 (first seen on #155, whose diff touches only `tweet.yml` and `release.yml`). It is not a flake and not that PR's: the runner's wslc moved from 2.9.9.0 to 2.9.10.0, and 2.9.10 moved `list --format json` to docker's shape.

The record wip probes went from

```json
{"CreatedAt":1788490827,"Id":"…","Image":"wip-e2e:latest","Name":"wip-e2e-app","Ports":[],"State":2,"StateChangedAt":1788490828}
```

to

```json
{"Command":"\"sleep 600\"","ID":"…","Image":"wip-e2e:latest","Names":"wip-e2e-app","State":"running","Status":"Up Less than a second", …}
```

Both fields wip reads were renamed out from under it, so this is a product bug the end-to-end job caught, not just a stale assertion:

- `Name` is gone. No record matched by name, and the parse fell back to whichever record came first — so `--filter name=app` could be answered with `app-worker`'s state.
- `State` is docker's name rather than wslc's enum number. The kind check rejected a string, so every container came back "listed, state unknown". `wip ps` reported a running container as `unknown`, `wip up` tried to `start` one that was already running (ERROR_INVALID_STATE), and a `restart:` policy never recognised an exited container to restart.

### Description

- `CliContext` reads both spellings, in one place each rather than at the three sites that spelled the field out: `RecordNames` accepts `Name` and `Names` (comma-separated, leading `/` trimmed, as docker writes it), and `ReadState` accepts the number or docker's name.
- Docker's state names map onto wslc's own numbers, so `DecideContainerAction`, `StatusLabel` and the restart watch keep reading one vocabulary and are unchanged. Names with no wslc equivalent (`paused`, `restarting`, `dead`) stay unknown and keep the conservative fallbacks those callers already document.
- `ListsNetwork` gets the same treatment, so a renamed field cannot silently make wip recreate an existing network.
- The end-to-end job asserted the wrong thing about all this: it matched `running` in the table `wslc list --all` prints, which is prose for a person — 2.9.9 wrote `running Less than a second ago`, 2.9.10 writes docker's `Up Less than a second`, naming no state at all. It now asserts `State` in the JSON probe, which is the field wip actually parses, and accepts either spelling for the same reason wip does. The table is still printed, and still checked for the container's name.

### Testing

- `ContainerEntryTests` gains the 2.9.10 record copied verbatim from the failing run, a case per state name, the comma-separated and `/`-prefixed name spellings, and the network listing under either field. `UnreadableStateStillCountsAsPresent` moved off `"running"` (now read) onto states that genuinely have no wslc equivalent.
- The .NET suites and the real-WSLC lifecycle were **not** run locally: this environment has no .NET SDK and the egress policy blocks installing one, and the E2E job needs Windows with a real WSLC. Both are left to this PR's CI, which is what the fix has to satisfy. The parse logic and every new expectation above were checked against the two real listings from the job logs before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147ZYkNgeAs3QBmjqPfEDHj

---
_Generated by [Claude Code](https://claude.ai/code/session_0147ZYkNgeAs3QBmjqPfEDHj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with legacy WSLC and Docker-compatible container and network output.
  * Container names are recognized across multiple formats, including slash-prefixed and comma-separated names.
  * Container states support recognized numeric and textual values, while unsupported values remain unknown.

* **Tests**
  * Expanded coverage for container and network parsing.
  * End-to-end checks now verify that containers reach the running state using JSON output.
  * Updated command-output examples and regression coverage for unreadable states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->