### PR TITLE
feat(cli): notify when a WinGet update is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,14 +217,16 @@ Alternatively, install it manually: download and extract `wip-<version>-win-x64.
 [Releases](https://github.com/slidict/wip/releases), then add the directory holding `wip.exe`
 to your PATH.
 
-**WinGet is on the way.** The manifest has been submitted as
-[microsoft/winget-pkgs#418285](https://github.com/microsoft/winget-pkgs/pull/418285) and is
-waiting on review — new packages are reviewed by hand, so it takes a few days. Once it merges,
-this is all it takes:
+Or install it from WinGet:
 
 ```powershell
 winget install Slidict.Wip
 ```
+
+At the start of each invocation, wip makes a short, best-effort check against the versions
+published in WinGet. If a newer one is available it prints a highlighted notice and the exact
+`winget upgrade` command. The check is advisory: network errors and timeouts are ignored and never
+change the requested command or its exit code.
 
 From source: `dotnet publish src/Wip.Cli/Wip.Cli.csproj -c Release -r win-x64`. This links
 with **MSVC** (Native AOT), so the .NET SDK alone stops with `Platform linker not found` —

--- a/README.md
+++ b/README.md
@@ -225,8 +225,9 @@ winget install Slidict.Wip
 
 At the start of each invocation, wip checks a locally cached WinGet version and refreshes stale
 data in a detached background process. If a newer version is available it prints a highlighted
-notice and the exact `winget upgrade` command. The check is advisory: it never waits for the
-network, and errors never change the requested command or its exit code.
+notice naming WinGet, Scoop, and manual-install update steps, since wip has no way to tell which
+one you installed with. The check is advisory: it never waits for the network, and errors never
+change the requested command or its exit code.
 
 From source: `dotnet publish src/Wip.Cli/Wip.Cli.csproj -c Release -r win-x64`. This links
 with **MSVC** (Native AOT), so the .NET SDK alone stops with `Platform linker not found` —

--- a/README.md
+++ b/README.md
@@ -223,10 +223,10 @@ Or install it from WinGet:
 winget install Slidict.Wip
 ```
 
-At the start of each invocation, wip makes a short, best-effort check against the versions
-published in WinGet. If a newer one is available it prints a highlighted notice and the exact
-`winget upgrade` command. The check is advisory: network errors and timeouts are ignored and never
-change the requested command or its exit code.
+At the start of each invocation, wip checks a locally cached WinGet version and refreshes stale
+data in a detached background process. If a newer version is available it prints a highlighted
+notice and the exact `winget upgrade` command. The check is advisory: it never waits for the
+network, and errors never change the requested command or its exit code.
 
 From source: `dotnet publish src/Wip.Cli/Wip.Cli.csproj -c Release -r win-x64`. This links
 with **MSVC** (Native AOT), so the .NET SDK alone stops with `Platform linker not found` —

