### PR TITLE
feat(compose): support native entrypoint

### DIFF
--- a/src/Wip.Core/Compose/ComposeFile.cs
+++ b/src/Wip.Core/Compose/ComposeFile.cs
@@ -18,7 +18,8 @@ public sealed class ComposeFile
 {
     private static readonly string[] ServiceKeys =
     [
-        "image", "build", "command", "environment", "ports", "volumes", "working_dir", "user", "restart",
+        "image", "build", "entrypoint", "command", "environment", "ports", "volumes", "working_dir", "user",
+        "restart",
         "depends_on", "profiles", "healthcheck",
     ];
 
@@ -120,6 +121,11 @@ public sealed class ComposeFile
             var service = services[name];
             var entry = RubyValue.NewMapping();
             entry["image"] = service.Build is not null ? ImageTag(name, service) : service.Image;
+            if (service.Entrypoint is not null)
+            {
+                entry["entrypoint"] = service.Entrypoint;
+            }
+
             entry["command"] = service.Command;
             entry["env"] = service.Environment;
             entry["ports"] = service.Ports.Cast<object?>().ToList();
@@ -169,6 +175,7 @@ public sealed class ComposeFile
         return new Service(
             image,
             build,
+            NormalizeCommand(mapping.GetValueOrDefault("entrypoint")),
             NormalizeCommand(mapping.GetValueOrDefault("command")),
             NormalizeKeyValues(name, mapping.GetValueOrDefault("environment"), "environment"),
             NormalizeList(name, mapping.GetValueOrDefault("ports"), "ports", ListHint),
@@ -476,6 +483,7 @@ public sealed class ComposeFile
     private sealed record Service(
         string? Image,
         OrderedDictionary<string, object?>? Build,
+        string? Entrypoint,
         string? Command,
         OrderedDictionary<string, object?> Environment,
         List<string> Ports,

--- a/src/Wip.Core/Execution/CommandBuilder.cs
+++ b/src/Wip.Core/Execution/CommandBuilder.cs
@@ -50,7 +50,7 @@ public sealed class CommandBuilder
             command.Add("-it");
         }
 
-        command.AddRange(Options(values, includeContainer: true, includePublish: false));
+        command.AddRange(Options(values, includeContainer: true, includePublish: false, includeEntrypoint: false));
         command.AddRange(arguments);
         return command;
     }
@@ -295,6 +295,7 @@ public sealed class CommandBuilder
         OrderedDictionary<string, object?> values,
         bool includeContainer = false,
         bool includePublish = true,
+        bool includeEntrypoint = true,
         bool sync = true)
     {
         var result = new List<string>();
@@ -309,6 +310,12 @@ public sealed class CommandBuilder
         {
             result.Add("-u");
             result.Add(user);
+        }
+
+        if (includeEntrypoint && RubyValue.Presence(values.GetValueOrDefault("entrypoint")) is { } entrypoint)
+        {
+            result.Add("--entrypoint");
+            result.Add(entrypoint);
         }
 
         foreach (var (key, value) in MergedEnvironment(values))

--- a/src/Wip.Core/Execution/CommandBuilder.cs
+++ b/src/Wip.Core/Execution/CommandBuilder.cs
@@ -74,7 +74,7 @@ public sealed class CommandBuilder
 
         command.AddRange(Options(values));
         command.Add(Required(values, "image"));
-        command.AddRange(arguments);
+        command.AddRange(ContainerArguments(values, arguments));
         return command;
     }
 
@@ -100,7 +100,9 @@ public sealed class CommandBuilder
 
         command.AddRange(Options(values));
         command.Add(Required(values, "image"));
-        command.AddRange(Shellwords.Split(RubyValue.ToStringValue(values.GetValueOrDefault("command"))));
+        command.AddRange(ContainerArguments(
+            values,
+            Shellwords.Split(RubyValue.ToStringValue(values.GetValueOrDefault("command")))));
         return command;
     }
 
