### PR TITLE
fix(cli): close refresh-lock race and prerelease overflow in update notifier

### DIFF
--- a/src/Wip.Core/Diagnostics/UpdateNotifier.cs
+++ b/src/Wip.Core/Diagnostics/UpdateNotifier.cs
@@ -72,6 +72,15 @@ public static class UpdateNotifier
 
         using (lease)
         {
+            // Winning the lock only means no refresh is in flight right now; a different
+            // helper could have already refreshed and released it between when this one was
+            // spawned and when it got the lock. Re-check freshness before spending another
+            // GitHub request on a cache that is no longer stale.
+            if (DateTimeOffset.UtcNow - ReadCache(cachePath).CheckedAt < RefreshInterval)
+            {
+                return;
+            }
+
             try
             {
                 using var client = CreateClient(handler);
@@ -173,14 +182,15 @@ public static class UpdateNotifier
 
     private static int CompareIdentifier(string candidate, string current)
     {
-        var candidateIsNumeric = candidate.Length > 0 && candidate.All(char.IsAsciiDigit);
-        var currentIsNumeric = current.Length > 0 && current.All(char.IsAsciiDigit);
+        var candidateIsNumeric = IsValidNumericIdentifier(candidate);
+        var currentIsNumeric = IsValidNumericIdentifier(current);
         if (candidateIsNumeric && currentIsNumeric)
         {
             // SemVer numeric identifiers have no length limit, so comparing them as integers
-            // could overflow; a longer run of digits is always the larger number (neither ever
-            // has a leading zero, since that itself is invalid per the spec), and same-length
-            // digit strings order the same numerically and lexically.
+            // could overflow; a longer run of digits is always the larger number, and
+            // same-length digit strings order the same numerically and lexically. Leading
+            // zeroes (rejected by IsValidNumericIdentifier below) would otherwise break the
+            // length comparison: "00" is not shorter than "0" despite being numerically equal.
             return candidate.Length != current.Length
                 ? candidate.Length.CompareTo(current.Length)
                 : string.CompareOrdinal(candidate, current);
@@ -190,6 +200,12 @@ public static class UpdateNotifier
             ? candidateIsNumeric ? -1 : 1
             : string.CompareOrdinal(candidate, current);
     }
+
+    /// <summary>SemVer numeric identifiers disallow leading zeroes, so "0" is numeric but
+    /// "00"/"01" are not -- comparing them as numbers would treat those as equal or misordered.
+    /// A digit run rejected here still compares fine as plain text via CompareOrdinal above.</summary>
+    private static bool IsValidNumericIdentifier(string value) =>
+        value.Length > 0 && value.All(char.IsAsciiDigit) && (value.Length == 1 || value[0] != '0');
 
     private static bool TryParseVersion(string value, out Version version, out string? prerelease)
     {

--- a/src/Wip.Core/Diagnostics/UpdateNotifier.cs
+++ b/src/Wip.Core/Diagnostics/UpdateNotifier.cs
@@ -57,16 +57,22 @@ public static class UpdateNotifier
     internal static void RefreshCache(HttpMessageHandler? handler, string cachePath)
     {
         var lockPath = LockPath(cachePath);
-        Directory.CreateDirectory(Path.GetDirectoryName(lockPath)!);
-
         FileStream lease;
         try
         {
+            Directory.CreateDirectory(Path.GetDirectoryName(lockPath)!);
             lease = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None);
         }
         catch (IOException)
         {
-            // Another refresh is already in flight for this cache.
+            // Either another refresh is already in flight for this cache, or the lock
+            // directory couldn't be created/opened (e.g. an unwritable LocalApplicationData).
+            // RefreshCache() is called directly by the detached helper process with nothing
+            // above it to catch this, so it has to be swallowed here to stay advisory.
+            return;
+        }
+        catch (UnauthorizedAccessException)
+        {
             return;
         }
 
@@ -182,15 +188,16 @@ public static class UpdateNotifier
 
     private static int CompareIdentifier(string candidate, string current)
     {
-        var candidateIsNumeric = IsValidNumericIdentifier(candidate);
-        var currentIsNumeric = IsValidNumericIdentifier(current);
+        // TryParseVersion already rejected any identifier that is an invalid mix (a leading-zero
+        // digit run isn't valid as either SemVer identifier kind), so a plain "all digits" check
+        // is enough to know both sides are valid numeric identifiers here.
+        var candidateIsNumeric = candidate.All(char.IsAsciiDigit);
+        var currentIsNumeric = current.All(char.IsAsciiDigit);
         if (candidateIsNumeric && currentIsNumeric)
         {
             // SemVer numeric identifiers have no length limit, so comparing them as integers
             // could overflow; a longer run of digits is always the larger number, and
-            // same-length digit strings order the same numerically and lexically. Leading
-            // zeroes (rejected by IsValidNumericIdentifier below) would otherwise break the
-            // length comparison: "00" is not shorter than "0" despite being numerically equal.
+            // same-length digit strings order the same numerically and lexically.
             return candidate.Length != current.Length
                 ? candidate.Length.CompareTo(current.Length)
                 : string.CompareOrdinal(candidate, current);
@@ -200,12 +207,6 @@ public static class UpdateNotifier
             ? candidateIsNumeric ? -1 : 1
             : string.CompareOrdinal(candidate, current);
     }
-
-    /// <summary>SemVer numeric identifiers disallow leading zeroes, so "0" is numeric but
-    /// "00"/"01" are not -- comparing them as numbers would treat those as equal or misordered.
-    /// A digit run rejected here still compares fine as plain text via CompareOrdinal above.</summary>
-    private static bool IsValidNumericIdentifier(string value) =>
-        value.Length > 0 && value.All(char.IsAsciiDigit) && (value.Length == 1 || value[0] != '0');
 
     private static bool TryParseVersion(string value, out Version version, out string? prerelease)
     {
@@ -219,7 +220,15 @@ public static class UpdateNotifier
         var prereleaseSuffix = normalized.IndexOf('-');
         if (prereleaseSuffix >= 0)
         {
-            prerelease = normalized[(prereleaseSuffix + 1)..];
+            var candidate = normalized[(prereleaseSuffix + 1)..];
+            if (!IsValidPrerelease(candidate))
+            {
+                version = null!;
+                prerelease = null;
+                return false;
+            }
+
+            prerelease = candidate;
             normalized = normalized[..prereleaseSuffix];
         }
         else
@@ -228,6 +237,25 @@ public static class UpdateNotifier
         }
 
         return Version.TryParse(normalized, out version!);
+    }
+
+    /// <summary>Every dot-separated identifier must be non-empty and match SemVer's grammar: a
+    /// numeric identifier (digits only, no leading zero unless it's just "0") or an alphanumeric
+    /// one (letters, digits and hyphens, with at least one non-digit). A digit run with a
+    /// leading zero, like "01", matches neither and is rejected outright rather than assigned to
+    /// either kind.</summary>
+    private static bool IsValidPrerelease(string prerelease) =>
+        prerelease.Length > 0 && prerelease.Split('.').All(IsValidPrereleaseIdentifier);
+
+    private static bool IsValidPrereleaseIdentifier(string identifier)
+    {
+        if (identifier.Length == 0 || !identifier.All(c => char.IsAsciiLetterOrDigit(c) || c == '-'))
+        {
+            return false;
+        }
+
+        var isNumeric = identifier.All(char.IsAsciiDigit);
+        return !isNumeric || identifier.Length == 1 || identifier[0] != '0';
     }
 
     internal static (DateTimeOffset CheckedAt, string? Latest) ReadCache(string cachePath)

--- a/src/Wip.Core/Diagnostics/UpdateNotifier.cs
+++ b/src/Wip.Core/Diagnostics/UpdateNotifier.cs
@@ -12,11 +12,6 @@ public static class UpdateNotifier
         "https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/s/Slidict/Wip?per_page=100";
     private static readonly TimeSpan RefreshInterval = TimeSpan.FromHours(24);
 
-    // Generous relative to the 3-second HTTP timeout below: if the helper crashed or was killed
-    // before it could delete its lease, a later invocation reclaims it instead of update checks
-    // going silent forever.
-    private static readonly TimeSpan RefreshLeaseTimeout = TimeSpan.FromSeconds(30);
-
     /// <summary>
     /// True when this process was launched by <see cref="StartRefreshProcess"/> to run
     /// <see cref="RefreshCache()"/> and exit, rather than a normal wip invocation. Gated by an
@@ -51,29 +46,50 @@ public static class UpdateNotifier
     /// <summary>Executed only by the hidden detached helper process.</summary>
     public static void RefreshCache() => RefreshCache(handler: null, CachePath());
 
+    /// <summary>
+    /// Holds an exclusive OS-level lock on the lease file for as long as the refresh takes.
+    /// Concurrent wip invocations against the same stale cache can each spawn a helper, but only
+    /// the one that wins the lock actually calls GitHub; the rest see the lock already taken and
+    /// exit immediately. Unlike a lease file whose mere existence is the marker, a held lock
+    /// needs no staleness timeout: if this process crashes, Windows releases the lock the moment
+    /// it exits, so a later invocation acquires it right away instead of waiting out a timeout.
+    /// </summary>
     internal static void RefreshCache(HttpMessageHandler? handler, string cachePath)
     {
+        var lockPath = LockPath(cachePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(lockPath)!);
+
+        FileStream lease;
         try
         {
-            using var client = CreateClient(handler);
-            var latest = FindLatestVersion(client.GetStringAsync(ManifestUrl).GetAwaiter().GetResult());
-            WriteCache(latest, cachePath);
+            lease = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None);
         }
-        catch (Exception)
+        catch (IOException)
         {
-            // Record the attempt to avoid slowing every invocation when the machine is offline.
+            // Another refresh is already in flight for this cache.
+            return;
+        }
+
+        using (lease)
+        {
             try
             {
-                WriteCache(ReadCache(cachePath).Latest, cachePath);
+                using var client = CreateClient(handler);
+                var latest = FindLatestVersion(client.GetStringAsync(ManifestUrl).GetAwaiter().GetResult());
+                WriteCache(latest, cachePath);
             }
             catch (Exception)
             {
-                // The cache itself may be unavailable; there is nothing advisory code can do.
+                // Record the attempt to avoid slowing every invocation when the machine is offline.
+                try
+                {
+                    WriteCache(ReadCache(cachePath).Latest, cachePath);
+                }
+                catch (Exception)
+                {
+                    // The cache itself may be unavailable; there is nothing advisory code can do.
+                }
             }
-        }
-        finally
-        {
-            TryDelete(LockPath(cachePath));
         }
     }
 
@@ -85,7 +101,10 @@ public static class UpdateNotifier
             return null;
         }
 
-        Version? latest = null;
+        // Compared pairwise with IsNewer (full SemVer precedence, prerelease included) rather
+        // than by parsed Version alone, so the winner does not depend on manifest entry order:
+        // a release must beat a same-numbered prerelease regardless of which one is enumerated
+        // first.
         string? latestText = null;
         foreach (var item in document.RootElement.EnumerateArray())
         {
@@ -93,14 +112,15 @@ public static class UpdateNotifier
                 typeProperty.GetString() != "dir" ||
                 !item.TryGetProperty("name", out var nameProperty) ||
                 nameProperty.GetString() is not { } name ||
-                !TryParseVersion(name, out var version, out _) ||
-                latest is not null && version <= latest)
+                !TryParseVersion(name, out _, out _))
             {
                 continue;
             }
 
-            latest = version;
-            latestText = name;
+            if (latestText is null || IsNewer(name, latestText))
+            {
+                latestText = name;
+            }
         }
         return latestText;
     }
