### PR TITLE
fix(release): scope model access and robustly truncate release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ concurrency:
 
 permissions:
   contents: read
-  models: read
 
 jobs:
   check:
@@ -363,6 +362,11 @@ jobs:
   tweet:
     name: Tweet the release
     needs: [check, publish]
+    # Reusable workflows cannot elevate the caller's token. Grant model access only
+    # to this handoff rather than to every job in the release workflow.
+    permissions:
+      contents: read
+      models: read
     uses: ./.github/workflows/tweet.yml
     with:
       tag: ${{ needs.check.outputs.tag }}

--- a/.github/workflows/tweet.yml
+++ b/.github/workflows/tweet.yml
@@ -80,7 +80,9 @@ jobs:
 
           release=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json body,url)
           release_url=$(jq -r .url <<< "$release")
-          release_notes=$(jq -r .body <<< "$release" | head -c 12000)
+          # Truncate in jq instead of piping into `head`: with pipefail, a release body
+          # over the limit can make jq receive SIGPIPE and abort the whole step.
+          release_notes=$(jq -r '(.body // "")[0:12000]' <<< "$release")
 
           previous=$(gh release list --repo "$GITHUB_REPOSITORY" --exclude-drafts --limit 100 \
             --json tagName --jq "[.[] | select(.tagName != \"$TAG\")][0].tagName // \"\"")


### PR DESCRIPTION
### Motivation

- Limit the blast radius of `models: read` by granting GitHub Models access only to the announcement handoff rather than the entire release workflow.
- Prevent the tweet job from failing with SIGPIPE when a very long release body is piped into `head` under `set -o pipefail` by truncating the text safely.

### Description

- Remove `models: read` from the top-level `permissions` in `.github/workflows/release.yml` and add a scoped `permissions` block (including `models: read`) to the `tweet` job call. 
- Change release-note truncation in `.github/workflows/tweet.yml` from piping into `head` to truncating inside `jq` with `jq -r '(.body // "")[0:12000]' <<< "$release"` so `null` bodies are handled and `pipefail`/SIGPIPE is avoided.
- Add clarifying comments to both workflows explaining the rationale for the permission scoping and the `jq` truncation.

### Testing

- Ran YAML validation with `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.parse_file(f); puts "parsed #{f}" }'` and all workflow files parsed successfully. ✅
- Verified `jq` truncation behavior with a Python check that feeds a 20,000-character `body` and asserts the output is 12,000 characters, and the assertion passed. ✅
- Ran `git diff --check` and `git status` to confirm the changes are clean and committed as `fix(release): scope announcement model access`. ✅
- Attempted to run the .NET test suite but `dotnet` is not installed in this environment, so those tests were skipped. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9b76ca41088322b4c83f0cf2836695)