### PR TITLE
docs: Add slide GIF to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 Homepage: https://wslc-wip.slidict.com/ · **[Full documentation: wip Wiki](https://github.com/slidict/wip/wiki)**
 
+[![wip slide](https://slidict.io/slides/160/gif?v=1788619628)](https://slidict.io/slides/160)
+
 `wip` is an OSS CLI wrapper that brings a [`dip`](https://github.com/bibendi/dip)-like
 workflow to Microsoft WSLC. It collects a project's container, image, environment variables, and
 commands into a single `wip.yml`, and forwards them to `wslc.exe` / `wslc` as safe argument arrays


### PR DESCRIPTION
Added a slide GIF to the README for visual representation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a slide image beneath the project header in the README.
  - The image links to the corresponding Slidict slide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->