@@ -157,7 +177,13 @@ public static class UpdateNotifier
         var currentIsNumeric = current.Length > 0 && current.All(char.IsAsciiDigit);
         if (candidateIsNumeric && currentIsNumeric)
         {
-            return long.Parse(candidate).CompareTo(long.Parse(current));
+            // SemVer numeric identifiers have no length limit, so comparing them as integers
+            // could overflow; a longer run of digits is always the larger number (neither ever
+            // has a leading zero, since that itself is invalid per the spec), and same-length
+            // digit strings order the same numerically and lexically.
+            return candidate.Length != current.Length
+                ? candidate.Length.CompareTo(current.Length)
+                : string.CompareOrdinal(candidate, current);
         }
 
         return candidateIsNumeric != currentIsNumeric
@@ -237,12 +263,6 @@ public static class UpdateNotifier
             return;
         }
 
-        var lockPath = TryAcquireRefreshLease(LockPath(CachePath()));
-        if (lockPath is null)
-        {
-            return;
-        }
-
         var start = new ProcessStartInfo(executable) { UseShellExecute = false, CreateNoWindow = true };
 
         // Under `dotnet run`/`dotnet path/to/wip.dll`, ProcessPath is the dotnet host itself, not
@@ -257,69 +277,10 @@ public static class UpdateNotifier
         }
 
         start.EnvironmentVariables[RefreshHelperEnvironmentVariable] = "1";