@@ -221,7 +223,9 @@ public sealed class CommandBuilder
 
         command.AddRange(Options(values, sync: false));
         command.Add(Required(values, "image"));
-        command.AddRange(Shellwords.Split(RubyValue.ToStringValue(values.GetValueOrDefault("command"))));
+        command.AddRange(ContainerArguments(
+            values,
+            Shellwords.Split(RubyValue.ToStringValue(values.GetValueOrDefault("command")))));
         return command;
     }
 
@@ -312,7 +316,7 @@ public sealed class CommandBuilder
             result.Add(user);
         }
 
-        if (includeEntrypoint && RubyValue.Presence(values.GetValueOrDefault("entrypoint")) is { } entrypoint)
+        if (includeEntrypoint && Entrypoint(values).FirstOrDefault() is { } entrypoint)
         {
             result.Add("--entrypoint");
             result.Add(entrypoint);
@@ -346,6 +350,18 @@ public sealed class CommandBuilder
 
         return result;
     }
+
+    /// <summary>
+    /// WSLC's <c>--entrypoint</c> replaces only the executable. Compose exec-form entrypoints
+    /// may also contain arguments, so append everything after the executable in front of the
+    /// service command rather than passing the whole joined value as an executable name.
+    /// </summary>
+    private static IEnumerable<string> ContainerArguments(
+        OrderedDictionary<string, object?> values,
+        IEnumerable<string> arguments) => Entrypoint(values).Skip(1).Concat(arguments);
+
+    private static IReadOnlyList<string> Entrypoint(OrderedDictionary<string, object?> values) =>
+        Shellwords.Split(RubyValue.ToStringValue(values.GetValueOrDefault("entrypoint")));
 
     /// <summary>
     /// With sync configured, a live bind mount of the target (<c>.:/app</c>) is swapped for

