### PR TITLE
fix(compose): stop entrypoint args from overriding the image CMD

### DIFF
--- a/src/Wip.Core/Compose/ComposeFile.cs
+++ b/src/Wip.Core/Compose/ComposeFile.cs
@@ -175,7 +175,7 @@ public sealed class ComposeFile
         return new Service(
             image,
             build,
-            NormalizeCommand(mapping.GetValueOrDefault("entrypoint")),
+            NormalizeEntrypoint(mapping.GetValueOrDefault("entrypoint")),
             NormalizeCommand(mapping.GetValueOrDefault("command")),
             NormalizeKeyValues(name, mapping.GetValueOrDefault("environment"), "environment"),
             NormalizeList(name, mapping.GetValueOrDefault("ports"), "ports", ListHint),
@@ -199,6 +199,24 @@ public sealed class ComposeFile
         return list is null
             ? RubyValue.Presence(value)
             : Shellwords.Join(list.Select(RubyValue.ToStringValue)).Presence();
+    }
+
+    /// <summary>
+    /// Unlike <see cref="NormalizeCommand"/>, an explicit <c>entrypoint: ""</c> or
+    /// <c>entrypoint: []</c> must survive as an intentional "clear the image's entrypoint"
+    /// instruction (an empty string), distinct from omitting <c>entrypoint:</c> entirely
+    /// (null): <see cref="Execution.CommandBuilder"/> emits <c>--entrypoint ""</c> only for
+    /// the former, and leaves the image's own entrypoint untouched for the latter.
+    /// </summary>
+    private static string? NormalizeEntrypoint(object? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        var list = RubyValue.AsSequence(value);
+        return list is null ? RubyValue.ToStringValue(value) : Shellwords.Join(list.Select(RubyValue.ToStringValue));
     }
 
     private OrderedDictionary<string, object?>? NormalizeBuild(string name, object? value)

--- a/src/Wip.Core/Execution/CommandBuilder.cs
+++ b/src/Wip.Core/Execution/CommandBuilder.cs
@@ -370,14 +370,15 @@ public sealed class CommandBuilder
     }
 
     /// <summary>
-    /// Null when <c>entrypoint:</c> is absent entirely, so the image's own entrypoint is left
-    /// untouched. Present with an empty <see cref="EntrypointOverride.Executable"/> for an
-    /// explicit <c>entrypoint: ""</c>/<c>entrypoint: []</c>, which clears it via
-    /// <c>--entrypoint ""</c> instead.
+    /// Null when <c>entrypoint:</c> is absent, or present but <c>null</c> (a raw wip.yml
+    /// dependency entry can write that explicitly; Compose normalization never does) -- either
+    /// way the image's own entrypoint is left untouched. Present with an empty
+    /// <see cref="EntrypointOverride.Executable"/> for an explicit <c>entrypoint: ""</c>/
+    /// <c>entrypoint: []</c>, which clears it via <c>--entrypoint ""</c> instead.
     /// </summary>
     private static EntrypointOverride? Entrypoint(OrderedDictionary<string, object?> values)
     {
-        if (!values.TryGetValue("entrypoint", out var raw))
+        if (!values.TryGetValue("entrypoint", out var raw) || raw is null)
         {
             return null;
         }

--- a/src/Wip.Core/Execution/CommandBuilder.cs
+++ b/src/Wip.Core/Execution/CommandBuilder.cs
@@ -316,10 +316,10 @@ public sealed class CommandBuilder
             result.Add(user);
         }
 
-        if (includeEntrypoint && Entrypoint(values).FirstOrDefault() is { } entrypoint)
+        if (includeEntrypoint && Entrypoint(values) is { } entrypoint)
         {
             result.Add("--entrypoint");
-            result.Add(entrypoint);
+            result.Add(entrypoint.Executable);
         }
 
         foreach (var (key, value) in MergedEnvironment(values))
@@ -354,14 +354,39 @@ public sealed class CommandBuilder
     /// <summary>
     /// WSLC's <c>--entrypoint</c> replaces only the executable. Compose exec-form entrypoints
     /// may also contain arguments, so append everything after the executable in front of the
