### PR TITLE
fix(tweet): exclude commits confined to .github/ from the announcement

### DIFF
--- a/.github/workflows/tweet.yml
+++ b/.github/workflows/tweet.yml
@@ -97,30 +97,20 @@ jobs:
 
           # Commit subjects for one Conventional Commit type, newest first, with the
           # prefix stripped, first letter capitalized, and long subjects clipped so a
-          # single line can't blow the tweet's character budget on its own. A commit whose
-          # changes are confined entirely to .github/ is skipped regardless of type: it's
-          # release or CI tooling, not anything a wip CLI user would notice, and Conventional
-          # Commit type alone can't tell the two apart (a workflow change is legitimately a
-          # "feat" from the repo's own point of view, just never the user's).
+          # single line can't blow the tweet's character budget on its own.
           pick_lines() {
-            local type="$1" sha subject files
-            while IFS= read -r sha; do
-              subject=$(git log -1 --format='%s' "$sha")
-              grep -Eqi "^${type}(\([^)]*\))?!?:[[:space:]]+" <<< "$subject" || continue
-
-              files=$(git diff-tree --no-commit-id --name-only -r "$sha")
-              if [ -n "$files" ] && ! grep -qvE '^\.github/' <<< "$files"; then
-                continue
-              fi
-
-              subject=$(sed -E "s/^${type}(\([^)]*\))?!?:[[:space:]]*//I; s/[[:space:].]+\$//" <<< "$subject")
-              [ -z "$subject" ] && continue
-              subject="${subject^}"
-              if [ "${#subject}" -gt 60 ]; then
-                subject="${subject:0:59}…"
-              fi
-              printf '%s\n' "$subject"
-            done < <(git log "$range" --format='%H')
+            local type="$1" subject
+            git log "$range" --format='%s' \
+              | grep -Ei "^${type}(\([^)]*\))?!?:[[:space:]]+" \
+              | sed -E "s/^${type}(\([^)]*\))?!?:[[:space:]]*//I; s/[[:space:].]+\$//" \
+              | while IFS= read -r subject; do
+                  [ -z "$subject" ] && continue
+                  subject="${subject^}"
+                  if [ "${#subject}" -gt 60 ]; then
+                    subject="${subject:0:59}…"
+                  fi
+                  printf '%s\n' "$subject"
+                done
           }
 
           # feat before fix before perf so the most user-visible change leads the post;
@@ -136,10 +126,10 @@ jobs:
           )
           lines=("${all_lines[@]:0:3}")
           if [ "${#lines[@]}" -eq 0 ]; then
-            # Not an error: a release can legitimately be entirely release/CI tooling (as
-            # v2.5.2 was), with nothing a wip CLI user would care about to announce. Leaving
-            # the text output unset skips the post step below rather than failing the job.
-            echo "No feat/fix/perf commits outside .github/ found in $range; skipping the tweet." >> "$GITHUB_STEP_SUMMARY"
+            # Not an error: a release with no feat/fix/perf commits at all has nothing to
+            # announce. Leaving the text output unset skips the post step below rather than
+            # failing the job.
+            echo "No feat/fix/perf commits found in $range; skipping the tweet." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
@@ -280,4 +270,4 @@ jobs:
           env.TWITTER_ACCESS_TOKEN_SECRET != '' &&
           steps.announcement.outputs.text == ''
         run: |
-          echo "No tweet was posted: every feat/fix/perf commit in this release was confined to .github/ (release or CI tooling), with nothing a wip CLI user would notice." >> "$GITHUB_STEP_SUMMARY"
+          echo "No tweet was posted: this release had no feat/fix/perf commits to announce." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/tweet.yml
+++ b/.github/workflows/tweet.yml
@@ -97,20 +97,30 @@ jobs:
 
           # Commit subjects for one Conventional Commit type, newest first, with the
           # prefix stripped, first letter capitalized, and long subjects clipped so a
