### PR TITLE
fix(tweet): lead every announcement with the release line, not a picked commit

### DIFF
--- a/.github/workflows/tweet.yml
+++ b/.github/workflows/tweet.yml
@@ -97,30 +97,20 @@ jobs:
 
           # Commit subjects for one Conventional Commit type, newest first, with the
           # prefix stripped, first letter capitalized, and long subjects clipped so a
-          # single line can't blow the tweet's character budget on its own. A commit whose
-          # changes are confined entirely to .github/ is skipped regardless of type: it's
-          # release or CI tooling, not anything a wip CLI user would notice, and Conventional
-          # Commit type alone can't tell the two apart (a workflow change is legitimately a
-          # "feat" from the repo's own point of view, just never the user's).
+          # single line can't blow the tweet's character budget on its own.
           pick_lines() {
-            local type="$1" sha subject files
-            while IFS= read -r sha; do
-              subject=$(git log -1 --format='%s' "$sha")
-              grep -Eqi "^${type}(\([^)]*\))?!?:[[:space:]]+" <<< "$subject" || continue
-
-              files=$(git diff-tree --no-commit-id --name-only -r "$sha")
-              if [ -n "$files" ] && ! grep -qvE '^\.github/' <<< "$files"; then
-                continue
-              fi
-
-              subject=$(sed -E "s/^${type}(\([^)]*\))?!?:[[:space:]]*//I; s/[[:space:].]+\$//" <<< "$subject")
-              [ -z "$subject" ] && continue
-              subject="${subject^}"
-              if [ "${#subject}" -gt 60 ]; then
-                subject="${subject:0:59}…"
-              fi
-              printf '%s\n' "$subject"
-            done < <(git log "$range" --format='%H')
+            local type="$1" subject
+            git log "$range" --format='%s' \
+              | grep -Ei "^${type}(\([^)]*\))?!?:[[:space:]]+" \
+              | sed -E "s/^${type}(\([^)]*\))?!?:[[:space:]]*//I; s/[[:space:].]+\$//" \
+              | while IFS= read -r subject; do
+                  [ -z "$subject" ] && continue
+                  subject="${subject^}"
+                  if [ "${#subject}" -gt 60 ]; then
+                    subject="${subject:0:59}…"
+                  fi
+                  printf '%s\n' "$subject"
+                done
           }
 
           # feat before fix before perf so the most user-visible change leads the post;
@@ -136,10 +126,10 @@ jobs:
           )
           lines=("${all_lines[@]:0:3}")
           if [ "${#lines[@]}" -eq 0 ]; then
-            # Not an error: a release can legitimately be entirely release/CI tooling (as
-            # v2.5.2 was), with nothing a wip CLI user would care about to announce. Leaving
-            # the text output unset skips the post step below rather than failing the job.
-            echo "No feat/fix/perf commits outside .github/ found in $range; skipping the tweet." >> "$GITHUB_STEP_SUMMARY"
+            # Not an error: a release with no feat/fix/perf commits at all has nothing to
+            # announce. Leaving the text output unset skips the post step below rather than
+            # failing the job.
+            echo "No feat/fix/perf commits found in $range; skipping the tweet." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
@@ -280,4 +270,4 @@ jobs:
           env.TWITTER_ACCESS_TOKEN_SECRET != '' &&
           steps.announcement.outputs.text == ''
         run: |
-          echo "No tweet was posted: every feat/fix/perf commit in this release was confined to .github/ (release or CI tooling), with nothing a wip CLI user would notice." >> "$GITHUB_STEP_SUMMARY"
+          echo "No tweet was posted: this release had no feat/fix/perf commits to announce." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/tweet.yml
+++ b/.github/workflows/tweet.yml
@@ -97,20 +97,30 @@ jobs:
 
           # Commit subjects for one Conventional Commit type, newest first, with the
           # prefix stripped, first letter capitalized, and long subjects clipped so a
-          # single line can't blow the tweet's character budget on its own.
+          # single line can't blow the tweet's character budget on its own. A commit whose
+          # changes are confined entirely to .github/ is skipped regardless of type: it's
+          # release or CI tooling, not anything a wip CLI user would notice, and Conventional
+          # Commit type alone can't tell the two apart (a workflow change is legitimately a
+          # "feat" from the repo's own point of view, just never the user's).
           pick_lines() {
-            local type="$1" subject
-            git log "$range" --format='%s' \
-              | grep -Ei "^${type}(\([^)]*\))?!?:[[:space:]]+" \
-              | sed -E "s/^${type}(\([^)]*\))?!?:[[:space:]]*//I; s/[[:space:].]+\$//" \
-              | while IFS= read -r subject; do
-                  [ -z "$subject" ] && continue
-                  subject="${subject^}"
-                  if [ "${#subject}" -gt 60 ]; then
-                    subject="${subject:0:59}…"
-                  fi
-                  printf '%s\n' "$subject"
-                done
+            local type="$1" sha subject files
+            while IFS= read -r sha; do
+              subject=$(git log -1 --format='%s' "$sha")
+              grep -Eqi "^${type}(\([^)]*\))?!?:[[:space:]]+" <<< "$subject" || continue
+
+              files=$(git diff-tree --no-commit-id --name-only -r "$sha")
+              if [ -n "$files" ] && ! grep -qvE '^\.github/' <<< "$files"; then
+                continue
+              fi
+
+              subject=$(sed -E "s/^${type}(\([^)]*\))?!?:[[:space:]]*//I; s/[[:space:].]+\$//" <<< "$subject")
+              [ -z "$subject" ] && continue
+              subject="${subject^}"
+              if [ "${#subject}" -gt 60 ]; then
+                subject="${subject:0:59}…"
+              fi
+              printf '%s\n' "$subject"
+            done < <(git log "$range" --format='%H')
           }
 
           # feat before fix before perf so the most user-visible change leads the post;