-    /// service command rather than passing the whole joined value as an executable name.
+    /// service command rather than passing the whole joined value as an executable name. Only
+    /// done when there is an actual command/argv, though: with none, wslc run (like Docker)
+    /// falls back to the image's own CMD as the new entrypoint's arguments, and splicing in
+    /// entrypoint arguments here would wrongly occupy that slot and suppress the image's CMD.
     /// </summary>
     private static IEnumerable<string> ContainerArguments(
         OrderedDictionary<string, object?> values,
-        IEnumerable<string> arguments) => Entrypoint(values).Skip(1).Concat(arguments);
+        IEnumerable<string> arguments)
+    {
+        var command = arguments as IReadOnlyCollection<string> ?? arguments.ToList();
+        return command.Count > 0 && Entrypoint(values) is { } entrypoint
+            ? entrypoint.Arguments.Concat(command)
+            : command;
+    }
 
-    private static IReadOnlyList<string> Entrypoint(OrderedDictionary<string, object?> values) =>
-        Shellwords.Split(RubyValue.ToStringValue(values.GetValueOrDefault("entrypoint")));
+    /// <summary>
+    /// Null when <c>entrypoint:</c> is absent entirely, so the image's own entrypoint is left
+    /// untouched. Present with an empty <see cref="EntrypointOverride.Executable"/> for an
+    /// explicit <c>entrypoint: ""</c>/<c>entrypoint: []</c>, which clears it via
+    /// <c>--entrypoint ""</c> instead.
+    /// </summary>
+    private static EntrypointOverride? Entrypoint(OrderedDictionary<string, object?> values)
+    {
+        if (!values.TryGetValue("entrypoint", out var raw))
+        {
+            return null;
+        }
+
+        var parts = Shellwords.Split(RubyValue.ToStringValue(raw));
+        return new EntrypointOverride(parts.FirstOrDefault() ?? string.Empty, parts.Skip(1).ToList());
+    }
+
+    private readonly record struct EntrypointOverride(string Executable, IReadOnlyList<string> Arguments);
 
     /// <summary>
     /// With sync configured, a live bind mount of the target (<c>.:/app</c>) is swapped for

--- a/tests/Wip.Tests/ComposeFileEntrypointTests.cs
+++ b/tests/Wip.Tests/ComposeFileEntrypointTests.cs
@@ -142,6 +142,28 @@ public class ComposeFileEntrypointTests
     }
 
     [Fact]
+    public void ExplicitNullEntrypointInARawDependencyLeavesTheImageEntrypointUntouched()
+    {
+        // Compose normalization never produces this (an omitted entrypoint: is left out of
+        // the mapping entirely, never set to null), but a raw wip.yml dependencies: entry can
+        // write "entrypoint:" (YAML null) directly, and that must mean the same as omitting it
+        // -- not the explicit-empty-string "clear the image's entrypoint" case.
+        var config = new Config(YamlLoader.LoadText("""
+            version: 1
+            mode: container
+            container: app
+            dependencies:
+              app:
+                image: myapp:dev
+                entrypoint:
+                command: serve
+            """, allowAliases: false));
+        var builder = new CommandBuilder("wslc.exe", config, new FakeEnvironment());
+
+        Assert.DoesNotContain("--entrypoint", builder.Up());
+    }
+
+    [Fact]
     public void EntrypointIsNotPassedToExec()
     {
         using var directory = new TemporaryDirectory();

--- a/tests/Wip.Tests/ComposeFileEntrypointTests.cs
+++ b/tests/Wip.Tests/ComposeFileEntrypointTests.cs
@@ -49,6 +49,99 @@ public class ComposeFileEntrypointTests
     }
 
     [Fact]