-        try
-        {
-            Process.Start(start)?.Dispose();
-        }
-        catch (Exception)
-        {
-            TryDelete(lockPath);
-        }
-    }
 
-    /// <summary>
-    /// Atomically claims the right to refresh, so concurrent wip invocations against the same
-    /// stale cache don't each spawn a helper and burn through GitHub's unauthenticated rate
-    /// limit. Returns the lease path on success, so it can be released if the helper never
-    /// starts.
-    /// </summary>
-    private static string? TryAcquireRefreshLease(string lockPath)
-    {
-        Directory.CreateDirectory(Path.GetDirectoryName(lockPath)!);
-        if (TryCreateLease(lockPath))
-        {
-            return lockPath;
-        }
-
-        try
-        {
-            if (DateTime.UtcNow - File.GetLastWriteTimeUtc(lockPath) <= RefreshLeaseTimeout)
-            {
-                return null;
-            }
-        }
-        catch (Exception)
-        {
-            return null;
-        }
-
-        TryDelete(lockPath);
-        return TryCreateLease(lockPath) ? lockPath : null;
-    }
-
-    private static bool TryCreateLease(string lockPath)
-    {
-        try
-        {
-            using var stream = new FileStream(lockPath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
-            return true;
-        }
-        catch (IOException)
-        {
-            return false;
-        }
-    }
-
-    private static void TryDelete(string path)
-    {
-        try
-        {
-            File.Delete(path);
-        }
-        catch (Exception)
-        {
-            // Best-effort cleanup; a leftover lease simply expires after RefreshLeaseTimeout.
-        }
+        // RefreshCache() itself claims the cross-process lock (see its remarks), so a redundant
+        // helper spawned here for the same stale cache just loses that race and exits at once.
+        Process.Start(start)?.Dispose();
     }
 
     private static HttpClient CreateClient(HttpMessageHandler? handler)

--- a/tests/Wip.Tests/UpdateNotifierTests.cs
+++ b/tests/Wip.Tests/UpdateNotifierTests.cs
@@ -33,6 +33,26 @@ public class UpdateNotifierTests
         Assert.Equal("2.5.2", UpdateNotifier.FindLatestVersion(response));
     }
 
