### PR TITLE
feat(release): publish/WinGet/tweet only after Scoop manifest merges

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -97,4 +97,4 @@ jobs:
             --base "${GITHUB_REF_NAME}" \
             --head "bump-version-v${NEXT}" \
             --title "chore: bump version to v${NEXT}" \
-            --body "Bump wip version to v${NEXT}. Merging this publishes v${NEXT}: the release workflow reads the version from Directory.Build.props, creates the tag, and updates the Scoop manifest after uploading the release archive."
+            --body "Bump wip version to v${NEXT}. Merging this builds v${NEXT} and opens a pull request updating the Scoop manifest with its verified digest. Merging *that* pull request is what actually publishes the release, submits it to WinGet, and posts the announcement to X."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,9 +97,9 @@ jobs:
             fi
 
             echo "needed=false" >> "$GITHUB_OUTPUT"
-            echo "Directory.Build.props has not changed since $previous, which is published with its artifacts; nothing to build." >> "$GITHUB_STEP_SUMMARY"
+            echo "$TAG matches the latest published release, $previous, which is complete with its artifacts; nothing to build." >> "$GITHUB_STEP_SUMMARY"
           else
-            draft_tag=$(gh release list --json tagName,isDraft,name \
+            draft_tag=$(gh release list --limit 100 --json tagName,isDraft,name \
               --jq '[.[] | select(.isDraft and .name == "Unreleased")] | .[0].tagName // ""')
 
             built=false
@@ -438,8 +438,24 @@ jobs:
             exit 1
           fi
 
-          published=$(gh release list --exclude-drafts --json tagName \
-            | jq -r --arg t "$TAG" 'any(.[]; .tagName == $t)')
+          # Looked up by tag directly rather than via `gh release list`, which defaults to the
+          # 30 most recent releases: paging could miss $TAG once the repository accumulates
+          # more releases than that, wrongly reporting an old, already-published version as
+          # not published and sending it back through publish/WinGet/tweet on a stale tag.
+          set +e
+          view=$(gh release view "$TAG" --json isDraft 2>&1)
+          view_status=$?
+          set -e
+
+          if [ "$view_status" -eq 0 ]; then
+            is_draft=$(jq -r '.isDraft' <<< "$view")
+            published=$([ "$is_draft" == "false" ] && echo true || echo false)
+          elif grep -qi "release not found" <<< "$view"; then
+            published=false
+          else
+            echo "::error::Could not look up release $TAG: $view"
+            exit 1
+          fi
 
           if [ "$published" == "true" ]; then
             echo "needed=false" >> "$GITHUB_OUTPUT"
@@ -480,7 +496,10 @@ jobs:
   winget:
     name: Submit to WinGet
     needs: [check-finalize, publish]
-    if: needs.check-finalize.outputs.needed == 'true'
+    # A custom `if:` replaces the default implicit success() check, so it has to ask for it
+    # explicitly too -- otherwise a failed publish wouldn't stop this from submitting a release
+    # that was never actually made public.
+    if: needs.check-finalize.outputs.needed == 'true' && needs.publish.result == 'success'
     uses: ./.github/workflows/winget.yml
     with:
       tag: ${{ needs.check-finalize.outputs.tag }}
@@ -494,7 +513,8 @@ jobs:
   tweet:
     name: Tweet the release
     needs: [check-finalize, publish]
-    if: needs.check-finalize.outputs.needed == 'true'
+    # See the same note on the winget job above: a custom `if:` needs its own success check.
+    if: needs.check-finalize.outputs.needed == 'true' && needs.publish.result == 'success'
     permissions:
       contents: read
     uses: ./.github/workflows/tweet.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,8 +103,12 @@ jobs:
             # "Unreleased" (the same race the attach job below guards against), silently
             # picking one would make this check nondeterministic -- it could look at the
             # wrong draft's assets and skip a rebuild that's actually still needed.
-            drafts=$(gh release list --limit 100 --json tagName,isDraft,name \
-              --jq '[.[] | select(.isDraft and .name == "Unreleased") | .tagName]')
+            # --paginate rather than a fixed --limit: every page is fetched, so a draft
+            # doesn't go unseen once the repository accumulates enough releases to push it
+            # past a fixed page size. --paginate emits one array per page and cannot be
+            # combined with --jq, so the pages are slurped into one array here and filtered.
+            drafts=$(gh api --paginate "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+              | jq -s '[.[][] | select(.draft and .name == "Unreleased") | .tag_name]')
             draft_count=$(jq 'length' <<< "$drafts")
 
             if [ "$draft_count" -gt 1 ]; then
@@ -289,10 +293,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          # This job intentionally has no checkout, so gh cannot infer the repository from
-          # a local .git directory. Address it explicitly for every `gh release` command.
-          drafts=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 100 --json tagName,name,isDraft \
-            --jq '[.[] | select(.isDraft and .name == "Unreleased") | .tagName]')
+          # --paginate rather than a fixed --limit: every page is fetched, so a draft doesn't
+          # go unseen once the repository accumulates enough releases to push it past a fixed
+          # page size. --paginate emits one array per page and cannot be combined with --jq,
+          # so the pages are slurped into one array here and filtered.
+          drafts=$(gh api --paginate "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+            | jq -s '[.[][] | select(.draft and .name == "Unreleased") | .tag_name]')
           count=$(echo "$drafts" | jq 'length')
 
           if [ "$count" -eq 0 ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,8 +99,20 @@ jobs:
             echo "needed=false" >> "$GITHUB_OUTPUT"
             echo "$TAG matches the latest published release, $previous, which is complete with its artifacts; nothing to build." >> "$GITHUB_STEP_SUMMARY"
           else
-            draft_tag=$(gh release list --limit 100 --json tagName,isDraft,name \
-              --jq '[.[] | select(.isDraft and .name == "Unreleased")] | .[0].tagName // ""')
+            # Enumerate rather than take the first match: with more than one draft named
+            # "Unreleased" (the same race the attach job below guards against), silently
+            # picking one would make this check nondeterministic -- it could look at the
+            # wrong draft's assets and skip a rebuild that's actually still needed.
+            drafts=$(gh release list --limit 100 --json tagName,isDraft,name \
+              --jq '[.[] | select(.isDraft and .name == "Unreleased") | .tagName]')
+            draft_count=$(jq 'length' <<< "$drafts")
+
+            if [ "$draft_count" -gt 1 ]; then
+              echo "::error::$draft_count draft releases are named \"Unreleased\" ($(jq -r 'join(", ")' <<< "$drafts")); cannot tell which one to check for an existing build."
+              exit 1
+            fi
+
+            draft_tag=$(jq -r '.[0] // ""' <<< "$drafts")
 
             built=false
             if [ -n "$draft_tag" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,17 @@ name: Release
 
 # Version-driven, the way the gem released: the version in the project file is the trigger,
 # not a tag anyone types. Every merge to main compares that file with the latest published
-# release, and only a merge that changes it creates a tag and releases anything.
+# release, and only a merge that changes it creates a tag and builds anything.
+#
+# Publishing is a second, separate trigger. Building attaches its archive and checksums to
+# the running "Unreleased" draft and proposes a Scoop manifest update (wip.json) with the
+# verified digest, but does not publish, submit to WinGet, or tweet -- those all depend on
+# the release actually being public (WinGet's validation and the tweet's link both need a
+# working download URL, which a draft does not have), so they wait for a human to merge that
+# Scoop manifest PR. That merge is itself a push to main, changing only wip.json, and is what
+# the check-finalize job below is watching for. This keeps every install path -- direct
+# download, WinGet, Scoop -- ready together at the moment the release is announced, instead of
+# announcing before Scoop can actually install it.
 on:
   push:
     branches:
@@ -33,7 +43,6 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       # Directory.Build.props is the single source of truth: the SDK stamps this into the
@@ -51,18 +60,28 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "tag=v$version" >> "$GITHUB_OUTPUT"
 
-      # A version bump is deliberately just a file change. At release time, compare that file
-      # with the commit selected by the latest published release instead of treating the draft
-      # release (or a prematurely-created tag) as the source of truth.
+      # A version bump is deliberately just a file change, compared against the latest
+      # published release rather than treating a tag or draft as the source of truth. But a
+      # bump that has already been built sits in an in-between state now that publishing is a
+      # separate, later trigger: Directory.Build.props keeps pointing at the new version from
+      # the moment it is bumped until the Scoop manifest PR for it is merged, long after this
+      # job's own build already ran once. Re-running it would rebuild and re-attach for
+      # nothing, so a bump already sitting on the "Unreleased" draft counts as done too, not
+      # just one that has made it all the way to a publish. The draft is matched by name, the
+      # same way the attach job below does, because its own tagName is only release-drafter's
+      # guessed next version, not necessarily this one.
       - name: Check for a version change
         id: changed
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
           set -euo pipefail
 
           previous=$(gh release list --exclude-drafts --limit 1 --json tagName --jq '.[0].tagName // ""')
-          if [ -n "$previous" ] && git diff --quiet "$previous" HEAD -- Directory.Build.props; then
+
+          if [ "$previous" == "$TAG" ]; then
             # "Already released" has to mean the downloads are there too. Publishing can make a
             # release immutable, so one that went out without its artifacts cannot be repaired by
             # re-running this workflow -- the only way out is a corrected version. Say that here
@@ -78,13 +97,31 @@ jobs:
             fi
 
             echo "needed=false" >> "$GITHUB_OUTPUT"
-            echo "Directory.Build.props has not changed since $previous, which is published with its artifacts; nothing to release." >> "$GITHUB_STEP_SUMMARY"
+            echo "Directory.Build.props has not changed since $previous, which is published with its artifacts; nothing to build." >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "needed=true" >> "$GITHUB_OUTPUT"
-            echo "Directory.Build.props changed since ${previous:-the repository began}; releasing the new version." >> "$GITHUB_STEP_SUMMARY"
+            draft_tag=$(gh release list --json tagName,isDraft,name \
+              --jq '[.[] | select(.isDraft and .name == "Unreleased")] | .[0].tagName // ""')
+
+            built=false
+            if [ -n "$draft_tag" ]; then
+              assets=$(gh release view "$draft_tag" --json assets --jq '[.assets[].name]')
+              has_archive=$(jq -r --arg n "wip-${VERSION}-win-x64.zip" 'any(.[]; . == $n)' <<< "$assets")
+              has_checksums=$(jq -r 'any(.[]; . == "SHA256SUMS")' <<< "$assets")
+              if [ "$has_archive" == "true" ] && [ "$has_checksums" == "true" ]; then
+                built=true
+              fi
+            fi
+
+            if [ "$built" == "true" ]; then
+              echo "needed=false" >> "$GITHUB_OUTPUT"
+              echo "$TAG is already built and attached to the Unreleased draft; waiting for its Scoop manifest update to be merged before publishing." >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "needed=true" >> "$GITHUB_OUTPUT"
+              echo "Directory.Build.props changed since ${previous:-the repository began}; building the new version." >> "$GITHUB_STEP_SUMMARY"
+            fi
           fi
 
-      # Tag only after the version comparison decides to release. Re-runs accept the same tag
+      # Tag only after the version comparison decides to build. Re-runs accept the same tag
       # at the same commit, but reject a tag that already points somewhere else.
       - name: Tag release commit
         if: steps.changed.outputs.needed == 'true'
@@ -111,7 +148,7 @@ jobs:
           case "$status" in
             200)
               # Re-read the ref on its own rather than picking the body back out of the headers.
-              # This only runs when the tag is already there, which is a re-run of a release.
+              # This only runs when the tag is already there, which is a re-run of a build.
               tagged_sha=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" --jq .object.sha)
               if [ "$tagged_sha" != "$GITHUB_SHA" ]; then
                 echo "::error::$TAG already points to $tagged_sha, not $GITHUB_SHA."
@@ -132,7 +169,7 @@ jobs:
           esac
 
   # Windows only because Native AOT cannot cross-compile between operating systems. Nothing
-  # else in the release needs it, and the publish job below exists because one of those other
+  # else in the build needs it, and the attach job below exists because one of those other
   # things actively breaks here.
   build:
     name: Build release artifacts
@@ -205,32 +242,36 @@ jobs:
   # config path with node:path's join, so on a Windows runner it asks the GitHub API for
   # `.github\release-drafter.yml` and gets a 404. There is no input that works around it --
   # passing `.github/release-drafter.yml` is normalised to backslashes too, and then joined a
-  # second time. Publishing from Linux is the fix.
-  publish:
-    name: Publish release
+  # second time. Running from Linux is the fix.
+  #
+  # Attaches to the draft and proposes the Scoop manifest update, but does not publish -- see
+  # the top-of-file note on why that waits for the Scoop manifest PR to be merged.
+  attach:
+    name: Attach build to the draft release
     needs: [check, build]
     runs-on: ubuntu-latest
 
     permissions:
       contents: write
-      # release-drafter reads merged pull requests, and the Scoop update is proposed as one.
+      # The Scoop update is proposed as a pull request.
       pull-requests: write
 
     steps:
-      # No checkout: release-drafter reads its config through the API, and the artifacts
-      # come from the build job.
+      # No checkout: the artifacts come from the build job, and the Scoop manifest update
+      # below does its own checkout once it actually needs the working tree.
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: release-dist
           path: dist
 
-      # Attach artifacts to the running changelog draft before publishing it. The draft is the
-      # one release-drafter keeps updated, so it is addressed by the name its name-template gives
-      # it in .github/release-drafter.yml rather than by position in the release list: a manual
-      # or stale draft must not be the thing that receives the artifacts and gets published under
-      # the release tag. Its tag is whatever next-patch guess release-drafter made; the actual
-      # version tag was created by the check job and is supplied when the draft is published.
+      # Attach artifacts to the running changelog draft. The draft is the one release-drafter
+      # keeps updated, so it is addressed by the name its name-template gives it in
+      # .github/release-drafter.yml rather than by position in the release list: a manual or
+      # stale draft must not be the thing that receives the artifacts and later gets published
+      # under the release tag. Its tag is whatever next-patch guess release-drafter made; the
+      # actual version tag was created by the check job and is supplied only when a later,
+      # separate run publishes the draft.
       - name: Upload release artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -256,21 +297,7 @@ jobs:
           gh release upload "$draft_tag" dist/*.zip dist/SHA256SUMS \
             --repo "$GITHUB_REPOSITORY" --clobber
 
-      # Publish only after every artifact is attached. The explicit tag and name replace the
-      # draft's guessed next-patch values with the version read from Directory.Build.props.
-      - name: Publish release
-        uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7
-        with:
-          config-name: release-drafter.yml
-          publish: true
-          tag: ${{ needs.check.outputs.tag }}
-          name: ${{ needs.check.outputs.tag }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # A Scoop manifest must contain the archive's digest, not a checksum-file URL. Keep
-      # the previous release installable until the new archive has been uploaded and
-      # published, then read back that release's checksum and propose the update. Main may
+      # A Scoop manifest must contain the archive's digest, not a checksum-file URL. Main may
       # be protected, so the workflow must not try to push the generated commit directly.
       - name: Check out repository for Scoop manifest update
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -286,16 +313,14 @@ jobs:
         run: |
           set -euo pipefail
           archive="wip-${VERSION}-win-x64.zip"
-          rm -rf scoop-release
-          mkdir scoop-release
-          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
-            --pattern SHA256SUMS --dir scoop-release
 
           # SHA256SUMS is written by PowerShell on a Windows runner, so its filename field can
-          # retain a carriage return when awk reads the CRLF-terminated line on Linux.
-          digest=$(awk -v archive="$archive" '{ sub(/\r$/, "", $2); if ($2 == archive) print tolower($1) }' scoop-release/SHA256SUMS)
+          # retain a carriage return when awk reads the CRLF-terminated line on Linux. Read it
+          # from this job's own artifact download rather than the draft release: the release
+          # isn't published yet at this point, so there is nothing more authoritative to fetch.
+          digest=$(awk -v archive="$archive" '{ sub(/\r$/, "", $2); if ($2 == archive) print tolower($1) }' dist/SHA256SUMS)
           if ! [[ "$digest" =~ ^[0-9a-f]{64}$ ]]; then
-            echo "::error::SHA256SUMS has no valid digest for $archive"
+            echo "::error::dist/SHA256SUMS has no valid digest for $archive"
             exit 1
           fi
 
@@ -340,18 +365,125 @@ jobs:
               --base "$GITHUB_REF_NAME" \
               --head "$branch" \
               --title "chore(scoop): update manifest for v${VERSION}" \
-              --body "Update the Scoop manifest with the verified digest from the published v${VERSION} archive."
+              --body "Update the Scoop manifest with the verified digest from the built v${VERSION} archive. Merging this publishes the release, submits it to WinGet, and posts the announcement to X."
           fi
+
+  # Separate from `check`: that job watches Directory.Build.props to decide whether a new
+  # version needs building; this one watches wip.json to decide whether an already-built
+  # version is ready to go live. They run independently -- on the push that bumps
+  # Directory.Build.props, wip.json has not changed yet, so this reports nothing to do; on the
+  # later push that merges the Scoop manifest PR, Directory.Build.props has not changed either,
+  # so `check` reports nothing to do while this one does.
+  check-finalize:
+    name: Check whether a build is ready to publish
+    runs-on: ubuntu-latest
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
+      needed: ${{ steps.ready.outputs.needed }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Read version
+        id: version
+        run: |
+          set -euo pipefail
+          version=$(jq -r '.version' wip.json)
+          if [ -z "$version" ] || [ "$version" == "null" ]; then
+            echo "Could not find .version in wip.json" >&2
+            exit 1
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+
+      # Ready to publish exactly when the tag the check job created already exists (the build
+      # ran) but no published release uses it yet (the finalize side hasn't run). A tag that
+      # doesn't exist at all means wip.json points at a version that was never built -- the
+      # Scoop manifest is only ever machine-generated by the attach job above, from a build
+      # that already created this same tag, so that should not be possible outside of manual
+      # edits or a mismatched merge.
+      - name: Check draft readiness
+        id: ready
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          set +e
+          response=$(gh api --include "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" 2>&1)
+          set -e
+
+          status=$(printf '%s\n' "$response" \
+            | awk '/^HTTP\// && $2 ~ /^[0-9][0-9][0-9]$/ { status = $2 } END { print status }')
+
+          case "$status" in
+            200) tag_exists=true ;;
+            404) tag_exists=false ;;
+            *)
+              echo "::error::Could not look up $TAG: the lookup answered ${status:-no HTTP status}."
+              printf '%s\n' "$response" >&2
+              exit 1
+              ;;
+          esac
+
+          if [ "$tag_exists" != "true" ]; then
+            echo "::error::wip.json references $TAG, but no such tag exists. Expected a completed release build to have created it already."
+            exit 1
+          fi
+
+          published=$(gh release list --exclude-drafts --json tagName \
+            | jq -r --arg t "$TAG" 'any(.[]; .tagName == $t)')
+
+          if [ "$published" == "true" ]; then
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+            echo "$TAG is already published; nothing to finalize." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+            echo "$TAG is built and wip.json is up to date; publishing, WinGet, and the tweet are ready to run." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  publish:
+    name: Publish release
+    needs: check-finalize
+    if: needs.check-finalize.outputs.needed == 'true'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      # release-drafter reads merged pull requests to build the release notes.
+      pull-requests: write
+
+    steps:
+      # The explicit tag and name replace the draft's guessed next-patch values with the
+      # version read from wip.json. No checkout: release-drafter reads its config through the
+      # API, and the artifacts were already attached to the draft by the attach job.
+      - name: Publish release
+        uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7
+        with:
+          config-name: release-drafter.yml
+          publish: true
+          tag: ${{ needs.check-finalize.outputs.tag }}
+          name: ${{ needs.check-finalize.outputs.tag }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Called rather than triggered: a release created with GITHUB_TOKEN does not raise
   # `release: published` for another workflow, so an event-based handoff would leave every
   # automated release unsubmitted with nothing to show for it.
   winget:
     name: Submit to WinGet
-    needs: [check, publish]
+    needs: [check-finalize, publish]
+    if: needs.check-finalize.outputs.needed == 'true'
     uses: ./.github/workflows/winget.yml
     with:
-      tag: ${{ needs.check.outputs.tag }}
+      tag: ${{ needs.check-finalize.outputs.tag }}
     # Mapped rather than inherited: `secrets: inherit` would hand the called workflow every
     # secret this repository has, when it needs exactly one.
     secrets:
@@ -361,12 +493,13 @@ jobs:
   # on the WinGet submission, so there's no reason to make one wait on the other.
   tweet:
     name: Tweet the release
-    needs: [check, publish]
+    needs: [check-finalize, publish]
+    if: needs.check-finalize.outputs.needed == 'true'
     permissions:
       contents: read
     uses: ./.github/workflows/tweet.yml
     with:
-      tag: ${{ needs.check.outputs.tag }}
+      tag: ${{ needs.check-finalize.outputs.tag }}
     # Mapped rather than inherited: `secrets: inherit` would hand the called workflow every
     # secret this repository has, when it needs exactly four.
     secrets:


### PR DESCRIPTION
## Summary
- Previously, merging the `Directory.Build.props` version-bump PR immediately built the release **and** published it, submitted it to WinGet, and posted the X announcement — all in the same run that also opened the Scoop manifest update PR. Since WinGet's own validation and the tweet's release link both need a *working* download URL, and a draft release's assets aren't publicly downloadable, every real install path (WinGet, Scoop) could lag behind the public announcement by however long that Scoop PR sat open for review.
- Split `release.yml` into two triggers so every install path is ready together when the release goes public:
  - **Phase 1** (`check` → `build` → `attach`, triggered by the `Directory.Build.props` bump): builds the archive, attaches it to the running `Unreleased` draft, and opens the Scoop manifest (`wip.json`) update PR. No longer publishes, submits to WinGet, or tweets.
  - **Phase 2** (`check-finalize` → `publish` → `winget` + `tweet`, triggered by merging that Scoop manifest PR): publishes the already-built draft as the real release, submits it to WinGet, and posts to X.
- `check`'s idempotency logic changed out of necessity: comparing `Directory.Build.props` against only the *published* release is no longer enough to know a build already happened, since a built-but-not-yet-published version now sits in an in-between state for as long as its Scoop PR is open. It now also recognizes a version already attached to the `Unreleased` draft (matched by name, since the draft's own tag is only release-drafter's guessed next version, not necessarily the real one) as already built, so the Scoop-PR-merge push doesn't trigger a redundant rebuild.
- `check-finalize` (new) treats a build as ready to finalize when its tag already exists (created by `check`) but isn't attached to a *published* release yet; if `wip.json` somehow references a tag that was never built, it fails loudly rather than silently no-opping.
- Updated `bump-version.yml`'s PR body, which previously said merging it "publishes" the release — no longer accurate.

## Test plan
- [x] Validated all touched/related workflow YAML files parse (`js-yaml`).
- [x] Dry-ran `check`'s new version-change logic against this repo's real, current steady state (`v2.5.1` published with complete assets) — correctly resolves `needed=false`.
- [x] Dry-ran the same logic simulating a fresh, not-yet-built version bump against the real `Unreleased` draft (currently empty) — correctly resolves `needed=true`.
- [x] Dry-ran `check-finalize`'s tag-existence lookup against the real `v2.5.1` tag — correctly resolves `tag_exists=true`.
- [x] Caught and fixed a real bug before merging: `gh release list --jq --arg t ...` doesn't work (`gh`'s `-q/--jq` flag takes a single expression string only, no `jq`-style `--arg`) — confirmed the failure locally (`unknown command "t" for "gh release list"`) and switched to piping into a real `jq -r --arg t ...` instead, matching the pattern already used elsewhere in this file.
- [ ] A real end-to-end run (bump version → merge → build/attach → merge Scoop PR → publish/WinGet/tweet) can only be verified by actually cutting the next release.

Known edge case, left as a loud failure rather than handled: if `Directory.Build.props` and `wip.json` were ever manually bumped to the same new version in a single commit (bypassing the normal two-PR flow), `check-finalize` could run before `check` creates that version's tag in the same workflow run, and would fail with an explicit error rather than silently doing the wrong thing. This shouldn't happen via the automated flow, since `wip.json` is only ever machine-updated in its own separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1z3dHVziPhCAhKf8ALfjQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Process**
  * Version updates now build artifacts and create a Scoop manifest pull request with a verified digest.
  * Build artifacts are attached to the unreleased draft and reused during finalization when available.
  * Merging the manifest update publishes the release, submits it to WinGet, and posts the announcement to X.
  * Release handling detects completed releases and duplicate unreleased drafts, preventing ambiguous finalization.
  * Downstream publishing steps proceed only after successful release publication.

* **Documentation**
  * Version-bump pull request instructions explain the updated release and publishing sequence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->