@@ -126,8 +136,11 @@ jobs:
           )
           lines=("${all_lines[@]:0:3}")
           if [ "${#lines[@]}" -eq 0 ]; then
-            echo "::error::No feat/fix/perf commits found in $range to announce."
-            exit 1
+            # Not an error: a release can legitimately be entirely release/CI tooling (as
+            # v2.5.2 was), with nothing a wip CLI user would care about to announce. Leaving
+            # the text output unset skips the post step below rather than failing the job.
+            echo "No feat/fix/perf commits outside .github/ found in $range; skipping the tweet." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
           fi
 
           text="${lines[0]}"$'\n\n'"wip ${TAG} released 🚀"
@@ -169,7 +182,8 @@ jobs:
           env.TWITTER_CONSUMER_KEY != '' &&
           env.TWITTER_CONSUMER_SECRET != '' &&
           env.TWITTER_ACCESS_TOKEN != '' &&
-          env.TWITTER_ACCESS_TOKEN_SECRET != ''
+          env.TWITTER_ACCESS_TOKEN_SECRET != '' &&
+          steps.announcement.outputs.text != ''
         env:
           TWEET_TEXT: ${{ steps.announcement.outputs.text }}
         run: |
@@ -257,3 +271,13 @@ jobs:
             echo "   and TWITTER_ACCESS_TOKEN_SECRET on the \`twitter\` environment, so"
             echo "   required reviewers can gate each use."
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Explain a tweet skipped for having nothing to announce
+        if: >-
+          env.TWITTER_CONSUMER_KEY != '' &&
+          env.TWITTER_CONSUMER_SECRET != '' &&
+          env.TWITTER_ACCESS_TOKEN != '' &&
+          env.TWITTER_ACCESS_TOKEN_SECRET != '' &&
+          steps.announcement.outputs.text == ''
+        run: |
+          echo "No tweet was posted: every feat/fix/perf commit in this release was confined to .github/ (release or CI tooling), with nothing a wip CLI user would notice." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/tweet.yml
+++ b/.github/workflows/tweet.yml
@@ -133,9 +133,13 @@ jobs:
             exit 0
           fi
 
-          text="${lines[0]}"$'\n\n'"wip ${TAG} released 🚀"
-          for ((i = 1; i < ${#lines[@]}; i++)); do
-            text+=$'\n'"• ${lines[$i]}"
+          # "wip vX.Y.Z released" leads every line uniformly, rather than singling one out as
+          # a headline above it: that structure was designed for an AI-rewritten opening hook,
+          # but a raw commit subject in that spot reads as broken far more easily than one
+          # more bullet below the actual announcement does.
+          text="wip ${TAG} released 🚀"
+          for line in "${lines[@]}"; do
+            text+=$'\n'"• ${line}"
           done
           text+=$'\n\n'"$release_url"
 


### PR DESCRIPTION
## Summary

The v2.5.2 release tweet ([actually posted](https://github.com/slidict/wip/actions/runs/33970052476)) put a raw commit subject in the tweet's headline slot, above "wip vX.Y.Z released":

```
Publish, submit to WinGet, and tweet only after the Scoop m…

wip v2.5.2 released 🚀
• Paginate the Unreleased draft lookup instead of a fixed lim…
• Fail loudly on multiple Unreleased drafts in check too
```

**Root cause**: the template pulls the first picked commit subject out as a standalone headline *above* the release announcement, a structure that was designed for #161's now-removed AI rewrite step (which used to turn a subject into a punchy, complete opening line). A raw commit subject dropped into that same slot reads as broken far more easily than it would as one more bullet underneath the actual "released" line — this one is both a multi-clause list ("Publish, X, and Y") and clipped mid-word by the 60-character limit ("Scoop m…"). The other two lines are just as much internal-tooling subjects, but read fine as minor bullets below the release line rather than as the thing the tweet leads with.

(An earlier version of this fix tried to filter out commits confined to `.github/` instead, on the theory that the *content* being internal tooling was the problem. That PR was closed — the actual problem is the template's structure, not which commit gets picked.)

## Fix

"wip vX.Y.Z released 🚀" now always leads, with every picked line as a plain, uniform bullet below it. `pick_lines()` itself is unchanged from #161 (plain Conventional Commit type matching, no filtering). Also kept: zero eligible commits skips the tweet quietly instead of failing the job, since a release can legitimately have nothing to announce.

## Test plan
- [x] Validated the YAML.
- [x] Confirmed the new template against `v2.5.0..v2.5.1`'s real commits — correctly leads with the release line, all three highlights as uniform bullets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1z3dHVziPhCAhKf8ALfjQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Releases without eligible feature, fix, or performance changes are now handled as successful no-op announcements instead of generating empty posts.
  - Release announcements now require nonempty content before posting.
  - Announcement formatting consistently begins with the release tag and lists selected changes as bullet points.
  - Skipped announcements now include a clear summary explaining why no post was made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->