-          # single line can't blow the tweet's character budget on its own.
+          # single line can't blow the tweet's character budget on its own. A commit whose
+          # changes are confined entirely to .github/ is skipped regardless of type: it's
+          # release or CI tooling, not anything a wip CLI user would notice, and Conventional
+          # Commit type alone can't tell the two apart (a workflow change is legitimately a
+          # "feat" from the repo's own point of view, just never the user's).
           pick_lines() {
-            local type="$1" subject
-            git log "$range" --format='%s' \
-              | grep -Ei "^${type}(\([^)]*\))?!?:[[:space:]]+" \
-              | sed -E "s/^${type}(\([^)]*\))?!?:[[:space:]]*//I; s/[[:space:].]+\$//" \
-              | while IFS= read -r subject; do
-                  [ -z "$subject" ] && continue
-                  subject="${subject^}"
-                  if [ "${#subject}" -gt 60 ]; then
-                    subject="${subject:0:59}…"
-                  fi
-                  printf '%s\n' "$subject"
-                done
+            local type="$1" sha subject files
+            while IFS= read -r sha; do
+              subject=$(git log -1 --format='%s' "$sha")
+              grep -Eqi "^${type}(\([^)]*\))?!?:[[:space:]]+" <<< "$subject" || continue
+
+              files=$(git diff-tree --no-commit-id --name-only -r "$sha")
+              if [ -n "$files" ] && ! grep -qvE '^\.github/' <<< "$files"; then
+                continue
+              fi
+
+              subject=$(sed -E "s/^${type}(\([^)]*\))?!?:[[:space:]]*//I; s/[[:space:].]+\$//" <<< "$subject")
+              [ -z "$subject" ] && continue
+              subject="${subject^}"
+              if [ "${#subject}" -gt 60 ]; then
+                subject="${subject:0:59}…"
+              fi
+              printf '%s\n' "$subject"
+            done < <(git log "$range" --format='%H')
           }
 
           # feat before fix before perf so the most user-visible change leads the post;
@@ -126,8 +136,11 @@ jobs:
           )
           lines=("${all_lines[@]:0:3}")
           if [ "${#lines[@]}" -eq 0 ]; then
-            echo "::error::No feat/fix/perf commits found in $range to announce."
-            exit 1
+            # Not an error: a release can legitimately be entirely release/CI tooling (as
+            # v2.5.2 was), with nothing a wip CLI user would care about to announce. Leaving
+            # the text output unset skips the post step below rather than failing the job.
+            echo "No feat/fix/perf commits outside .github/ found in $range; skipping the tweet." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
           fi
 
           text="${lines[0]}"$'\n\n'"wip ${TAG} released 🚀"
@@ -169,7 +182,8 @@ jobs:
           env.TWITTER_CONSUMER_KEY != '' &&
           env.TWITTER_CONSUMER_SECRET != '' &&
           env.TWITTER_ACCESS_TOKEN != '' &&
-          env.TWITTER_ACCESS_TOKEN_SECRET != ''
+          env.TWITTER_ACCESS_TOKEN_SECRET != '' &&
+          steps.announcement.outputs.text != ''
         env:
           TWEET_TEXT: ${{ steps.announcement.outputs.text }}
         run: |
@@ -257,3 +271,13 @@ jobs:
             echo "   and TWITTER_ACCESS_TOKEN_SECRET on the \`twitter\` environment, so"
             echo "   required reviewers can gate each use."
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Explain a tweet skipped for having nothing to announce
+        if: >-
+          env.TWITTER_CONSUMER_KEY != '' &&
+          env.TWITTER_CONSUMER_SECRET != '' &&
+          env.TWITTER_ACCESS_TOKEN != '' &&
+          env.TWITTER_ACCESS_TOKEN_SECRET != '' &&
+          steps.announcement.outputs.text == ''
+        run: |
+          echo "No tweet was posted: every feat/fix/perf commit in this release was confined to .github/ (release or CI tooling), with nothing a wip CLI user would notice." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary (updated — simplified per follow-up direction)

The v2.5.2 release tweet went out with an internal release-tooling commit subject as its first highlight line ("Publish, submit to WinGet, and tweet only after the Scoop m…"), because every feat/fix/perf commit in that release happened to be this session's own work on release.yml/tweet.yml.

This PR originally added filtering to exclude commits confined entirely to `.github/`. Per follow-up direction, that's more complexity than warranted here — reverted back to the simple type-only matching from #161. The one thing kept from this PR: zero eligible commits is now a quiet skip (step-summary note, no tweet) rather than a hard job failure, since a release can legitimately have nothing to announce.

The specific problem line can't recur regardless of this filtering question: it's already baked into the v2.5.1→v2.5.2 diff that was already posted. Every future release only diffs against v2.5.2 onward, so that exact commit is never in range again — nothing further to filter for it specifically.

## Test plan
- [x] Validated the YAML.
- [x] Confirmed the reverted logic matches #161's original behavior for `v2.5.0..v2.5.1` (still picks 3 real product highlight lines).
- [ ] The already-posted v2.5.2 tweet itself is unaffected by this PR — that's a judgment call for whoever manages the @slidict_oss account, not something to act on unilaterally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1z3dHVziPhCAhKf8ALfjQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Release announcements now consider all matching feature, bug-fix, and performance changes, including changes limited to CI configuration.
  - Releases without eligible change types are skipped with clearer summary messaging.
  - Announcements continue to post only when meaningful announcement text is available.
  - Skip reasons are surfaced in workflow summaries for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->