+    [Fact]
+    public void PicksAReleaseOverASamePrereleaseRegardlessOfManifestOrder()
+    {
+        const string prereleaseFirst = """
+            [
+              { "name": "2.5.2-rc.1", "type": "dir" },
+              { "name": "2.5.2", "type": "dir" }
+            ]
+            """;
+        const string releaseFirst = """
+            [
+              { "name": "2.5.2", "type": "dir" },
+              { "name": "2.5.2-rc.1", "type": "dir" }
+            ]
+            """;
+
+        Assert.Equal("2.5.2", UpdateNotifier.FindLatestVersion(prereleaseFirst));
+        Assert.Equal("2.5.2", UpdateNotifier.FindLatestVersion(releaseFirst));
+    }
+
     [Theory]
     [InlineData("2.5.3", "2.5.2", true)]
     [InlineData("2.5.2", "2.5.2", false)]
@@ -45,6 +65,8 @@ public class UpdateNotifierTests
     [InlineData("2.5.2-rc.1", "2.5.2-rc.2", false)]
     [InlineData("2.5.2-beta", "2.5.2-alpha", true)]
     [InlineData("2.5.2-rc.1", "2.5.2-rc.1.1", false)]
+    [InlineData("2.5.2-rc.99999999999999999999", "2.5.2-rc.1", true)]
+    [InlineData("2.5.2-rc.99999999999999999999", "2.5.2-rc.99999999999999999998", true)]
     public void ComparesVersions(string candidate, string current, bool expected)
     {
         Assert.Equal(expected, UpdateNotifier.IsNewer(candidate, current));
@@ -191,7 +213,7 @@ public class UpdateNotifierTests
     }
 
     [Fact]