--- a/tests/Wip.Tests/ComposeFileEntrypointTests.cs
+++ b/tests/Wip.Tests/ComposeFileEntrypointTests.cs
@@ -35,9 +35,16 @@ public class ComposeFileEntrypointTests
             """, allowAliases: false), Path.Combine(directory.Path, "wip.yml"));
         var builder = new CommandBuilder("wslc.exe", config, new FakeEnvironment());
 
+        var expectedEntrypoint = Shellwords.Split(expected);
+        var expectedCommand = new List<string>
+        {
+            "wslc.exe", "run", "--name", "app", "--network", directory.Name, "-d", "--entrypoint",
+            expectedEntrypoint[0], "myapp:dev",
+        };
+        expectedCommand.AddRange(expectedEntrypoint.Skip(1));
+        expectedCommand.Add("serve");
         Assert.Equal(
-            ["wslc.exe", "run", "--name", "app", "--network", directory.Name, "-d", "--entrypoint", expected,
-                "myapp:dev", "serve"],
+            expectedCommand,
             builder.Up(detach: true));
     }
 

--- a/tests/Wip.Tests/ComposeFileEntrypointTests.cs
+++ b/tests/Wip.Tests/ComposeFileEntrypointTests.cs
@@ -1,0 +1,80 @@
+using Wip.Compose;
+using Wip.Configuration;
+using Wip.Execution;
+using Wip.Platform;
+using Wip.Yaml;
+
+namespace Wip.Tests;
+
+public class ComposeFileEntrypointTests
+{
+    [Theory]
+    [InlineData("entrypoint: /usr/local/bin/start", "/usr/local/bin/start")]
+    [InlineData("entrypoint: [\"/usr/local/bin/start\", \"--verbose\"]", "/usr/local/bin/start --verbose")]
+    public void EntrypointIsNormalizedAndPassedToWslcRun(string entrypointYaml, string expected)
+    {
+        using var directory = new TemporaryDirectory();
+        var composePath = Path.Combine(directory.Path, "compose.yml");
+        File.WriteAllText(composePath, $$"""
+            services:
+              app:
+                image: myapp:dev
+                {{entrypointYaml}}
+                command: serve
+            """);
+
+        var compose = ComposeFile.Load(composePath);
+        var app = (OrderedDictionary<string, object?>)compose.ToDependenciesMapping()["app"]!;
+        Assert.Equal(expected, app["entrypoint"]);
+
+        var config = new Config(YamlLoader.LoadText($$"""
+            mode: compose-native
+            compose:
+              file: {{composePath}}
+              service: app
+            """, allowAliases: false), Path.Combine(directory.Path, "wip.yml"));
+        var builder = new CommandBuilder("wslc.exe", config, new FakeEnvironment());
+
+        Assert.Equal(
+            ["wslc.exe", "run", "--name", "app", "--network", directory.Name, "-d", "--entrypoint", expected,
+                "myapp:dev", "serve"],
+            builder.Up(detach: true));
+    }
+
+    [Fact]
+    public void EntrypointIsNotPassedToExec()
+    {
+        using var directory = new TemporaryDirectory();
+        var composePath = Path.Combine(directory.Path, "compose.yml");
+        File.WriteAllText(composePath, """
+            services:
+              app:
+                image: myapp:dev
+                entrypoint: /usr/local/bin/start
+            """);
+        var config = new Config(YamlLoader.LoadText($$"""
+            mode: compose-native
+            compose:
+              file: {{composePath}}
+              service: app
+            """, allowAliases: false), Path.Combine(directory.Path, "wip.yml"));
+        var builder = new CommandBuilder("wslc.exe", config, new FakeEnvironment());
+
+        Assert.DoesNotContain("--entrypoint", builder.Exec(["sh"]));
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        internal TemporaryDirectory() => Path = Directory.CreateTempSubdirectory("wip-test-").FullName;
+        internal string Path { get; }
+        internal string Name => new DirectoryInfo(Path).Name;
+        public void Dispose() => Directory.Delete(Path, recursive: true);
+    }
+
+    private sealed class FakeEnvironment : IEnvironment
+    {
+        public bool IsInteractive => false;
+        public bool IsWsl2 => true;
+        public string Architecture => "linux/amd64";
+    }
+}


### PR DESCRIPTION
### Motivation

- Support reading Compose `entrypoint` in `mode: compose-native` so the native runner can preserve service entrypoints when starting containers.
- Pass normalized entrypoints to `wslc run` while ensuring `wslc exec` (invoking commands inside a running container) does not receive an entrypoint override.

### Description

- Add `entrypoint` to the Compose service keys and parse/normalize it via the existing `NormalizeCommand` flow into a new `Entrypoint` field on the `Service` record in `ComposeFile`.
- Emit `entrypoint` in `ComposeFile.ToDependenciesMapping()` when present so downstream code sees it in dependency entries.
- Extend `CommandBuilder.Options()` with an `includeEntrypoint` flag and emit `--entrypoint <value>` when enabled, and call `Options(..., includeEntrypoint: false)` from `Exec()` so `wslc exec` does not receive it while `run`/`up` do.
- Add unit tests `tests/Wip.Tests/ComposeFileEntrypointTests.cs` that verify scalar and exec-form entrypoints are normalized, that `wslc run` receives `--entrypoint`, and that `wslc exec` does not.

### Testing

- Attempted to run the test suite with `dotnet test --no-restore`, which failed because `dotnet` is not available in the execution environment. 
- New unit tests were added to cover the feature but were not executed in this environment due to the missing .NET runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9eb030a6b48322a5ad99b4af039422)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compose services support configured entrypoints in scalar and array formats.
  * Entrypoints are normalized and applied when starting services.
  * Entrypoint arguments are forwarded correctly before configured commands.

* **Bug Fixes**
  * Entrypoint options are excluded when executing commands inside running services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->