--- a/src/Wip.Cli/Program.cs
+++ b/src/Wip.Cli/Program.cs
@@ -9,6 +9,10 @@ internal static class Program
 {
     internal static int Main(string[] args)
     {
+        // This is advisory and deliberately runs before parsing or executing the requested
+        // command. UpdateNotifier contains all failure handling so it cannot affect behavior.
+        UpdateNotifier.NotifyIfAvailable();
+
         var root = BuildRoot();
 
         // System.CommandLine installs its own top-level handler that prints a raw stack

--- a/src/Wip.Cli/Program.cs
+++ b/src/Wip.Cli/Program.cs
@@ -9,7 +9,7 @@ internal static class Program
 {
     internal static int Main(string[] args)
     {
-        if (args is [UpdateNotifier.RefreshArgument])
+        if (UpdateNotifier.IsRefreshHelperInvocation)
         {
             UpdateNotifier.RefreshCache();
             return 0;

--- a/src/Wip.Cli/Program.cs
+++ b/src/Wip.Cli/Program.cs
@@ -9,8 +9,14 @@ internal static class Program
 {
     internal static int Main(string[] args)
     {
-        // This is advisory and deliberately runs before parsing or executing the requested
-        // command. UpdateNotifier contains all failure handling so it cannot affect behavior.
+        if (args is [UpdateNotifier.RefreshArgument])
+        {
+            UpdateNotifier.RefreshCache();
+            return 0;
+        }
+
+        // Reading the cache and starting a detached refresh perform no network I/O here, so
+        // update discovery cannot hold up the command the user actually requested.
         UpdateNotifier.NotifyIfAvailable();
 
         var root = BuildRoot();

--- a/src/Wip.Core/Diagnostics/Log.cs
+++ b/src/Wip.Core/Diagnostics/Log.cs
@@ -28,6 +28,7 @@ public static class Log
     private const string TagAccent = "\x1b[36m";
     private const string WarnAccent = "\x1b[33m";
     private const string ErrorAccent = "\x1b[31m";
+    private const string UpdateAccent = "\x1b[1;35m";
     private const string Reset = "\x1b[0m";
 
     /// <summary>Writes "wip: message" to stderr, tinting the tag when the terminal supports it.</summary>
@@ -42,6 +43,26 @@ public static class Log
     /// already failed.</summary>
     public static void Error(string message) => Console.Error.WriteLine(
         FormatError(message, IsColorEnabled(), DisplayLanguage.CurrentPrimaryLanguageId()));
+
+    /// <summary>Writes a deliberately prominent, non-fatal update recommendation.</summary>
+    internal static void UpdateAvailable(string current, string latest)
+    {
+        var colorize = IsColorEnabled();
+        Console.Error.WriteLine(FormatUpdateAvailable(current, latest, colorize));
+    }
+
+    internal static string FormatUpdateAvailable(string current, string latest, bool colorize)
+    {
+        var heading = "*** WIP UPDATE AVAILABLE ***";
+        var command = "winget upgrade --id Slidict.Wip --exact";
+        if (colorize)
+        {
+            heading = $"{UpdateAccent}{heading}{Reset}";
+            command = $"{UpdateAccent}{command}{Reset}";
+        }
+
+        return $"\n{heading}\n  {current} -> {latest}\n  Run: {command}\n";
+    }
 
     /// <summary>Pure formatting, kept apart from <see cref="IsColorEnabled"/> so the tag's shape
     /// is testable without a real console or environment variables.</summary>

--- a/src/Wip.Core/Diagnostics/Log.cs
+++ b/src/Wip.Core/Diagnostics/Log.cs
@@ -54,14 +54,15 @@ public static class Log
     internal static string FormatUpdateAvailable(string current, string latest, bool colorize)
     {
         var heading = "*** WIP UPDATE AVAILABLE ***";
-        var command = "winget upgrade --id Slidict.Wip --exact";
+        var guidance = "Update with WinGet (winget upgrade --id Slidict.Wip --exact), "
+            + "Scoop (scoop update wip), or your manual install's usual steps.";
         if (colorize)
         {
             heading = $"{UpdateAccent}{heading}{Reset}";
-            command = $"{UpdateAccent}{command}{Reset}";
+            guidance = $"{UpdateAccent}{guidance}{Reset}";
         }
 
-        return $"\n{heading}\n  {current} -> {latest}\n  Run: {command}\n";
+        return $"\n{heading}\n  {current} -> {latest}\n  {guidance}\n";
     }
 
     /// <summary>Pure formatting, kept apart from <see cref="IsColorEnabled"/> so the tag's shape

--- a/src/Wip.Core/Diagnostics/UpdateNotifier.cs
+++ b/src/Wip.Core/Diagnostics/UpdateNotifier.cs
@@ -1,32 +1,59 @@
+using System.Diagnostics;
 using System.Net.Http.Headers;
 using System.Text.Json;
 
 namespace Wip.Diagnostics;
 
-/// <summary>Checks the public WinGet manifest index and advertises an available update.</summary>
+/// <summary>Advertises WinGet updates without putting network I/O on a command's hot path.</summary>
 public static class UpdateNotifier
 {
+    public const string RefreshArgument = "__refresh-winget-version";
     internal const string ManifestUrl =
         "https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/s/Slidict/Wip";
+    private static readonly TimeSpan RefreshInterval = TimeSpan.FromHours(24);
 
-    /// <summary>
-    /// Best-effort by design: an unavailable network, a changed response, or a timeout must
-    /// never stop (or change the exit code of) the command the user actually asked wip to run.
-    /// </summary>
+    /// <summary>Reads the last result immediately, then refreshes stale data out of process.</summary>
     public static void NotifyIfAvailable()
+    {
+        try
+        {
+            var cached = ReadCache();
+            if (cached.Latest is not null && IsNewer(cached.Latest, WipVersion.Current))
+            {
+                Log.UpdateAvailable(WipVersion.Current, cached.Latest);
+            }
+
+            if (DateTimeOffset.UtcNow - cached.CheckedAt >= RefreshInterval)
+            {
+                StartRefreshProcess();
+            }
+        }
+        catch (Exception)
+        {
+            // Update discovery is advisory; even local cache/process failures are ignored.
+        }
+    }
+
+    /// <summary>Executed only by the hidden detached helper process.</summary>
+    public static void RefreshCache()
     {
         try
         {
             using var client = CreateClient();
             var latest = FindLatestVersion(client.GetStringAsync(ManifestUrl).GetAwaiter().GetResult());
-            if (latest is not null && IsNewer(latest, WipVersion.Current))
-            {
-                Log.UpdateAvailable(WipVersion.Current, latest);
-            }
+            WriteCache(latest);
         }
         catch (Exception)
         {
-            // Update discovery is advisory. In particular, offline use remains fully usable.
+            // Record the attempt to avoid slowing every invocation when the machine is offline.
+            try
+            {
+                WriteCache(ReadCache().Latest);
+            }
+            catch (Exception)
+            {
+                // The cache itself may be unavailable; there is nothing advisory code can do.
+            }
         }
     }
 
@@ -42,10 +69,8 @@ public static class UpdateNotifier
         string? latestText = null;
         foreach (var item in document.RootElement.EnumerateArray())
         {
-            if (!item.TryGetProperty("name", out var nameProperty) ||
-                nameProperty.GetString() is not { } name ||
-                !TryParseVersion(name, out var version) ||
-                latest is not null && version <= latest)
+            if (!item.TryGetProperty("name", out var property) || property.GetString() is not { } name ||
+                !TryParseVersion(name, out var version) || latest is not null && version <= latest)
             {
                 continue;
             }
@@ -53,14 +78,12 @@ public static class UpdateNotifier
             latest = version;
             latestText = name;
         }
-
         return latestText;
     }
 
     internal static bool IsNewer(string candidate, string current) =>
         TryParseVersion(candidate, out var candidateVersion) &&
-        TryParseVersion(current, out var currentVersion) &&
-        candidateVersion > currentVersion;
+        TryParseVersion(current, out var currentVersion) && candidateVersion > currentVersion;
 
     private static bool TryParseVersion(string value, out Version version)
     {
@@ -74,9 +97,54 @@ public static class UpdateNotifier
         return Version.TryParse(normalized, out version!);
     }
 
+    private static (DateTimeOffset CheckedAt, string? Latest) ReadCache()
+    {
+        var path = CachePath();
+        if (!File.Exists(path))
+        {
+            return (DateTimeOffset.MinValue, null);
+        }
+
+        using var document = JsonDocument.Parse(File.ReadAllText(path));
+        var root = document.RootElement;
+        return (root.GetProperty("checkedAt").GetDateTimeOffset(), root.GetProperty("latest").GetString());
+    }
+
+    private static void WriteCache(string? latest)
+    {
+        var path = CachePath();
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        var temporary = $"{path}.{Environment.ProcessId}.tmp";
+        using (var stream = File.Create(temporary))
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("checkedAt", DateTimeOffset.UtcNow);
+            writer.WriteString("latest", latest);
+            writer.WriteEndObject();
+        }
+
+        File.Move(temporary, path, overwrite: true);
+    }
+
+    private static string CachePath() => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "wip", "update.json");
+
+    private static void StartRefreshProcess()
+    {
+        if (Environment.ProcessPath is not { } executable)
+        {
+            return;
+        }
+
+        var start = new ProcessStartInfo(executable) { UseShellExecute = false, CreateNoWindow = true };
+        start.ArgumentList.Add(RefreshArgument);
+        Process.Start(start)?.Dispose();
+    }
+
     private static HttpClient CreateClient()
     {
-        var client = new HttpClient { Timeout = TimeSpan.FromSeconds(1) };
+        var client = new HttpClient { Timeout = TimeSpan.FromSeconds(3) };
         client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("wip", WipVersion.Current));
         client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
         return client;

--- a/src/Wip.Core/Diagnostics/UpdateNotifier.cs
+++ b/src/Wip.Core/Diagnostics/UpdateNotifier.cs
@@ -1,0 +1,84 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+namespace Wip.Diagnostics;
+
+/// <summary>Checks the public WinGet manifest index and advertises an available update.</summary>
+public static class UpdateNotifier
+{
+    internal const string ManifestUrl =
+        "https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/s/Slidict/Wip";
+
+    /// <summary>
+    /// Best-effort by design: an unavailable network, a changed response, or a timeout must
+    /// never stop (or change the exit code of) the command the user actually asked wip to run.
+    /// </summary>
+    public static void NotifyIfAvailable()
+    {
+        try
+        {
+            using var client = CreateClient();
+            var latest = FindLatestVersion(client.GetStringAsync(ManifestUrl).GetAwaiter().GetResult());
+            if (latest is not null && IsNewer(latest, WipVersion.Current))
+            {
+                Log.UpdateAvailable(WipVersion.Current, latest);
+            }
+        }
+        catch (Exception)
+        {
+            // Update discovery is advisory. In particular, offline use remains fully usable.
+        }
+    }
+
+    internal static string? FindLatestVersion(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        if (document.RootElement.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        Version? latest = null;
+        string? latestText = null;
+        foreach (var item in document.RootElement.EnumerateArray())
+        {
+            if (!item.TryGetProperty("name", out var nameProperty) ||
+                nameProperty.GetString() is not { } name ||
+                !TryParseVersion(name, out var version) ||
+                latest is not null && version <= latest)
+            {
+                continue;
+            }
+
+            latest = version;
+            latestText = name;
+        }
+
+        return latestText;
+    }
+
+    internal static bool IsNewer(string candidate, string current) =>
+        TryParseVersion(candidate, out var candidateVersion) &&
+        TryParseVersion(current, out var currentVersion) &&
+        candidateVersion > currentVersion;
+
+    private static bool TryParseVersion(string value, out Version version)
+    {
+        var normalized = value.TrimStart('v', 'V');
+        var suffix = normalized.IndexOfAny(['-', '+']);
+        if (suffix >= 0)
+        {
+            normalized = normalized[..suffix];
+        }
+
+        return Version.TryParse(normalized, out version!);
+    }
+
+    private static HttpClient CreateClient()
+    {
+        var client = new HttpClient { Timeout = TimeSpan.FromSeconds(1) };
+        client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("wip", WipVersion.Current));
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+        return client;
+    }
+}

--- a/src/Wip.Core/Diagnostics/UpdateNotifier.cs
+++ b/src/Wip.Core/Diagnostics/UpdateNotifier.cs
@@ -7,17 +7,31 @@ namespace Wip.Diagnostics;
 /// <summary>Advertises WinGet updates without putting network I/O on a command's hot path.</summary>
 public static class UpdateNotifier
 {
-    public const string RefreshArgument = "__refresh-winget-version";
+    private const string RefreshHelperEnvironmentVariable = "WIP_UPDATE_REFRESH_HELPER";
     internal const string ManifestUrl =
-        "https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/s/Slidict/Wip";
+        "https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/s/Slidict/Wip?per_page=100";
     private static readonly TimeSpan RefreshInterval = TimeSpan.FromHours(24);
+
+    // Generous relative to the 3-second HTTP timeout below: if the helper crashed or was killed
+    // before it could delete its lease, a later invocation reclaims it instead of update checks
+    // going silent forever.
+    private static readonly TimeSpan RefreshLeaseTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// True when this process was launched by <see cref="StartRefreshProcess"/> to run
+    /// <see cref="RefreshCache()"/> and exit, rather than a normal wip invocation. Gated by an
+    /// environment variable set only on that child process, not by argv, so an ordinary command
+    /// the user happens to type can never be mistaken for the helper.
+    /// </summary>
+    public static bool IsRefreshHelperInvocation =>
+        Environment.GetEnvironmentVariable(RefreshHelperEnvironmentVariable) == "1";
 
     /// <summary>Reads the last result immediately, then refreshes stale data out of process.</summary>
     public static void NotifyIfAvailable()
     {
         try
         {
-            var cached = ReadCache();
+            var cached = ReadCache(CachePath());
             if (cached.Latest is not null && IsNewer(cached.Latest, WipVersion.Current))
             {
                 Log.UpdateAvailable(WipVersion.Current, cached.Latest);
@@ -35,25 +49,31 @@ public static class UpdateNotifier
     }
 
     /// <summary>Executed only by the hidden detached helper process.</summary>
-    public static void RefreshCache()
+    public static void RefreshCache() => RefreshCache(handler: null, CachePath());
+
+    internal static void RefreshCache(HttpMessageHandler? handler, string cachePath)
     {
         try
         {
-            using var client = CreateClient();
+            using var client = CreateClient(handler);
             var latest = FindLatestVersion(client.GetStringAsync(ManifestUrl).GetAwaiter().GetResult());
-            WriteCache(latest);
+            WriteCache(latest, cachePath);
         }
         catch (Exception)
         {
             // Record the attempt to avoid slowing every invocation when the machine is offline.
             try
             {
-                WriteCache(ReadCache().Latest);
+                WriteCache(ReadCache(cachePath).Latest, cachePath);
             }
             catch (Exception)
             {
                 // The cache itself may be unavailable; there is nothing advisory code can do.
             }
+        }
+        finally
+        {
+            TryDelete(LockPath(cachePath));
         }
     }
 
@@ -69,8 +89,12 @@ public static class UpdateNotifier
         string? latestText = null;
         foreach (var item in document.RootElement.EnumerateArray())
         {
-            if (!item.TryGetProperty("name", out var property) || property.GetString() is not { } name ||
-                !TryParseVersion(name, out var version) || latest is not null && version <= latest)
+            if (!item.TryGetProperty("type", out var typeProperty) ||
+                typeProperty.GetString() != "dir" ||
+                !item.TryGetProperty("name", out var nameProperty) ||
+                nameProperty.GetString() is not { } name ||
+                !TryParseVersion(name, out var version, out _) ||
+                latest is not null && version <= latest)
             {
                 continue;
             }
@@ -81,40 +105,114 @@ public static class UpdateNotifier
         return latestText;
     }
 
-    internal static bool IsNewer(string candidate, string current) =>
-        TryParseVersion(candidate, out var candidateVersion) &&
-        TryParseVersion(current, out var currentVersion) && candidateVersion > currentVersion;
+    internal static bool IsNewer(string candidate, string current)
+    {
+        if (!TryParseVersion(candidate, out var candidateVersion, out var candidatePrerelease) ||
+            !TryParseVersion(current, out var currentVersion, out var currentPrerelease))
+        {
+            return false;
+        }
 
-    private static bool TryParseVersion(string value, out Version version)
+        return candidateVersion != currentVersion
+            ? candidateVersion > currentVersion
+            : ComparePrerelease(candidatePrerelease, currentPrerelease) > 0;
+    }
+
+    /// <summary>
+    /// Follows SemVer 2.0's precedence rules (spec item 11): a release with no prerelease tag
+    /// always outranks a prerelease of the same numeric version; two prereleases compare their
+    /// dot-separated identifiers left to right, where a numeric identifier always ranks below an
+    /// alphanumeric one, and running out of identifiers first ranks lower.
+    /// </summary>
+    private static int ComparePrerelease(string? candidate, string? current)
+    {
+        if (candidate == current)
+        {
+            return 0;
+        }
+
+        if (candidate is null || current is null)
+        {
+            return candidate is null ? 1 : -1;
+        }
+
+        var candidateIds = candidate.Split('.');
+        var currentIds = current.Split('.');
+        var sharedLength = Math.Min(candidateIds.Length, currentIds.Length);
+        for (var i = 0; i < sharedLength; i++)
+        {
+            var comparison = CompareIdentifier(candidateIds[i], currentIds[i]);
+            if (comparison != 0)
+            {
+                return comparison;
+            }
+        }
+
+        return candidateIds.Length.CompareTo(currentIds.Length);
+    }
+
+    private static int CompareIdentifier(string candidate, string current)
+    {
+        var candidateIsNumeric = candidate.Length > 0 && candidate.All(char.IsAsciiDigit);
+        var currentIsNumeric = current.Length > 0 && current.All(char.IsAsciiDigit);
+        if (candidateIsNumeric && currentIsNumeric)
+        {
+            return long.Parse(candidate).CompareTo(long.Parse(current));
+        }
+
+        return candidateIsNumeric != currentIsNumeric
+            ? candidateIsNumeric ? -1 : 1
+            : string.CompareOrdinal(candidate, current);
+    }
+
+    private static bool TryParseVersion(string value, out Version version, out string? prerelease)
     {
         var normalized = value.TrimStart('v', 'V');
-        var suffix = normalized.IndexOfAny(['-', '+']);
-        if (suffix >= 0)
+        var buildSuffix = normalized.IndexOf('+');
+        if (buildSuffix >= 0)
         {
-            normalized = normalized[..suffix];
+            normalized = normalized[..buildSuffix];
+        }
+
+        var prereleaseSuffix = normalized.IndexOf('-');
+        if (prereleaseSuffix >= 0)
+        {
+            prerelease = normalized[(prereleaseSuffix + 1)..];
+            normalized = normalized[..prereleaseSuffix];
+        }
+        else
+        {
+            prerelease = null;
         }
 
         return Version.TryParse(normalized, out version!);
     }
 
-    private static (DateTimeOffset CheckedAt, string? Latest) ReadCache()
+    internal static (DateTimeOffset CheckedAt, string? Latest) ReadCache(string cachePath)
     {
-        var path = CachePath();
-        if (!File.Exists(path))
+        if (!File.Exists(cachePath))
         {
             return (DateTimeOffset.MinValue, null);
         }
 
-        using var document = JsonDocument.Parse(File.ReadAllText(path));
-        var root = document.RootElement;
-        return (root.GetProperty("checkedAt").GetDateTimeOffset(), root.GetProperty("latest").GetString());
+        try
+        {
+            using var document = JsonDocument.Parse(File.ReadAllText(cachePath));
+            var root = document.RootElement;
+            return (root.GetProperty("checkedAt").GetDateTimeOffset(), root.GetProperty("latest").GetString());
+        }
+        catch (Exception)
+        {
+            // A truncated or hand-edited cache file must not permanently disable update checks;
+            // treat it the same as a missing one so the next refresh recreates it.
+            return (DateTimeOffset.MinValue, null);
+        }
     }
 
-    private static void WriteCache(string? latest)
+    internal static void WriteCache(string? latest, string cachePath)
     {
-        var path = CachePath();
-        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-        var temporary = $"{path}.{Environment.ProcessId}.tmp";
+        Directory.CreateDirectory(Path.GetDirectoryName(cachePath)!);
+        var temporary = $"{cachePath}.{Environment.ProcessId}.tmp";
         using (var stream = File.Create(temporary))
         using (var writer = new Utf8JsonWriter(stream))
         {
@@ -124,11 +222,13 @@ public static class UpdateNotifier
             writer.WriteEndObject();
         }
 
-        File.Move(temporary, path, overwrite: true);
+        File.Move(temporary, cachePath, overwrite: true);
     }
 
     private static string CachePath() => Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "wip", "update.json");
+
+    private static string LockPath(string cachePath) => $"{cachePath}.lock";
 
     private static void StartRefreshProcess()
     {
@@ -137,14 +237,95 @@ public static class UpdateNotifier
             return;
         }
 
+        var lockPath = TryAcquireRefreshLease(LockPath(CachePath()));
+        if (lockPath is null)
+        {
+            return;
+        }
+
         var start = new ProcessStartInfo(executable) { UseShellExecute = false, CreateNoWindow = true };
-        start.ArgumentList.Add(RefreshArgument);
-        Process.Start(start)?.Dispose();
+
+        // Under `dotnet run`/`dotnet path/to/wip.dll`, ProcessPath is the dotnet host itself, not
+        // wip: without the assembly path dotnet has nothing to execute and the helper never
+        // refreshes the cache. args[0] is the managed entry point dotnet was given, which is
+        // exactly that path (and reading it, unlike Assembly.Location, is safe under AOT/single
+        // file too).
+        if (Path.GetFileNameWithoutExtension(executable).Equals("dotnet", StringComparison.OrdinalIgnoreCase) &&
+            Environment.GetCommandLineArgs() is [{ Length: > 0 } assemblyPath, ..])
+        {
+            start.ArgumentList.Add(assemblyPath);
+        }
+
+        start.EnvironmentVariables[RefreshHelperEnvironmentVariable] = "1";
+        try
+        {
+            Process.Start(start)?.Dispose();
+        }
+        catch (Exception)
+        {
+            TryDelete(lockPath);
+        }
     }
 
-    private static HttpClient CreateClient()
+    /// <summary>
+    /// Atomically claims the right to refresh, so concurrent wip invocations against the same
+    /// stale cache don't each spawn a helper and burn through GitHub's unauthenticated rate
+    /// limit. Returns the lease path on success, so it can be released if the helper never
+    /// starts.
+    /// </summary>
+    private static string? TryAcquireRefreshLease(string lockPath)
     {
-        var client = new HttpClient { Timeout = TimeSpan.FromSeconds(3) };
+        Directory.CreateDirectory(Path.GetDirectoryName(lockPath)!);
+        if (TryCreateLease(lockPath))
+        {
+            return lockPath;
+        }
+
+        try
+        {
+            if (DateTime.UtcNow - File.GetLastWriteTimeUtc(lockPath) <= RefreshLeaseTimeout)
+            {
+                return null;
+            }
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+
+        TryDelete(lockPath);
+        return TryCreateLease(lockPath) ? lockPath : null;
+    }
+
+    private static bool TryCreateLease(string lockPath)
+    {
+        try
+        {
+            using var stream = new FileStream(lockPath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+            return true;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (Exception)
+        {
+            // Best-effort cleanup; a leftover lease simply expires after RefreshLeaseTimeout.
+        }
+    }
+
+    private static HttpClient CreateClient(HttpMessageHandler? handler)
+    {
+        var client = handler is null ? new HttpClient() : new HttpClient(handler, disposeHandler: false);
+        client.Timeout = TimeSpan.FromSeconds(3);
         client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("wip", WipVersion.Current));
         client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
         return client;

--- a/tests/Wip.Tests/UpdateNotifierTests.cs
+++ b/tests/Wip.Tests/UpdateNotifierTests.cs
@@ -1,0 +1,52 @@
+using Wip.Diagnostics;
+
+namespace Wip.Tests;
+
+public class UpdateNotifierTests
+{
+    [Fact]
+    public void FindsHighestVersionInWinGetDirectoryListing()
+    {
+        const string response = """
+            [
+              { "name": "2.4.9", "type": "dir" },
+              { "name": "not-a-version", "type": "file" },
+              { "name": "2.10.0", "type": "dir" },
+              { "name": "2.5.2", "type": "dir" }
+            ]
+            """;
+
+        Assert.Equal("2.10.0", UpdateNotifier.FindLatestVersion(response));
+    }
+
+    [Theory]
+    [InlineData("2.5.3", "2.5.2", true)]
+    [InlineData("2.5.2", "2.5.2", false)]
+    [InlineData("2.5.1", "2.5.2", false)]
+    [InlineData("v3.0.0", "2.5.2+build", true)]
+    [InlineData("invalid", "2.5.2", false)]
+    public void ComparesVersions(string candidate, string current, bool expected)
+    {
+        Assert.Equal(expected, UpdateNotifier.IsNewer(candidate, current));
+    }
+
+    [Fact]
+    public void FormatsProminentPlainUpdateNotice()
+    {
+        var actual = Log.FormatUpdateAvailable("2.5.2", "2.6.0", colorize: false);
+
+        Assert.Contains("*** WIP UPDATE AVAILABLE ***", actual);
+        Assert.Contains("2.5.2 -> 2.6.0", actual);
+        Assert.Contains("winget upgrade --id Slidict.Wip --exact", actual);
+        Assert.DoesNotContain('\x1b', actual);
+    }
+
+    [Fact]
+    public void HighlightsUpdateHeadingAndCommandWhenColorEnabled()
+    {
+        var actual = Log.FormatUpdateAvailable("2.5.2", "2.6.0", colorize: true);
+
+        Assert.Contains("\x1b[1;35m*** WIP UPDATE AVAILABLE ***\x1b[0m", actual);
+        Assert.Contains("\x1b[1;35mwinget upgrade --id Slidict.Wip --exact\x1b[0m", actual);
+    }
+}

--- a/tests/Wip.Tests/UpdateNotifierTests.cs
+++ b/tests/Wip.Tests/UpdateNotifierTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Wip.Diagnostics;
 
 namespace Wip.Tests;
@@ -19,12 +20,31 @@ public class UpdateNotifierTests
         Assert.Equal("2.10.0", UpdateNotifier.FindLatestVersion(response));
     }
 
+    [Fact]
+    public void IgnoresNonDirectoryEntriesEvenWithAHigherVersionName()
+    {
+        const string response = """
+            [
+              { "name": "2.5.2", "type": "dir" },
+              { "name": "9.9.9", "type": "file" }
+            ]
+            """;
+
+        Assert.Equal("2.5.2", UpdateNotifier.FindLatestVersion(response));
+    }
+
     [Theory]
     [InlineData("2.5.3", "2.5.2", true)]
     [InlineData("2.5.2", "2.5.2", false)]
     [InlineData("2.5.1", "2.5.2", false)]
     [InlineData("v3.0.0", "2.5.2+build", true)]
     [InlineData("invalid", "2.5.2", false)]
+    [InlineData("2.5.2", "2.5.2-rc.1", true)]
+    [InlineData("2.5.2-rc.1", "2.5.2", false)]
+    [InlineData("2.5.2-rc.2", "2.5.2-rc.1", true)]
+    [InlineData("2.5.2-rc.1", "2.5.2-rc.2", false)]
+    [InlineData("2.5.2-beta", "2.5.2-alpha", true)]
+    [InlineData("2.5.2-rc.1", "2.5.2-rc.1.1", false)]
     public void ComparesVersions(string candidate, string current, bool expected)
     {
         Assert.Equal(expected, UpdateNotifier.IsNewer(candidate, current));
@@ -38,6 +58,7 @@ public class UpdateNotifierTests
         Assert.Contains("*** WIP UPDATE AVAILABLE ***", actual);
         Assert.Contains("2.5.2 -> 2.6.0", actual);
         Assert.Contains("winget upgrade --id Slidict.Wip --exact", actual);
+        Assert.Contains("scoop update wip", actual);
         Assert.DoesNotContain('\x1b', actual);
     }
 
@@ -47,6 +68,155 @@ public class UpdateNotifierTests
         var actual = Log.FormatUpdateAvailable("2.5.2", "2.6.0", colorize: true);
 
         Assert.Contains("\x1b[1;35m*** WIP UPDATE AVAILABLE ***\x1b[0m", actual);
-        Assert.Contains("\x1b[1;35mwinget upgrade --id Slidict.Wip --exact\x1b[0m", actual);
+        Assert.Contains("\x1b[1;35m", actual);
+    }
+
+    [Fact]
+    public void ReadCacheTreatsAMissingFileAsNeverChecked()
+    {
+        var path = TempCachePath();
+
+        var (checkedAt, latest) = UpdateNotifier.ReadCache(path);
+
+        Assert.Equal(DateTimeOffset.MinValue, checkedAt);
+        Assert.Null(latest);
+    }
+
+    [Fact]
+    public void WriteThenReadCacheRoundTrips()
+    {
+        var path = TempCachePath();
+        try
+        {
+            UpdateNotifier.WriteCache("2.6.0", path);
+
+            var (checkedAt, latest) = UpdateNotifier.ReadCache(path);
+
+            Assert.Equal("2.6.0", latest);
+            Assert.True(DateTimeOffset.UtcNow - checkedAt < TimeSpan.FromMinutes(1));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void ReadCacheTreatsCorruptedJsonAsNeverChecked()
+    {
+        var path = TempCachePath();
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, "{ not valid json");
+
+            var (checkedAt, latest) = UpdateNotifier.ReadCache(path);
+
+            Assert.Equal(DateTimeOffset.MinValue, checkedAt);
+            Assert.Null(latest);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void ReadCacheTreatsAMissingPropertyAsNeverChecked()
+    {
+        var path = TempCachePath();
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, """{ "latest": "2.6.0" }""");
+
+            var (checkedAt, latest) = UpdateNotifier.ReadCache(path);
+
+            Assert.Equal(DateTimeOffset.MinValue, checkedAt);
+            Assert.Null(latest);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void RefreshCacheWritesTheLatestVersionOnSuccess()
+    {
+        var path = TempCachePath();
+        try
+        {
+            const string response = """
+                [
+                  { "name": "2.5.2", "type": "dir" },
+                  { "name": "2.9.0", "type": "dir" }
+                ]
+                """;
+            var handler = new StubHandler(() => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(response),
+            });
+
+            UpdateNotifier.RefreshCache(handler, path);
+
+            var (_, latest) = UpdateNotifier.ReadCache(path);
+            Assert.Equal("2.9.0", latest);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void RefreshCachePreservesThePreviousResultWhenTheRequestFails()
+    {
+        var path = TempCachePath();
+        try
+        {
+            UpdateNotifier.WriteCache("2.5.2", path);
+            var handler = new StubHandler(() => throw new HttpRequestException("offline"));
+
+            UpdateNotifier.RefreshCache(handler, path);
+
+            var (checkedAt, latest) = UpdateNotifier.ReadCache(path);
+            Assert.Equal("2.5.2", latest);
+            Assert.True(DateTimeOffset.UtcNow - checkedAt < TimeSpan.FromMinutes(1));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void RefreshCacheReleasesItsLeaseEvenWhenTheRequestFails()
+    {
+        var path = TempCachePath();
+        var lockPath = $"{path}.lock";
+        try
+        {
+            var handler = new StubHandler(() => throw new HttpRequestException("offline"));
+
+            UpdateNotifier.RefreshCache(handler, path);
+
+            Assert.False(File.Exists(lockPath));
+        }
+        finally
+        {
+            File.Delete(path);
+            File.Delete(lockPath);
+        }
+    }
+
+    private static string TempCachePath() =>
+        Path.Combine(Path.GetTempPath(), "wip-tests", $"update-{Guid.NewGuid():N}.json");
+
+    private sealed class StubHandler(Func<HttpResponseMessage> responseFactory) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(responseFactory());
     }
 }


### PR DESCRIPTION
### Motivation

- wip is published to WinGet and should gently inform users when a newer WinGet-published version exists immediately after `wip` is invoked without affecting the requested command or its exit code.  
- The notice must be prominent (visually highlighted when possible) but strictly advisory so offline use and CI are unaffected.

### Description

- Add `UpdateNotifier` (`src/Wip.Core/Diagnostics/UpdateNotifier.cs`) which does a best-effort query of the GitHub contents API for the WinGet manifest directory and finds the highest version entry.  
- Call `UpdateNotifier.NotifyIfAvailable()` at the start of `Program.Main` so the advisory check runs before parsing/executing the requested command and cannot change command behavior.  
- Extend `Log` (`src/Wip.Core/Diagnostics/Log.cs`) with `UpdateAvailable` and `FormatUpdateAvailable` to print a prominent magenta banner and the exact `winget upgrade --id Slidict.Wip --exact` command, falling back to plain text when color is not available.  
- Update README to document WinGet installation and the non-invasive update-notification behavior, and add unit tests (`tests/Wip.Tests/UpdateNotifierTests.cs`) for manifest parsing, version comparison, and plain/colored formatting.

### Testing

- Ran `git diff --check` and repository checks (no diff-check failures).  
- Added unit tests in `tests/Wip.Tests/UpdateNotifierTests.cs`, but `dotnet test wip.slnx --no-restore` could not be executed here because the .NET SDK is not installed in this environment.  
- Attempted a live GitHub contents API smoke check with `curl`, but the shared environment returned HTTP 403 so remote verification could not be completed; the notifier is defensive and ignores network/timeouts so this does not affect correctness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa36eca51f08322b3159576ca5d408d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The CLI checks cached update data at startup without delaying command execution.
  - Update notices show the current and latest versions with guidance for WinGet, Scoop, or manual installation.
  - Update checks support preview versions and improved terminal formatting.
  - A dedicated refresh operation updates the local cache and exits successfully.

- **Documentation**
  - Installation instructions now include WinGet installation through `Slidict.Wip`.

- **Bug Fixes**
  - Network, malformed cache, and update-check failures no longer interrupt command execution or change its exit status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->