-    public void RefreshCacheReleasesItsLeaseEvenWhenTheRequestFails()
+    public void RefreshCacheReleasesItsLockEvenWhenTheRequestFails()
     {
         var path = TempCachePath();
         var lockPath = $"{path}.lock";
@@ -201,7 +223,38 @@ public class UpdateNotifierTests
 
             UpdateNotifier.RefreshCache(handler, path);
 
-            Assert.False(File.Exists(lockPath));
+            // Throws if the lock is still held, failing the test.
+            using var stream = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None);
+        }
+        finally
+        {
+            File.Delete(path);
+            File.Delete(lockPath);
+        }
+    }
+
+    [Fact]
+    public void RefreshCacheSkipsTheRequestWhenAnotherRefreshHoldsTheLock()
+    {
+        var path = TempCachePath();
+        var lockPath = $"{path}.lock";
+        Directory.CreateDirectory(Path.GetDirectoryName(lockPath)!);
+        try
+        {
+            using (new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None))
+            {
+                var requested = false;
+                var handler = new StubHandler(() =>
+                {
+                    requested = true;
+                    return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("[]") };
+                });
+
+                UpdateNotifier.RefreshCache(handler, path);
+
+                Assert.False(requested);
+                Assert.False(File.Exists(path));
+            }
         }
         finally
         {

--- a/tests/Wip.Tests/UpdateNotifierTests.cs
+++ b/tests/Wip.Tests/UpdateNotifierTests.cs
@@ -53,6 +53,22 @@ public class UpdateNotifierTests
         Assert.Equal("2.5.2", UpdateNotifier.FindLatestVersion(releaseFirst));
     }
 
+    [Fact]
+    public void SkipsDirectoriesWithAMalformedPrereleaseTag()
+    {
+        const string response = """
+            [
+              { "name": "2.5.2-rc.01", "type": "dir" },
+              { "name": "2.4.9", "type": "dir" }
+            ]
+            """;
+
+        // "01" is not a valid SemVer identifier (a numeric identifier can't have a leading
+        // zero, and an alphanumeric one needs a non-digit character), so the whole directory
+        // name is rejected rather than winning by some fallback ordering.
+        Assert.Equal("2.4.9", UpdateNotifier.FindLatestVersion(response));
+    }
+
     [Theory]
     [InlineData("2.5.3", "2.5.2", true)]
     [InlineData("2.5.2", "2.5.2", false)]
@@ -67,7 +83,7 @@ public class UpdateNotifierTests
     [InlineData("2.5.2-rc.1", "2.5.2-rc.1.1", false)]
     [InlineData("2.5.2-rc.99999999999999999999", "2.5.2-rc.1", true)]
     [InlineData("2.5.2-rc.99999999999999999999", "2.5.2-rc.99999999999999999998", true)]
-    [InlineData("2.5.2-rc.01", "2.5.2-rc.1", true)]
+    [InlineData("2.5.2-rc.01", "2.5.2-rc.1", false)]
     [InlineData("2.5.2-rc.1", "2.5.2-rc.01", false)]
     public void ComparesVersions(string candidate, string current, bool expected)
     {
@@ -262,6 +278,34 @@ public class UpdateNotifierTests
         {
             File.Delete(path);
             File.Delete(lockPath);
+        }
+    }
+
+    [Fact]
+    public void RefreshCacheSwallowsAFailureToCreateTheLockDirectory()
+    {
+        // A file where the lock's parent directory needs to be makes Directory.CreateDirectory
+        // throw IOException, the same shape an unwritable LocalApplicationData would produce.
+        // RefreshCache() runs directly inside the detached helper process with nothing above it
+        // to catch this, so it must not escape here either.
+        var blocker = TempCachePath();
+        Directory.CreateDirectory(Path.GetDirectoryName(blocker)!);
+        File.WriteAllText(blocker, "not a directory");
+        var cachePath = Path.Combine(blocker, "update.json");
+        try
+        {
+            var handler = new StubHandler(() => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("[]"),
+            });
+
+            var exception = Record.Exception(() => UpdateNotifier.RefreshCache(handler, cachePath));
+
+            Assert.Null(exception);
+        }
+        finally
+        {
+            File.Delete(blocker);
         }
     }
 

--- a/tests/Wip.Tests/UpdateNotifierTests.cs
+++ b/tests/Wip.Tests/UpdateNotifierTests.cs
@@ -67,6 +67,8 @@ public class UpdateNotifierTests
     [InlineData("2.5.2-rc.1", "2.5.2-rc.1.1", false)]
     [InlineData("2.5.2-rc.99999999999999999999", "2.5.2-rc.1", true)]
     [InlineData("2.5.2-rc.99999999999999999999", "2.5.2-rc.99999999999999999998", true)]