+    public void ExecFormEntrypointWithoutCommandLeavesTheImageCmdIntact()
+    {
+        using var directory = new TemporaryDirectory();
+        var composePath = Path.Combine(directory.Path, "compose.yml");
+        File.WriteAllText(composePath, """
+            services:
+              app:
+                image: myapp:dev
+                entrypoint: ["/usr/local/bin/start", "--verbose"]
+            """);
+
+        var config = new Config(YamlLoader.LoadText($$"""
+            mode: compose-native
+            compose:
+              file: {{composePath}}
+              service: app
+            """, allowAliases: false), Path.Combine(directory.Path, "wip.yml"));
+        var builder = new CommandBuilder("wslc.exe", config, new FakeEnvironment());
+
+        // No command: means no argv, so wslc (like Docker) must fall back to the image's own
+        // CMD for the new entrypoint's arguments -- "--verbose" must not be spliced in here,
+        // or it would occupy that slot and suppress the image's CMD.
+        Assert.Equal(
+            [
+                "wslc.exe", "run", "--name", "app", "--network", directory.Name, "-d",
+                "--entrypoint", "/usr/local/bin/start", "myapp:dev",
+            ],
+            builder.Up(detach: true));
+    }
+
+    [Theory]
+    [InlineData("entrypoint: \"\"")]
+    [InlineData("entrypoint: []")]
+    public void ExplicitEmptyEntrypointClearsTheImageEntrypoint(string entrypointYaml)
+    {
+        using var directory = new TemporaryDirectory();
+        var composePath = Path.Combine(directory.Path, "compose.yml");
+        File.WriteAllText(composePath, $$"""
+            services:
+              app:
+                image: myapp:dev
+                {{entrypointYaml}}
+                command: serve
+            """);
+
+        var compose = ComposeFile.Load(composePath);
+        var app = (OrderedDictionary<string, object?>)compose.ToDependenciesMapping()["app"]!;
+        Assert.Equal("", app["entrypoint"]);
+
+        var config = new Config(YamlLoader.LoadText($$"""
+            mode: compose-native
+            compose:
+              file: {{composePath}}
+              service: app
+            """, allowAliases: false), Path.Combine(directory.Path, "wip.yml"));
+        var builder = new CommandBuilder("wslc.exe", config, new FakeEnvironment());
+
+        Assert.Equal(
+            [
+                "wslc.exe", "run", "--name", "app", "--network", directory.Name, "-d",
+                "--entrypoint", "", "myapp:dev", "serve",
+            ],
+            builder.Up(detach: true));
+    }
+
+    [Fact]
+    public void OmittedEntrypointLeavesTheImageEntrypointUntouched()
+    {
+        using var directory = new TemporaryDirectory();
+        var composePath = Path.Combine(directory.Path, "compose.yml");
+        File.WriteAllText(composePath, """
+            services:
+              app:
+                image: myapp:dev
+                command: serve
+            """);
+
+        var compose = ComposeFile.Load(composePath);
+        var app = (OrderedDictionary<string, object?>)compose.ToDependenciesMapping()["app"]!;
+        Assert.False(app.ContainsKey("entrypoint"));
+
+        var config = new Config(YamlLoader.LoadText($$"""
+            mode: compose-native
+            compose:
+              file: {{composePath}}
+              service: app
+            """, allowAliases: false), Path.Combine(directory.Path, "wip.yml"));
+        var builder = new CommandBuilder("wslc.exe", config, new FakeEnvironment());
+
+        Assert.DoesNotContain("--entrypoint", builder.Up(detach: true));
+    }
+
+    [Fact]
     public void EntrypointIsNotPassedToExec()
     {
         using var directory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
Follow-up to #170: the last Copilot review landed at 13:45 UTC, close to when the PR was merged, so two findings never got addressed.

- `ContainerArguments()` always spliced an exec-form entrypoint's trailing arguments into the container argv, even when the service defined no `command:`. That made `wslc run --entrypoint <exe> <image> <entrypoint-args...>` treat those args as the container command, silently overriding the image's own `CMD` — Docker (and wslc) only do that when explicit argv follows the image name; with none, the image's `CMD` is supposed to still apply. Fixed by only splicing entrypoint arguments in when there's an actual command/argv to append them to.
- `entrypoint: ""` / `entrypoint: []` were being collapsed to the same `null` as omitting `entrypoint:` entirely, so `--entrypoint` was never emitted for an explicit "clear the image's entrypoint" request. `ComposeFile.NormalizeEntrypoint` now preserves the explicit empty value, and `CommandBuilder` distinguishes "key absent" from "key present but empty" so it emits `--entrypoint ""` for the latter.
- Added the test Copilot asked for: exec-form `entrypoint:` with no `command:`, asserting the image `CMD` slot is left alone.

## Test plan
- [x] `dotnet build`
- [x] `dotnet test` (777 passed, 16 pre-existing skips, 0 failed)
- [x] New/updated tests: no-command exec-form entrypoint preserves image CMD, explicit empty entrypoint emits `--entrypoint ""`, omitted entrypoint emits no `--entrypoint` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E1xYCyG3ffSe549ewTgzTv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker Compose entrypoint handling.
  * Preserved image command arguments when no command is specified.
  * Explicitly empty entrypoints now clear the image entrypoint.
  * Omitted or explicitly null entrypoints now leave the image configuration unchanged.
  * Sequence-form entrypoints are handled consistently.

* **Tests**
  * Added coverage for omitted, null, empty, and exec-form entrypoints, including image command preservation and explicit clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->