+    [InlineData("2.5.2-rc.01", "2.5.2-rc.1", true)]
+    [InlineData("2.5.2-rc.1", "2.5.2-rc.01", false)]
     public void ComparesVersions(string candidate, string current, bool expected)
     {
         Assert.Equal(expected, UpdateNotifier.IsNewer(candidate, current));
@@ -197,7 +199,7 @@ public class UpdateNotifierTests
         var path = TempCachePath();
         try
         {
-            UpdateNotifier.WriteCache("2.5.2", path);
+            WriteStaleCache(path, "2.5.2");
             var handler = new StubHandler(() => throw new HttpRequestException("offline"));
 
             UpdateNotifier.RefreshCache(handler, path);
@@ -205,6 +207,36 @@ public class UpdateNotifierTests
             var (checkedAt, latest) = UpdateNotifier.ReadCache(path);
             Assert.Equal("2.5.2", latest);
             Assert.True(DateTimeOffset.UtcNow - checkedAt < TimeSpan.FromMinutes(1));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void RefreshCacheSkipsARedundantRequestWhenTheCacheIsAlreadyFresh()
+    {
+        var path = TempCachePath();
+        try
+        {
+            // Simulates a different helper having already refreshed the cache between when
+            // this one was spawned and when it won the lock: nothing here holds the lock, but
+            // the cache itself is already fresh, so RefreshCache's own double-check should
+            // skip the network call entirely.
+            UpdateNotifier.WriteCache("2.5.2", path);
+            var requested = false;
+            var handler = new StubHandler(() =>
+            {
+                requested = true;
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("[]") };
+            });
+
+            UpdateNotifier.RefreshCache(handler, path);
+
+            Assert.False(requested);
+            var (_, latest) = UpdateNotifier.ReadCache(path);
+            Assert.Equal("2.5.2", latest);
         }
         finally
         {
@@ -265,6 +297,14 @@ public class UpdateNotifierTests
 
     private static string TempCachePath() =>
         Path.Combine(Path.GetTempPath(), "wip-tests", $"update-{Guid.NewGuid():N}.json");
+
+    private static void WriteStaleCache(string path, string? latest)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        var checkedAt = DateTimeOffset.UtcNow - TimeSpan.FromDays(2);
+        var latestJson = latest is null ? "null" : $"\"{latest}\"";
+        File.WriteAllText(path, $$"""{"checkedAt":"{{checkedAt:O}}","latest":{{latestJson}}}""");
+    }
 
     private sealed class StubHandler(Func<HttpResponseMessage> responseFactory) : HttpMessageHandler
     {


### PR DESCRIPTION
## Summary
- Follow-up to #178: the last two reviews (Copilot + CodeRabbit) landed on commit 0f32fc8 right around merge time, so they never got addressed before merge.
- Replaces the create/expire-by-mtime refresh lease with an exclusive OS-level file lock held for the refresh's duration, closing the TOCTOU window where two concurrent processes could both reclaim a "stale" lease and start duplicate GitHub requests.
- Fixes a potential `OverflowException` in prerelease comparison: numeric SemVer identifiers are now compared as digit strings instead of parsed with `long.Parse`.
- `FindLatestVersion` now selects the manifest winner via `IsNewer` (full SemVer precedence) instead of comparing only the parsed `Version`, so a release always outranks a same-numbered prerelease regardless of listing order.
- Skipped one CodeRabbit nitpick as out of scope: switching the manifest fetch from the GitHub Contents API to the Git Trees API to handle >1000 entries. This package will not plausibly have more than the 100 versions `per_page=100` already covers; adding a second API dependency for that isn't warranted here.

## Test plan
- [x] `dotnet build`
- [x] `dotnet test` (774 passed, 16 pre-existing skips, 0 failed)
- [x] New tests cover: order-independent release-vs-prerelease selection, huge numeric prerelease identifiers (no overflow), lock release after refresh, and refresh skipping the HTTP call when another process holds the lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E1xYCyG3ffSe549ewTgzTv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved refresh coordination to prevent concurrent refresh attempts.
  * Ensured refresh locks are released after failed requests.
  * Preserved stale cache data when refreshes fail, including lock-directory errors.
  * Skipped redundant refresh requests when cached data is already current.
  * Improved version selection and prerelease validation, including large numeric identifiers and leading-zero handling.

* **Tests**
  * Expanded coverage for refresh failures, cache freshness, lock contention, and version precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->